### PR TITLE
Release v0.2.0-beta.2

### DIFF
--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1243,8 +1243,8 @@
                     </div>
 
                     <div x-show="editing !== null" x-cloak class="sched-form">
-                        <label class="sched-field">Name <input type="text" x-model="form.name" class="login-input"></label>
-                        <label class="sched-field">Time <input type="time" x-model="form.time" class="login-input"></label>
+                        <label class="sched-field">Name <input type="text" x-model="form.name" class="sched-input"></label>
+                        <label class="sched-field">Time <input type="time" x-model="form.time" class="sched-input"></label>
                         <div class="sched-field">Days
                             <div class="sched-days">
                                 <template x-for="d in days" :key="d.bit">
@@ -1253,22 +1253,22 @@
                             </div>
                         </div>
                         <label class="sched-field">Action
-                            <select x-model="form.actionType" class="login-input">
+                            <select x-model="form.actionType" class="sched-input">
                                 <template x-for="a in actionTypes" :key="a.value">
                                     <option :value="a.value" x-text="a.label"></option>
                                 </template>
                             </select>
                         </label>
                         <label class="sched-field" x-show="isButtonAction(form.actionType)">Device
-                            <select x-model="form.target" class="login-input">
+                            <select x-model="form.target" class="sched-input">
                                 <template x-for="b in buttons" :key="b"><option :value="b" x-text="b"></option></template>
                             </select>
                         </label>
                         <label class="sched-field" x-show="form.actionType === 'circulation_mode'">Mode
-                            <input type="text" x-model="form.target" class="login-input" placeholder="e.g. Pool">
+                            <input type="text" x-model="form.target" class="sched-input" placeholder="e.g. Pool">
                         </label>
                         <label class="sched-field" x-show="isValueAction(form.actionType)">Value
-                            <input type="number" x-model.number="form.value" class="login-input">
+                            <input type="number" x-model.number="form.value" class="sched-input">
                         </label>
                         <label class="sched-field"><input type="checkbox" x-model="form.enabled"> Enabled</label>
                         <div class="sched-form-actions">

--- a/assets/web/styles/app.css
+++ b/assets/web/styles/app.css
@@ -281,7 +281,8 @@ nav .nav-controls {
 .login-title { font-size: 1.25rem; margin: 0.25rem 0; color: var(--text-primary); }
 .login-subtitle { color: var(--text-muted, #94a3b8); font-size: 0.85rem; margin-bottom: 1.25rem; }
 
-.login-input {
+.login-input,
+.sched-input {
     width: 100%;
     box-sizing: border-box;
     padding: 0.6rem 0.75rem;

--- a/cicd/packer/README.md
+++ b/cicd/packer/README.md
@@ -162,7 +162,7 @@ Workflows automatically use self-hosted runners when these variables are set. Re
 | `07-ccache.sh` | ccache (5 GB max, compression enabled) |
 | `08-github-runner.sh` | GitHub Actions runner agent + auto-registration service |
 | `09-sonarcloud-tools.sh` | SonarCloud build-wrapper for Linux |
-| `10-cleanup.sh` | apt clean, log truncation, free space zeroing |
+| `10-cleanup.sh` | apt clean, log truncation, `fstrim` (UNMAP) free-space reclaim to keep the thin vmdk small |
 
 ### Windows Runner
 

--- a/cicd/packer/scripts/linux/08-github-runner.sh
+++ b/cicd/packer/scripts/linux/08-github-runner.sh
@@ -91,6 +91,14 @@ if [ -z "$REPO_URL" ] || [ -z "$TOKEN" ]; then
     exit 0
 fi
 
+# Give this clone a unique hostname matching its runner name. Together with the
+# reset machine-id (10-cleanup.sh) this stops cloned VMs from presenting an
+# identical DHCP client-id and colliding on the same DHCP lease.
+if [ -n "$NAME" ]; then
+    echo "Setting hostname to '${NAME}'"
+    hostnamectl set-hostname "${NAME}" || true
+fi
+
 echo "Registering runner '${NAME}' for ${REPO_URL}"
 
 cd "${RUNNER_DIR}"

--- a/cicd/packer/scripts/linux/10-cleanup.sh
+++ b/cicd/packer/scripts/linux/10-cleanup.sh
@@ -18,9 +18,27 @@ rm -rf /tmp/* /var/tmp/*
 unset HISTFILE
 rm -f /root/.bash_history /home/runner/.bash_history
 
-# Zero free space for better template compression
-dd if=/dev/zero of=/zero bs=1M 2>/dev/null || true
-rm -f /zero
+# Reset the machine-id so every VM cloned from this template generates its OWN
+# unique id on first boot. machine-id(5): "for operating system images which
+# are replicated... /etc/machine-id should be empty". A cloned, populated
+# machine-id makes systemd-networkd send an identical DHCP client-id, so every
+# clone is handed the SAME DHCP lease -> duplicate-IP conflict on the network.
+# (Hostname is made unique per clone by the auto-register step in
+# 08-github-runner.sh, which sets it from guestinfo.runner_name.)
+truncate -s 0 /etc/machine-id
+rm -f /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
+# Reclaim freed blocks via TRIM/UNMAP so the thin-provisioned virtual disk
+# actually deflates on the datastore.
+#
+# Do NOT zero-fill free space (`dd if=/dev/zero of=/zero`): on a thin vmdk that
+# forces VMware to allocate every "free" block, inflating the disk toward its
+# full provisioned size (~150 GB) with no automatic deflate. The template then
+# clones huge and fills the datastore. `fstrim` issues SCSI UNMAP instead, which
+# VMFS6 reclaims, keeping the template — and every VM cloned from it — genuinely
+# thin (in-guest usage is only ~20-25 GB).
+fstrim -av || true
 sync
 
 echo "==> Cleanup complete"

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -23,9 +23,10 @@ test.describe('UI authentication', () => {
     const overlay = page.locator('.login-overlay');
     await expect(overlay).toBeVisible();
 
-    // Scope field/button lookups to the overlay: the `.login-input` class is also
-    // reused by the Schedules form (which lives in the DOM via x-show), so an
-    // unscoped `.login-input` matches multiple elements and trips strict mode.
+    // Scope field/button lookups to the overlay as a defensive measure: even
+    // though `.login-input` is now unique to the overlay (the Schedules form
+    // uses `.sched-input`), scoping keeps these locators robust against any
+    // future class reuse and avoids strict-mode surprises.
     // Wrong token -> error, still on the login overlay.
     await overlay.locator('.login-input').fill('definitely-wrong-token');
     await overlay.locator('.login-submit').click();


### PR DESCRIPTION
Promotes develop to main for the v0.2.0-beta.2 pre-release.

Delta since v0.2.0-beta.1:
- fix(cicd): keep the Linux runner template thin (fstrim/UNMAP instead of zero-fill) and give each clone a unique machine-id + hostname.
- refactor(webui): give the Schedules form its own .sched-input class so the login overlay's .login-input is unique again (resolves the e2e auth strict-mode collision). Verified: auth + schedules e2e pass locally.

CI on develop is green at this tree; the release pipeline re-builds, tests and smoke-tests all 3 platforms before publishing.