### PR TITLE
Release v0.2.0-beta.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,10 @@ jobs:
   docker-verify:
     name: Docker Verification
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
+    # Surfaced so the "Login to Docker Hub" step's `if:` can gate on the optional
+    # secret being present. See release.yml / docs/releasing.md.
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
       - uses: actions/checkout@v4
@@ -303,21 +307,43 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Build CI target
-        uses: docker/build-push-action@v6
+      # Authenticate to Docker Hub when credentials are configured so base-image
+      # pulls (ubuntu:25.04, node:22-bookworm-slim) use the higher authenticated
+      # rate limit instead of the anonymous per-IP quota. Gated so fork PRs (which
+      # receive no secrets) still build anonymously.
+      - name: Login to Docker Hub
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@v3
         with:
-          context: .
-          target: ci
-          push: false
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Both builds are wrapped in a bounded retry so a transient Docker Hub CDN
+      # blob timeout pulling a base image doesn't fail CI. A retry reuses the
+      # BuildKit layer cache + the in-Dockerfile ccache/vcpkg cache mounts, so it
+      # only re-fetches the layer that timed out. docker/setup-buildx-action makes
+      # its builder the default, so `docker buildx build` here is equivalent to the
+      # docker/build-push-action invocations it replaces.
+      - name: Build CI target
+        uses: nick-fields/retry@v3
+        with:
+          shell: bash
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_wait_seconds: 30
+          retry_on: error
+          command: docker buildx build --target ci .
 
       - name: Build runtime target
-        uses: docker/build-push-action@v6
+        uses: nick-fields/retry@v3
         with:
-          context: .
-          target: runtime
-          push: false
-          load: true
-          tags: aqualink-automate:verify
+          shell: bash
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_wait_seconds: 30
+          retry_on: error
+          command: docker buildx build --target runtime --load --tag aqualink-automate:verify .
 
       # The runtime image now bundles the Matter sidecar (built by the matter-builder
       # stage). The --version smoke test exercises the app via the supervising

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,12 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
     permissions:
       packages: write
+    # Surfaced so the "Login to Docker Hub" step's `if:` can gate on the optional
+    # secret being present (the `secrets` context is not usable in step-level
+    # `if`). Only the username is exposed; the token is referenced directly in the
+    # step's `with:`.
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
       - uses: actions/checkout@v4
@@ -312,6 +318,20 @@ jobs:
           submodules: recursive
 
       - uses: docker/setup-buildx-action@v3
+
+      # The Dockerfile's base images (ubuntu:25.04, node:22-bookworm-slim) are
+      # pulled from Docker Hub. Anonymous pulls share the runner's egress IP and
+      # hit the strict anonymous rate limit (acute on self-hosted runners) — the
+      # recurring reliability risk. Authenticating raises the pull quota. Gated on
+      # the optional DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets so forks and
+      # credential-less runs still build anonymously. See docs/releasing.md.
+      - name: Login to Docker Hub
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -331,19 +351,36 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve-version.outputs.version_tag }}
             type=raw,value=latest,enable=${{ needs.resolve-version.outputs.is_prerelease != 'true' }}
 
+      # Build + push via buildx, wrapped in a bounded retry. A single transient
+      # Docker Hub CDN blob timeout (seen during v0.2.0-beta.1) must not fail the
+      # whole release; a retry reuses the BuildKit layer cache plus the in-Dockerfile
+      # ccache/vcpkg cache mounts, so it only re-fetches the layer that timed out.
+      # docker/setup-buildx-action makes its builder the default, so this is
+      # equivalent to docker/build-push-action (same underlying buildx). Tags and
+      # labels come from docker/metadata-action; passing them through env keeps the
+      # newline-separated lists intact inside the retry command.
       - name: Build and push runtime image
-        uses: docker/build-push-action@v6
+        uses: nick-fields/retry@v3
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+          IMAGE_LABELS: ${{ steps.meta.outputs.labels }}
+          VERSION: ${{ needs.resolve-version.outputs.version_tag }}
         with:
-          context: .
-          target: runtime
-          push: true
-          build-args: |
-            VERSION=${{ needs.resolve-version.outputs.version_tag }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          shell: bash
+          timeout_minutes: 90
+          max_attempts: 3
+          retry_wait_seconds: 30
+          retry_on: error
+          command: |
+            cmd=(docker buildx build --target runtime --push --build-arg "VERSION=${VERSION}")
+            while IFS= read -r tag;   do [ -n "$tag" ]   && cmd+=(--tag   "$tag");   done <<< "${IMAGE_TAGS}"
+            while IFS= read -r label; do [ -n "$label" ] && cmd+=(--label "$label"); done <<< "${IMAGE_LABELS}"
+            cmd+=(.)
+            printf 'Running:'; printf ' %q' "${cmd[@]}"; echo
+            "${cmd[@]}"
 
       # Verify the image we just published is actually pullable from GHCR and
-      # runs. build-push-action pushes straight to the registry without loading
+      # runs. `buildx build --push` pushes straight to the registry without loading
       # the image locally, so `docker pull` here genuinely exercises the published
       # artifact (not a local build cache). Assert it reports the resolved version.
       - name: Smoke test — pull & run the published image

--- a/assets/web/api/swagger.yaml
+++ b/assets/web/api/swagger.yaml
@@ -49,7 +49,10 @@ info:
     `AlertTransition`. The `AlertTransition` payload (fault-detection alerts) is
     `{ "condition": <string>, "state": "raised"|"cleared", "ts": <unix-seconds>,
     "detail": <string> }`, where `condition` is one of `chlorinator_fault`,
-    `salt_low`, `service_mode`, `serial_comms_loss`.
+    `chlorinator_warning`, `salt_low`, `service_mode`, `serial_comms_loss`.
+    `chlorinator_warning` covers the cell warnings (no flow, low/high salt, clean
+    cell, low/high voltage/current, low temperature); the specific warning is
+    named in `detail`.
   version: 1.0.0
   contact:
     name: Aqualink Automate

--- a/assets/web/scripts/pwa.js
+++ b/assets/web/scripts/pwa.js
@@ -10,6 +10,23 @@
     return;
   }
 
+  // When an UPDATED worker takes control (e.g. a redeployed shell that bumped
+  // CACHE_VERSION, which calls skipWaiting()+clients.claim()), reload once so
+  // this tab runs the fresh JS/CSS it now serves instead of the assets it
+  // loaded under the old worker. Guarded two ways: only armed when the page was
+  // already controlled at load (a genuine update, not a first-ever install), and
+  // the `refreshing` latch prevents a reload loop.
+  if (navigator.serviceWorker.controller) {
+    var refreshing = false;
+    navigator.serviceWorker.addEventListener('controllerchange', function onControllerChange() {
+      if (refreshing) {
+        return;
+      }
+      refreshing = true;
+      window.location.reload();
+    });
+  }
+
   window.addEventListener('load', function onLoad() {
     navigator.serviceWorker.register('/sw.js').catch(function onError(err) {
       console.warn('Service worker registration failed:', err);

--- a/assets/web/scripts/stores/alerts-store.js
+++ b/assets/web/scripts/stores/alerts-store.js
@@ -9,6 +9,7 @@
 // Friendly labels for the known condition keys (falls back to the raw key).
 const ALERT_LABELS = {
     chlorinator_fault: 'Chlorinator fault',
+    chlorinator_warning: 'Chlorinator warning',
     salt_low: 'Salt low',
     service_mode: 'Service mode',
     serial_comms_loss: 'Serial comms lost',

--- a/assets/web/styles/components.css
+++ b/assets/web/styles/components.css
@@ -873,6 +873,11 @@ html.dark .gauge-card {
 }
 
 .section-toggle .section-title {
+    /* Reset BOTH inherited block margins: the base .section-title has a 0.5rem
+       margin-top, and inside this `align-items: center` flex header that
+       asymmetric top margin shifts the label below the chevron. Zeroing both
+       lets flex centre the text against the chevron. */
+    margin-top: 0;
     margin-bottom: 0;
     color: var(--text-secondary);
 }

--- a/assets/web/sw.js
+++ b/assets/web/sw.js
@@ -23,9 +23,11 @@
  *   - /ws/*   : never intercepted (WebSocket upgrades are not cacheable and must
  *     reach the backend untouched).
  *
- * The cache name is version-stamped.  Bump CACHE_VERSION whenever the static
- * shell assets change so returning clients pick up the new files (old caches are
- * purged on activate).
+ * The cache name is stamped with the build version at build/package time (see
+ * cmake/stamp_sw_version.cmake), so each release gets its own cache and stale
+ * offline shells purge on activate. The literal below is only the source/dev
+ * fallback when the file is served unstamped (e.g. --doc-root <assets/web>);
+ * with the network-first strategy above, online freshness never depends on it.
  */
 
 const CACHE_VERSION = 'v2';

--- a/assets/web/sw.js
+++ b/assets/web/sw.js
@@ -5,10 +5,17 @@
  * of scope (see WS7): offline command queueing and push notifications.
  *
  * Caching strategy:
- *   - Static shell (HTML / JS / CSS / icons / fonts-from-same-origin): cache
- *     first, falling back to network and populating the cache on a miss.
- *   - Navigations: serve the cached app shell (index.html) when the network is
- *     unavailable so the SPA still boots offline.
+ *   - Static shell (JS / CSS / icons / fonts-from-same-origin): NETWORK FIRST,
+ *     falling back to the cached copy only when the network is unreachable. The
+ *     server already marks these assets `no-cache` (revalidate via ETag); a
+ *     cache-first service worker silently IGNORES that — the Cache Storage API
+ *     does not honour HTTP cache semantics — and would pin returning clients to
+ *     stale JS/CSS until CACHE_VERSION is bumped, even though the HTML (served
+ *     network-first below) is fresh. That fresh-HTML + stale-JS mismatch breaks
+ *     the UI until a hard reload. Network-first keeps online clients current and
+ *     still boots offline from the last good copy.
+ *   - Navigations: try the network, serve the cached app shell (index.html) when
+ *     the network is unavailable so the SPA still boots offline.
  *   - /api/*  : NETWORK ONLY.  Never cached and never served from cache — API
  *     responses (equipment state, auth checks, etc.) must always be live, and a
  *     stale cached /api/auth/check could wrongly keep an unauthenticated client
@@ -21,7 +28,7 @@
  * purged on activate).
  */
 
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = 'v2';
 const CACHE_NAME = `aqualink-shell-${CACHE_VERSION}`;
 
 // Core app-shell assets to precache so the UI boots offline.  Kept deliberately
@@ -109,14 +116,13 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Static assets: cache first, then network (populating the cache on a miss).
+  // Static assets: network first, falling back to cache when offline. Always
+  // prefer the live file so a redeployed JS/CSS bundle reaches the client on the
+  // next normal load (no hard reload needed); refresh the cached copy on every
+  // successful fetch so the offline fallback stays current.
   event.respondWith(
     (async () => {
       const cache = await caches.open(CACHE_NAME);
-      const cached = await cache.match(request);
-      if (cached) {
-        return cached;
-      }
       try {
         const response = await fetch(request);
         // Only cache successful, basic (same-origin) responses.
@@ -125,6 +131,11 @@ self.addEventListener('fetch', (event) => {
         }
         return response;
       } catch (err) {
+        // Offline — serve the last good cached copy if we have one.
+        const cached = await cache.match(request);
+        if (cached) {
+          return cached;
+        }
         // Offline and not cached — surface the network failure.
         throw err;
       }

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -152,6 +152,18 @@ endif()
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets/ssl/ DESTINATION ${AQ_SSL_DESTINATION} COMPONENT SslAssets)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets/web/ DESTINATION ${AQ_WEB_DESTINATION} COMPONENT WebAssets)
+
+# Stamp the installed service worker's cache name with the build version (mirrors
+# the dev-tree POST_BUILD step in src/CMakeLists.txt) so a packaged upgrade purges
+# the previous version's offline shell on activate. Declared after the web-asset
+# directory install so it runs once those files are staged.
+install(CODE "
+    execute_process(COMMAND \"${CMAKE_COMMAND}\"
+        -D \"SW_JS=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${AQ_WEB_DESTINATION}/sw.js\"
+        -D \"AQ_VERSION=${PROJECT_VERSION}\"
+        -P \"${CMAKE_SOURCE_DIR}/cmake/stamp_sw_version.cmake\")
+" COMPONENT WebAssets)
+
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
     DESTINATION ${AQ_EXAMPLES_DESTINATION}
     COMPONENT ExampleConfigs

--- a/cmake/stamp_sw_version.cmake
+++ b/cmake/stamp_sw_version.cmake
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# stamp_sw_version.cmake
+# ======================
+# Rewrites the `const CACHE_VERSION = '...';` line in a (copied or installed)
+# service-worker script so each build/package gets a unique service-worker cache
+# name. That makes the activate-time purge drop the previous version's offline
+# shell cache cleanly across upgrades. Online freshness already comes from the
+# network-first fetch strategy in sw.js; this only governs the offline fallback.
+#
+# Invoked via:  cmake -D SW_JS=<path to sw.js> -D AQ_VERSION=<version> -P <this>
+# Absent file (e.g. a doc-root without a service worker) is a quiet no-op.
+# ---------------------------------------------------------------------------
+
+if(NOT EXISTS "${SW_JS}")
+    return()
+endif()
+
+if(NOT DEFINED AQ_VERSION OR AQ_VERSION STREQUAL "")
+    set(AQ_VERSION "0")
+endif()
+
+file(READ "${SW_JS}" _sw_contents)
+string(REGEX REPLACE
+    "const CACHE_VERSION = '[^']*';"
+    "const CACHE_VERSION = '${AQ_VERSION}';"
+    _sw_contents "${_sw_contents}")
+file(WRITE "${SW_JS}" "${_sw_contents}")

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,6 +28,25 @@ Prerelease versions use the format `<label>.<N>`:
 - **Local builds without tags**: Falls back to `0.0.0-dev`, making it obvious this is not a release build.
 - **CMake `project()`**: Receives only the `M.M.P` portion (CMake doesn't support prerelease in `VERSION`). The full version including prerelease is available via `PROJECT_VERSION_FULL`.
 
+## Repository Configuration
+
+### Docker Hub credentials (optional but recommended)
+
+The `runtime`/`ci` Docker images build `FROM ubuntu:25.04` and `FROM node:22-bookworm-slim`, which are pulled from Docker Hub. Anonymous pulls share the runner's egress IP and are subject to Docker Hub's anonymous per-IP rate limit — a recurring CI reliability risk, especially on **self-hosted runners** (one shared IP across many jobs) and during Docker Hub CDN hiccups.
+
+Configure these **optional** repository secrets to authenticate base-image pulls and get a higher rate limit:
+
+| Secret              | Value                                                                 |
+|---------------------|-----------------------------------------------------------------------|
+| `DOCKERHUB_USERNAME`| A Docker Hub account username                                         |
+| `DOCKERHUB_TOKEN`   | A Docker Hub **access token** (Account Settings → Personal access tokens; `Public Repo Read-only` scope is sufficient) |
+
+Both the release `docker-publish` job and the CI `docker-verify` job log in to Docker Hub **only when both secrets are present** (`if: env.DOCKERHUB_USERNAME != ''`). If they are unset — forks, or before they are configured — the workflows fall back to anonymous pulls and still work. Nothing else is required.
+
+The Docker build steps are additionally wrapped in a **bounded retry** (`nick-fields/retry`, 3 attempts), so a single transient base-image blob timeout retries instead of failing the whole release; the retry reuses the BuildKit layer cache, so it only re-fetches the layer that timed out.
+
+> **Self-hosted runners:** for heavily-used self-hosted runners you can additionally configure a [pull-through registry mirror](https://docs.docker.com/docker-hub/image-library/mirror/) on the runner host (a local registry caching Docker Hub, referenced via `registry-mirrors` in `/etc/docker/daemon.json` and the BuildKit builder config). This is host/daemon configuration — not part of these workflow files — and complements the authentication above.
+
 ## Pre-release Checklist
 
 Before creating a release:
@@ -127,6 +146,14 @@ Ensure tags follow the `v<M>.<M>.<P>` format exactly. Lightweight and annotated 
 ### Package filename doesn't include prerelease
 
 The prerelease suffix is only added when `PROJECT_VERSION_PRERELEASE` is non-empty. Verify the tag includes a prerelease suffix (e.g. `v1.0.0-beta.1`).
+
+### Docker build fails pulling a base image (rate limit or CDN timeout)
+
+Symptoms: `docker-publish` (release) or `docker-verify` (CI) fails while pulling `ubuntu:25.04` or `node:22-bookworm-slim`, with errors like `toomanyrequests: ... rate limit` or `dial tcp ...(production.cloudfront.docker.com): i/o timeout`.
+
+- The build steps already retry up to 3 times, so a one-off CDN timeout should self-heal — check whether the run eventually succeeded on a later attempt.
+- If you see rate-limit (`toomanyrequests`) errors, configure the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets (see [Docker Hub credentials](#docker-hub-credentials-optional-but-recommended)) so pulls are authenticated.
+- On self-hosted runners, consider a pull-through registry mirror (same section) to remove the dependency on Docker Hub's CDN for repeat builds.
 
 ### Manual dispatch tag already exists
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,9 @@ add_custom_command(
 	# Copy beside the executable into web/ to match the runtime default doc-root
 	# (Application::DOC_ROOT = <exe_dir>/web) and the packaged layout (bin/web).
 	COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CMAKE_SOURCE_DIR}/assets/web" "$<TARGET_FILE_DIR:aqualink-automate>/web"
+	# Stamp the service-worker cache name with the build version: a unique cache
+	# per build whose old offline shells purge on activate (see cmake/stamp_sw_version.cmake).
+	COMMAND ${CMAKE_COMMAND} -D "SW_JS=$<TARGET_FILE_DIR:aqualink-automate>/web/sw.js" -D "AQ_VERSION=${PROJECT_VERSION}" -P "${CMAKE_SOURCE_DIR}/cmake/stamp_sw_version.cmake"
 	COMMENT "Syncing web assets"
 )
 

--- a/src/core/alerting/alert_condition.h
+++ b/src/core/alerting/alert_condition.h
@@ -20,6 +20,7 @@ namespace AqualinkAutomate::Alerting
 	namespace ConditionKeys
 	{
 		inline constexpr std::string_view ChlorinatorFault{ "chlorinator_fault" };
+		inline constexpr std::string_view ChlorinatorWarning{ "chlorinator_warning" };
 		inline constexpr std::string_view SaltLow{ "salt_low" };
 		inline constexpr std::string_view ServiceMode{ "service_mode" };
 		inline constexpr std::string_view SerialCommsLoss{ "serial_comms_loss" };
@@ -40,12 +41,13 @@ namespace AqualinkAutomate::Alerting
 	// DataHub traits without emitting a per-device status event, so a generic
 	// "device lost comms" cannot be detected cleanly without new hub plumbing.
 	// It can be added as a fifth entry once such a signal exists.
-	inline constexpr std::array<AlertConditionInfo, 4> AlertConditions
+	inline constexpr std::array<AlertConditionInfo, 5> AlertConditions
 	{ {
-		{ ConditionKeys::ChlorinatorFault, "Chlorinator Fault" },
-		{ ConditionKeys::SaltLow,          "Salt Low" },
-		{ ConditionKeys::ServiceMode,      "Service Mode" },
-		{ ConditionKeys::SerialCommsLoss,  "Serial Comms Loss" },
+		{ ConditionKeys::ChlorinatorFault,   "Chlorinator Fault" },
+		{ ConditionKeys::ChlorinatorWarning, "Chlorinator Warning" },
+		{ ConditionKeys::SaltLow,            "Salt Low" },
+		{ ConditionKeys::ServiceMode,        "Service Mode" },
+		{ ConditionKeys::SerialCommsLoss,    "Serial Comms Loss" },
 	} };
 
 	// Subtopic (appended to the MQTT topic prefix via MqttClient::BuildTopic)

--- a/src/core/alerting/alert_monitor.cpp
+++ b/src/core/alerting/alert_monitor.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <chrono>
 #include <format>
+#include <optional>
+#include <string_view>
 #include <utility>
 
 #include "alerting/alert_monitor.h"
@@ -25,14 +27,45 @@ namespace AqualinkAutomate::Alerting
 				std::chrono::system_clock::now().time_since_epoch()).count();
 		}
 
-		// A genuine chlorinator FAULT (not a transient warning).  Warnings such as
-		// low/high salt or no-flow are surfaced elsewhere; this condition latches
-		// only on the hard-fault states and clears on Ok/Unknown (and on warnings,
-		// which are not faults).
+		// A genuine chlorinator FAULT (not a transient warning).  This condition
+		// latches only on the hard-fault states; transient warnings are surfaced
+		// by the separate chlorinator_warning condition below.
 		bool IsChlorinatorFault(Kernel::ChlorinatorHealth health)
 		{
 			return health == Kernel::ChlorinatorHealth::Error_CheckPCB
 				|| health == Kernel::ChlorinatorHealth::GeneralFault;
+		}
+
+		// Human-readable label for a hard-fault health state (used in the alert
+		// detail so the log line / UI toast names the specific fault).
+		std::string_view ChlorinatorFaultLabel(Kernel::ChlorinatorHealth health)
+		{
+			switch (health)
+			{
+			case Kernel::ChlorinatorHealth::Error_CheckPCB: return "Check PCB";
+			case Kernel::ChlorinatorHealth::GeneralFault:   return "General fault";
+			default:                                        return "Fault";
+			}
+		}
+
+		// Maps a chlorinator health value to a human-readable WARNING label, or
+		// std::nullopt when the value is not a warning (Ok / TurningOff / a hard
+		// fault / Unknown).  This is the chlorinator-agnostic catalogue of the
+		// cell warnings the AlertMonitor surfaces — every warning the device layer
+		// can report, not just low salt.
+		std::optional<std::string_view> ChlorinatorWarningLabel(Kernel::ChlorinatorHealth health)
+		{
+			switch (health)
+			{
+			case Kernel::ChlorinatorHealth::Warning_NoFlow:         return "No flow";
+			case Kernel::ChlorinatorHealth::Warning_LowSalt:        return "Low salt";
+			case Kernel::ChlorinatorHealth::Warning_HighSalt:       return "High salt";
+			case Kernel::ChlorinatorHealth::Warning_HighCurrent:    return "High current";
+			case Kernel::ChlorinatorHealth::Warning_CleanCell:      return "Clean cell";
+			case Kernel::ChlorinatorHealth::Warning_LowVoltage:     return "Low voltage";
+			case Kernel::ChlorinatorHealth::Warning_LowTemperature: return "Low temperature";
+			default:                                                return std::nullopt;
+			}
 		}
 
 		std::uint64_t TotalMessageCount(const Kernel::StatisticsHub& stats)
@@ -152,6 +185,7 @@ namespace AqualinkAutomate::Alerting
 	void AlertMonitor::EvaluateAll()
 	{
 		EvaluateSaltLow();
+		EvaluateChlorinatorWarning();
 		EvaluateChlorinatorFault();
 		EvaluateServiceMode();
 		EvaluateSerialCommsLoss();
@@ -194,6 +228,36 @@ namespace AqualinkAutomate::Alerting
 		}
 	}
 
+	void AlertMonitor::EvaluateChlorinatorWarning()
+	{
+		if (!m_DataHub)
+		{
+			return;
+		}
+
+		auto chlorinators = m_DataHub->Chlorinators();
+		if (chlorinators.empty())
+		{
+			// No chlorinator discovered -> clear any latched warning.
+			SetCondition(ConditionKeys::ChlorinatorWarning, false, "No chlorinator present");
+			return;
+		}
+
+		auto health = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::ChlorinatorHealthTrait{});
+		std::optional<std::string_view> warning;
+		if (health.has_value())
+		{
+			warning = ChlorinatorWarningLabel(health.value());
+		}
+
+		// Raise while the cell is reporting any warning, naming the specific one
+		// in the detail so the log line / UI toast is actionable.  The health trait
+		// is dwell-smoothed at the device layer, so this does not flap when the
+		// cell sits on a boundary.
+		SetCondition(ConditionKeys::ChlorinatorWarning, warning.has_value(),
+			warning.has_value() ? std::format("Chlorinator warning: {}", warning.value()) : "Chlorinator health OK");
+	}
+
 	void AlertMonitor::EvaluateChlorinatorFault()
 	{
 		if (!m_DataHub)
@@ -213,7 +277,7 @@ namespace AqualinkAutomate::Alerting
 		const bool fault = health.has_value() && IsChlorinatorFault(health.value());
 
 		SetCondition(ConditionKeys::ChlorinatorFault, fault,
-			fault ? "Chlorinator reporting a fault" : "Chlorinator health OK");
+			fault ? std::format("Chlorinator fault: {}", ChlorinatorFaultLabel(health.value())) : "Chlorinator health OK");
 	}
 
 	void AlertMonitor::EvaluateServiceMode()

--- a/src/core/alerting/alert_monitor.h
+++ b/src/core/alerting/alert_monitor.h
@@ -71,6 +71,7 @@ namespace AqualinkAutomate::Alerting
 
 		// Individual evaluators (exposed for targeted unit tests).
 		void EvaluateSaltLow();
+		void EvaluateChlorinatorWarning();
 		void EvaluateChlorinatorFault();
 		void EvaluateServiceMode();
 		void EvaluateSerialCommsLoss();

--- a/src/core/http/server/routing/routing.cpp
+++ b/src/core/http/server/routing/routing.cpp
@@ -344,7 +344,17 @@ namespace AqualinkAutomate::HTTP::Routing
 				}
 
 				LogTrace(Channel::Web, [&] { return std::format("Handling HTTP {} request for {}", magic_enum::enum_name(req.method()), std::string_view(req.target())); });
-				return p->OnRequest(req);
+
+				// Dynamic route responses (API equipment state, diagnostics, etc.)
+				// reflect live data and must never be reused from a cache. The service
+				// worker already treats /api as network-only; stamping no-store here —
+				// the single place a registered route's mutable Response is still in
+				// hand before it is type-erased into a message_generator — is the
+				// defence-in-depth for direct browser fetches and any intermediary,
+				// and means no handler has to remember to set it.
+				HTTP::Response resp = p->OnRequest(req);
+				resp.set(boost::beast::http::field::cache_control, "no-store");
+				return resp;
 			}
 			else if (sf_route.has_value() && sf_route->match(req.target(), static_file_result))
 			{

--- a/src/core/http/webroute_auth_check.cpp
+++ b/src/core/http/webroute_auth_check.cpp
@@ -9,7 +9,7 @@
 namespace AqualinkAutomate::HTTP
 {
 
-	HTTP::Message WebRoute_AuthCheck::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_AuthCheck::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_AuthCheck::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_auth_check.h
+++ b/src/core/http/webroute_auth_check.h
@@ -19,7 +19,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_AuthCheck() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 	};
 
 }

--- a/src/core/http/webroute_diagnostics_actualdevices.cpp
+++ b/src/core/http/webroute_diagnostics_actualdevices.cpp
@@ -26,7 +26,7 @@ namespace AqualinkAutomate::HTTP
 		return CollectDeviceDiagnostics(*m_EquipmentHub, false);
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_ActualDevices::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_ActualDevices::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_ActualDevices::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_diagnostics_actualdevices.h
+++ b/src/core/http/webroute_diagnostics_actualdevices.h
@@ -25,7 +25,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Diagnostics_ActualDevices() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		// Collect diagnostic JSON for every *non-emulated* device in the hub.
 		nlohmann::json CollectActualDiagnostics() const;

--- a/src/core/http/webroute_diagnostics_devices.cpp
+++ b/src/core/http/webroute_diagnostics_devices.cpp
@@ -56,7 +56,7 @@ namespace AqualinkAutomate::HTTP
 		return CollectDeviceDiagnostics(*m_EquipmentHub, true);
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Devices::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Devices::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_Devices::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_diagnostics_devices.h
+++ b/src/core/http/webroute_diagnostics_devices.h
@@ -33,7 +33,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Diagnostics_Devices() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		// Collect diagnostic JSON for every *emulated* device in the hub.
 		nlohmann::json CollectEmulatedDiagnostics() const;

--- a/src/core/http/webroute_diagnostics_logging.cpp
+++ b/src/core/http/webroute_diagnostics_logging.cpp
@@ -17,7 +17,7 @@ using namespace AqualinkAutomate::Logging;
 namespace AqualinkAutomate::HTTP
 {
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Logging::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Logging::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_Logging::OnRequest", std::source_location::current());
 
@@ -34,7 +34,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Logging::HandleGet(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Logging::HandleGet(const HTTP::Request& req)
 	{
 		nlohmann::json result;
 
@@ -60,7 +60,7 @@ namespace AqualinkAutomate::HTTP
 		return MakeJsonResponse(req, HTTP::Status::ok, result.dump());
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Logging::HandlePost(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Logging::HandlePost(const HTTP::Request& req)
 	{
 		try
 		{

--- a/src/core/http/webroute_diagnostics_logging.h
+++ b/src/core/http/webroute_diagnostics_logging.h
@@ -13,11 +13,11 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Diagnostics_Logging() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandleGet(const HTTP::Request& req);
-		HTTP::Message HandlePost(const HTTP::Request& req);
+		HTTP::Response HandleGet(const HTTP::Request& req);
+		HTTP::Response HandlePost(const HTTP::Request& req);
 	};
 
 }

--- a/src/core/http/webroute_diagnostics_matter.cpp
+++ b/src/core/http/webroute_diagnostics_matter.cpp
@@ -149,7 +149,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	HTTP::Message WebRoute_Diagnostics_Matter::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Matter::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_Matter::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_diagnostics_matter.h
+++ b/src/core/http/webroute_diagnostics_matter.h
@@ -38,7 +38,7 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Diagnostics_Matter& operator=(WebRoute_Diagnostics_Matter&&) = delete;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		// Background-thread body: polls the sidecar off the main loop and updates the

--- a/src/core/http/webroute_diagnostics_mqtt.cpp
+++ b/src/core/http/webroute_diagnostics_mqtt.cpp
@@ -21,7 +21,7 @@ namespace AqualinkAutomate::HTTP
 	{
 	}
 
-	HTTP::Message WebRoute_Diagnostics_Mqtt::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Mqtt::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_Mqtt::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_diagnostics_mqtt.h
+++ b/src/core/http/webroute_diagnostics_mqtt.h
@@ -17,7 +17,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Diagnostics_Mqtt() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		// MQTT is constructed AFTER the routes are registered, so resolve it

--- a/src/core/http/webroute_diagnostics_options.cpp
+++ b/src/core/http/webroute_diagnostics_options.cpp
@@ -8,7 +8,7 @@
 namespace AqualinkAutomate::HTTP
 {
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Options::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Options::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_Options::OnRequest", std::source_location::current());
 
@@ -22,7 +22,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Options::HandleGet(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Options::HandleGet(const HTTP::Request& req)
 	{
 		nlohmann::json options = nlohmann::json::array();
 		for (const auto& meta : Options::AppOption::RegisteredOptions())

--- a/src/core/http/webroute_diagnostics_options.h
+++ b/src/core/http/webroute_diagnostics_options.h
@@ -13,10 +13,10 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Diagnostics_Options() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandleGet(const HTTP::Request& req);
+		HTTP::Response HandleGet(const HTTP::Request& req);
 	};
 
 }

--- a/src/core/http/webroute_diagnostics_recording.cpp
+++ b/src/core/http/webroute_diagnostics_recording.cpp
@@ -34,7 +34,7 @@ namespace AqualinkAutomate::HTTP
 			return result;
 		}
 
-		HTTP::Message MakeJsonResponse(const HTTP::Request& req, HTTP::Status code, const std::string& body)
+		HTTP::Response MakeJsonResponse(const HTTP::Request& req, HTTP::Status code, const std::string& body)
 		{
 			HTTP::Response resp{ code, req.version() };
 			resp.set(boost::beast::http::field::server, ServerFields::Server());
@@ -158,7 +158,7 @@ namespace AqualinkAutomate::HTTP
 		m_RecordingController = hub_locator.TryFind<Interfaces::IRecordingController>();
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Recording::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Recording::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Diagnostics_Recording::OnRequest", std::source_location::current());
 
@@ -175,7 +175,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Recording::HandleGet(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Recording::HandleGet(const HTTP::Request& req)
 	{
 		Interfaces::IRecordingController::Status status;
 		if (m_RecordingController)
@@ -188,7 +188,7 @@ namespace AqualinkAutomate::HTTP
 		return MakeJsonResponse(req, HTTP::Status::ok, StatusToJson(status).dump());
 	}
 
-	boost::beast::http::message_generator WebRoute_Diagnostics_Recording::HandlePost(const HTTP::Request& req)
+	HTTP::Response WebRoute_Diagnostics_Recording::HandlePost(const HTTP::Request& req)
 	{
 		if (!m_RecordingController)
 		{

--- a/src/core/http/webroute_diagnostics_recording.h
+++ b/src/core/http/webroute_diagnostics_recording.h
@@ -17,11 +17,11 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Diagnostics_Recording() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandleGet(const HTTP::Request& req);
-		HTTP::Message HandlePost(const HTTP::Request& req);
+		HTTP::Response HandleGet(const HTTP::Request& req);
+		HTTP::Response HandlePost(const HTTP::Request& req);
 
 	private:
 		// Non-owning: the controller is owned by the serial chain (SerialPort) for

--- a/src/core/http/webroute_equipment.cpp
+++ b/src/core/http/webroute_equipment.cpp
@@ -61,7 +61,7 @@ namespace AqualinkAutomate::HTTP
 		m_PreferencesHub = hub_locator.Find<Kernel::PreferencesHub>();
 	}
 
-	Message WebRoute_Equipment::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Equipment::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_equipment.h
+++ b/src/core/http/webroute_equipment.h
@@ -18,7 +18,7 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Equipment(Kernel::HubLocator& hub_locator);
 
 	public:
-        HTTP::Message OnRequest(const HTTP::Request& req) final;
+        HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };

--- a/src/core/http/webroute_equipment_button.cpp
+++ b/src/core/http/webroute_equipment_button.cpp
@@ -61,7 +61,7 @@ namespace AqualinkAutomate::HTTP
 		m_CommandDispatcher = hub_locator.TryFind<Interfaces::ICommandDispatcher>();
 	}
 
-	HTTP::Message WebRoute_Equipment_Button::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Button::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_EquipmentButton::OnRequest", std::source_location::current());
 
@@ -78,7 +78,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	HTTP::Message WebRoute_Equipment_Button::ButtonIndividual_GetHandler(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Button::ButtonIndividual_GetHandler(const HTTP::Request& req)
 	{
 		const std::string UNKNOWN_BUTTON_ID{ "Unknown Or Missing Button Id" };
 
@@ -123,7 +123,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	HTTP::Message WebRoute_Equipment_Button::ButtonIndividual_PostHandler(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Button::ButtonIndividual_PostHandler(const HTTP::Request& req)
 	{
 		const std::string UNKNOWN_BUTTON_ID{ "Unknown Or Missing Button Id" };
 
@@ -206,7 +206,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	HTTP::Message WebRoute_Equipment_Button::Report_ButtonDoesntExist(const HTTP::Request& req, const std::string& button_id)
+	HTTP::Response WebRoute_Equipment_Button::Report_ButtonDoesntExist(const HTTP::Request& req, const std::string& button_id)
 	{
 		LogInfo(Channel::Web, std::format("Received an invalid button id ('{}'); rejecting button request", button_id));
 
@@ -216,7 +216,7 @@ namespace AqualinkAutomate::HTTP
 		return resp;
 	}
 
-	HTTP::Message WebRoute_Equipment_Button::Report_SystemIsInactive(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Button::Report_SystemIsInactive(const HTTP::Request& req)
 	{
 		LogInfo(Channel::Web, "Aqualink Automate has not yet initialised (PoolConfiguration == Unknown); rejecting button action request");
 

--- a/src/core/http/webroute_equipment_button.h
+++ b/src/core/http/webroute_equipment_button.h
@@ -17,15 +17,15 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Equipment_Button(Kernel::HubLocator& hub_locator);
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	public:
-		HTTP::Message ButtonIndividual_GetHandler(const HTTP::Request& req);
-		HTTP::Message ButtonIndividual_PostHandler(const HTTP::Request& req);
+		HTTP::Response ButtonIndividual_GetHandler(const HTTP::Request& req);
+		HTTP::Response ButtonIndividual_PostHandler(const HTTP::Request& req);
 
 	private:
-		HTTP::Message Report_ButtonDoesntExist(const HTTP::Request& req, const std::string& button_id);
-		HTTP::Message Report_SystemIsInactive(const HTTP::Request& req);
+		HTTP::Response Report_ButtonDoesntExist(const HTTP::Request& req, const std::string& button_id);
+		HTTP::Response Report_SystemIsInactive(const HTTP::Request& req);
 
 	private:
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };

--- a/src/core/http/webroute_equipment_buttons.cpp
+++ b/src/core/http/webroute_equipment_buttons.cpp
@@ -26,7 +26,7 @@ namespace AqualinkAutomate::HTTP
 		m_PreferencesHub = hub_locator.Find<Kernel::PreferencesHub>();
     }
 
-    HTTP::Message WebRoute_Equipment_Buttons::OnRequest(const HTTP::Request& req)
+    HTTP::Response WebRoute_Equipment_Buttons::OnRequest(const HTTP::Request& req)
     {
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_EquipmentButtons::OnRequest", std::source_location::current());
 
@@ -43,7 +43,7 @@ namespace AqualinkAutomate::HTTP
 		}
     }
 
-	HTTP::Message WebRoute_Equipment_Buttons::ButtonCollection_GetHandler(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Buttons::ButtonCollection_GetHandler(const HTTP::Request& req)
 	{
 		nlohmann::json buttons, all_buttons;
 
@@ -102,7 +102,7 @@ namespace AqualinkAutomate::HTTP
         return resp;
 	}
 
-	HTTP::Message WebRoute_Equipment_Buttons::ButtonCollection_PostHandler(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Buttons::ButtonCollection_PostHandler(const HTTP::Request& req)
     {
         HTTP::Response resp{HTTP::Status::ok, req.version()};
 

--- a/src/core/http/webroute_equipment_buttons.h
+++ b/src/core/http/webroute_equipment_buttons.h
@@ -17,11 +17,11 @@ namespace AqualinkAutomate::HTTP
         WebRoute_Equipment_Buttons(Kernel::HubLocator& hub_locator);
 
     public:
-        HTTP::Message OnRequest(const HTTP::Request& req) final;
+        HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	public:
-        HTTP::Message ButtonCollection_GetHandler(const HTTP::Request& req);
-        HTTP::Message ButtonCollection_PostHandler(const HTTP::Request& req);
+        HTTP::Response ButtonCollection_GetHandler(const HTTP::Request& req);
+        HTTP::Response ButtonCollection_PostHandler(const HTTP::Request& req);
 
 	private:
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };

--- a/src/core/http/webroute_equipment_chlorinator.cpp
+++ b/src/core/http/webroute_equipment_chlorinator.cpp
@@ -41,7 +41,7 @@ namespace AqualinkAutomate::HTTP
 		m_CommandDispatcher = hub_locator.TryFind<Interfaces::ICommandDispatcher>();
 	}
 
-	HTTP::Message WebRoute_Equipment_Chlorinator::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Chlorinator::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_EquipmentChlorinator::OnRequest", std::source_location::current());
 
@@ -52,7 +52,7 @@ namespace AqualinkAutomate::HTTP
 		return HTTP::Responses::Response_405(req);
 	}
 
-	HTTP::Message WebRoute_Equipment_Chlorinator::HandlePost(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Chlorinator::HandlePost(const HTTP::Request& req)
 	{
 		if (!m_CommandDispatcher)
 		{

--- a/src/core/http/webroute_equipment_chlorinator.h
+++ b/src/core/http/webroute_equipment_chlorinator.h
@@ -20,10 +20,10 @@ namespace AqualinkAutomate::HTTP
 		explicit WebRoute_Equipment_Chlorinator(Kernel::HubLocator& hub_locator);
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandlePost(const HTTP::Request& req);
+		HTTP::Response HandlePost(const HTTP::Request& req);
 
 	private:
 		std::shared_ptr<Interfaces::ICommandDispatcher> m_CommandDispatcher{ nullptr };

--- a/src/core/http/webroute_equipment_devices.cpp
+++ b/src/core/http/webroute_equipment_devices.cpp
@@ -12,7 +12,7 @@ namespace AqualinkAutomate::HTTP
 		m_PreferencesHub = hub_locator.Find<Kernel::PreferencesHub>();
 	}
 	
-    HTTP::Message WebRoute_Equipment_Devices::OnRequest(const HTTP::Request& req)
+    HTTP::Response WebRoute_Equipment_Devices::OnRequest(const HTTP::Request& req)
     {
         auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_EquipmentDevices::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_equipment_devices.h
+++ b/src/core/http/webroute_equipment_devices.h
@@ -17,7 +17,7 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Equipment_Devices(Kernel::HubLocator& hub_locator);
 
 	public:
-        HTTP::Message OnRequest(const HTTP::Request& req) final;
+        HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };

--- a/src/core/http/webroute_equipment_iaq.cpp
+++ b/src/core/http/webroute_equipment_iaq.cpp
@@ -40,7 +40,7 @@ namespace AqualinkAutomate::HTTP
 		m_CommandDispatcher = hub_locator.TryFind<Interfaces::ICommandDispatcher>();
 	}
 
-	HTTP::Message WebRoute_Equipment_IAQ::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_IAQ::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Equipment_IAQ::OnRequest", std::source_location::current());
 
@@ -51,7 +51,7 @@ namespace AqualinkAutomate::HTTP
 		return HTTP::Responses::Response_405(req);
 	}
 
-	HTTP::Message WebRoute_Equipment_IAQ::HandlePost(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_IAQ::HandlePost(const HTTP::Request& req)
 	{
 		if (!m_CommandDispatcher)
 		{

--- a/src/core/http/webroute_equipment_iaq.h
+++ b/src/core/http/webroute_equipment_iaq.h
@@ -21,10 +21,10 @@ namespace AqualinkAutomate::HTTP
 		explicit WebRoute_Equipment_IAQ(Kernel::HubLocator& hub_locator);
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandlePost(const HTTP::Request& req);
+		HTTP::Response HandlePost(const HTTP::Request& req);
 
 	private:
 		std::shared_ptr<Interfaces::ICommandDispatcher> m_CommandDispatcher{ nullptr };

--- a/src/core/http/webroute_equipment_setpoints.cpp
+++ b/src/core/http/webroute_equipment_setpoints.cpp
@@ -41,7 +41,7 @@ namespace AqualinkAutomate::HTTP
 		m_CommandDispatcher = hub_locator.TryFind<Interfaces::ICommandDispatcher>();
 	}
 
-	HTTP::Message WebRoute_Equipment_Setpoints::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Setpoints::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_EquipmentSetpoints::OnRequest", std::source_location::current());
 
@@ -58,7 +58,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	HTTP::Message WebRoute_Equipment_Setpoints::HandleGet(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Setpoints::HandleGet(const HTTP::Request& req)
 	{
 		nlohmann::json body;
 
@@ -75,7 +75,7 @@ namespace AqualinkAutomate::HTTP
 		return resp;
 	}
 
-	HTTP::Message WebRoute_Equipment_Setpoints::HandlePost(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Setpoints::HandlePost(const HTTP::Request& req)
 	{
 		if (!m_CommandDispatcher)
 		{

--- a/src/core/http/webroute_equipment_setpoints.h
+++ b/src/core/http/webroute_equipment_setpoints.h
@@ -17,11 +17,11 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Equipment_Setpoints(Kernel::HubLocator& hub_locator);
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandleGet(const HTTP::Request& req);
-		HTTP::Message HandlePost(const HTTP::Request& req);
+		HTTP::Response HandleGet(const HTTP::Request& req);
+		HTTP::Response HandlePost(const HTTP::Request& req);
 
 	private:
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };

--- a/src/core/http/webroute_equipment_spaside_remotes.cpp
+++ b/src/core/http/webroute_equipment_spaside_remotes.cpp
@@ -48,7 +48,7 @@ namespace AqualinkAutomate::HTTP
 			return envelope;
 		}
 
-		HTTP::Message MakeJsonResponse(const HTTP::Request& req, HTTP::Status code, const std::string& body)
+		HTTP::Response MakeJsonResponse(const HTTP::Request& req, HTTP::Status code, const std::string& body)
 		{
 			HTTP::Response resp{ code, req.version() };
 			resp.set(boost::beast::http::field::server, ServerFields::Server());
@@ -71,7 +71,7 @@ namespace AqualinkAutomate::HTTP
 		m_PreferencesHub = hub_locator.TryFind<Kernel::PreferencesHub>();
 	}
 
-	HTTP::Message WebRoute_Equipment_SpasideRemotes::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_SpasideRemotes::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Equipment_SpasideRemotes::OnRequest", std::source_location::current());
 
@@ -88,7 +88,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	HTTP::Message WebRoute_Equipment_SpasideRemotes::HandleGet(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_SpasideRemotes::HandleGet(const HTTP::Request& req)
 	{
 		std::vector<Interfaces::ISpasideRemoteController::RemoteState> remotes;
 		if (m_Controller)
@@ -149,7 +149,7 @@ namespace AqualinkAutomate::HTTP
 		return MakeJsonResponse(req, HTTP::Status::ok, envelope.dump());
 	}
 
-	HTTP::Message WebRoute_Equipment_SpasideRemotes::HandlePost(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_SpasideRemotes::HandlePost(const HTTP::Request& req)
 	{
 		if (!m_Controller)
 		{

--- a/src/core/http/webroute_equipment_spaside_remotes.h
+++ b/src/core/http/webroute_equipment_spaside_remotes.h
@@ -29,11 +29,11 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Equipment_SpasideRemotes() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
-		HTTP::Message HandleGet(const HTTP::Request& req);
-		HTTP::Message HandlePost(const HTTP::Request& req);
+		HTTP::Response HandleGet(const HTTP::Request& req);
+		HTTP::Response HandlePost(const HTTP::Request& req);
 
 	private:
 		// Non-owning: the controller is owned by the application for its whole lifetime. nullptr

--- a/src/core/http/webroute_equipment_version.cpp
+++ b/src/core/http/webroute_equipment_version.cpp
@@ -12,7 +12,7 @@ namespace AqualinkAutomate::HTTP
 		m_DataHub = hub_locator.Find<Kernel::DataHub>();
 	}
 
-	HTTP::Message WebRoute_Equipment_Version::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Equipment_Version::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_EquipmentVersion::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_equipment_version.h
+++ b/src/core/http/webroute_equipment_version.h
@@ -16,7 +16,7 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Equipment_Version(Kernel::HubLocator& hub_locator);
 
 	public:
-        HTTP::Message OnRequest(const HTTP::Request& req) final;
+        HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };

--- a/src/core/http/webroute_history.cpp
+++ b/src/core/http/webroute_history.cpp
@@ -41,7 +41,7 @@ namespace AqualinkAutomate::HTTP
 			return out;
 		}
 
-		HTTP::Message JsonResponse(const HTTP::Request& req, const nlohmann::json& body)
+		HTTP::Response JsonResponse(const HTTP::Request& req, const nlohmann::json& body)
 		{
 			HTTP::Response resp{ HTTP::Status::ok, req.version() };
 			resp.set(boost::beast::http::field::server, ServerFields::Server());
@@ -59,7 +59,7 @@ namespace AqualinkAutomate::HTTP
 	{
 	}
 
-	HTTP::Message WebRoute_History::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_History::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_History::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_history.h
+++ b/src/core/http/webroute_history.h
@@ -26,7 +26,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_History() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<History::HistoryService> m_Service;

--- a/src/core/http/webroute_metrics.cpp
+++ b/src/core/http/webroute_metrics.cpp
@@ -120,7 +120,7 @@ namespace AqualinkAutomate::HTTP
 		m_StatisticsHub = hub_locator.Find<Kernel::StatisticsHub>();
 	}
 
-	HTTP::Message WebRoute_Metrics::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Metrics::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Metrics::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_metrics.h
+++ b/src/core/http/webroute_metrics.h
@@ -21,7 +21,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Metrics() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Kernel::StatisticsHub> m_StatisticsHub{ nullptr };

--- a/src/core/http/webroute_preferences.cpp
+++ b/src/core/http/webroute_preferences.cpp
@@ -20,7 +20,7 @@ namespace AqualinkAutomate::HTTP
 	{
 	}
 
-	HTTP::Message WebRoute_Preferences::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Preferences::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Preferences::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_preferences.h
+++ b/src/core/http/webroute_preferences.h
@@ -20,7 +20,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Preferences() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Preferences::PreferencesService> m_Service;

--- a/src/core/http/webroute_schedules.cpp
+++ b/src/core/http/webroute_schedules.cpp
@@ -55,7 +55,7 @@ namespace AqualinkAutomate::HTTP
 	{
 	}
 
-	HTTP::Message WebRoute_Schedules::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Schedules::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Schedules::OnRequest", std::source_location::current());
 
@@ -101,7 +101,7 @@ namespace AqualinkAutomate::HTTP
 	{
 	}
 
-	HTTP::Message WebRoute_Schedule::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Schedule::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Schedule::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_schedules.h
+++ b/src/core/http/webroute_schedules.h
@@ -24,7 +24,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Schedules() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Scheduling::SchedulerService> m_Service;
@@ -39,7 +39,7 @@ namespace AqualinkAutomate::HTTP
 		~WebRoute_Schedule() override = default;
 
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) final;
+		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 	private:
 		std::shared_ptr<Scheduling::SchedulerService> m_Service;

--- a/src/core/http/webroute_version.cpp
+++ b/src/core/http/webroute_version.cpp
@@ -29,7 +29,7 @@ namespace AqualinkAutomate::HTTP
 		}
 	}
 
-	boost::beast::http::message_generator WebRoute_Version::OnRequest(const HTTP::Request& req)
+	HTTP::Response WebRoute_Version::OnRequest(const HTTP::Request& req)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("WebRoute_Version::OnRequest", std::source_location::current());
 

--- a/src/core/http/webroute_version.h
+++ b/src/core/http/webroute_version.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::HTTP
         ~WebRoute_Version() override = default;
 
 	public:
-        HTTP::Message OnRequest(const HTTP::Request& req) final;
+        HTTP::Response OnRequest(const HTTP::Request& req) final;
 	};
 
 }

--- a/src/core/interfaces/iwebroute.h
+++ b/src/core/interfaces/iwebroute.h
@@ -17,7 +17,10 @@ namespace AqualinkAutomate::Interfaces
         virtual const std::string_view Route() const = 0;
 
     public:
-        virtual HTTP::Message OnRequest(const HTTP::Request& req) = 0;
+        // Returns a mutable Response (not a type-erased message_generator) so the
+        // router can stamp response-wide policy — e.g. Cache-Control: no-store on
+        // dynamic API data — in one place before serialising. See HTTP_OnRequest.
+        virtual HTTP::Response OnRequest(const HTTP::Request& req) = 0;
     };
 
 	template<const auto& ROUTE_URL>

--- a/src/jandy/devices/aquarite_device.cpp
+++ b/src/jandy/devices/aquarite_device.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <format>
 #include <functional>
+#include <optional>
 #include <source_location>
 
 #include <magic_enum/magic_enum.hpp>
@@ -41,6 +43,14 @@ namespace AqualinkAutomate::Devices
 			default:                                                 return Kernel::ChlorinatorHealth::Unknown;
 			}
 		}
+
+		// A "concerning" health is a warning or fault the user should keep seeing;
+		// Ok and the transient TurningOff are benign.  Used to make clearing a
+		// warning slow (sticky) while raising one stays fast.
+		bool IsConcerningHealth(Kernel::ChlorinatorHealth health)
+		{
+			return !(health == Kernel::ChlorinatorHealth::Ok || health == Kernel::ChlorinatorHealth::TurningOff);
+		}
 	}
 	// namespace
 
@@ -75,6 +85,15 @@ namespace AqualinkAutomate::Devices
 		LogWarning(Channel::Devices, [this]() { return std::format("Aquarite (0x{:02x}): Watchdog timeout occurred - marking chlorinator as having lost communications.", DeviceId().Id()()); });
 
 		Status(Devices::DeviceStatus_LostComms{});
+
+		// Reset the publish-path smoothing so that, when communications resume,
+		// the first fresh reading is shown immediately rather than being held back
+		// by the pre-timeout dwell/median history (the watchdog forces the
+		// displayed health to Unknown below, bypassing the dwell state).
+		m_HealthInitialised = false;
+		m_HealthCandidateCount = 0;
+		m_SaltWindowCount = 0;
+		m_SaltWindowNext = 0;
 
 		// Reflect the loss of communications in the DataHub: the chlorinator is no longer
 		// reporting, so drive its operating status Off and health to Unknown rather than
@@ -213,6 +232,81 @@ namespace AqualinkAutomate::Devices
 		device->AuxillaryTraits.Set(DutyCycleTrait{}, clamped_percentage);
 	}
 
+	AquariteDevice::PPM AquariteDevice::MedianFilteredSalt(PPM raw_sample)
+	{
+		m_SaltWindow[m_SaltWindowNext] = raw_sample;
+		m_SaltWindowNext = (m_SaltWindowNext + 1) % SALT_MEDIAN_WINDOW;
+		if (m_SaltWindowCount < SALT_MEDIAN_WINDOW)
+		{
+			++m_SaltWindowCount;
+		}
+
+		// Median of the populated samples.  For an even count this returns the
+		// upper-middle element, which is an acceptable median proxy; the window is
+		// odd-sized and fills within a few frames, so most readings are an exact
+		// median.
+		std::array<PPM, SALT_MEDIAN_WINDOW> scratch = m_SaltWindow;
+		const auto first = scratch.begin();
+		const auto last = first + static_cast<std::ptrdiff_t>(m_SaltWindowCount);
+		const auto middle = first + static_cast<std::ptrdiff_t>(m_SaltWindowCount / 2);
+		std::nth_element(first, middle, last);
+		return *middle;
+	}
+
+	std::optional<Kernel::ChlorinatorHealth> AquariteDevice::DwellChlorinatorHealth(Kernel::ChlorinatorHealth raw_health)
+	{
+		// Never let an undecodable status (Unknown) disturb the displayed health:
+		// hold the last shown value rather than flashing "Unknown".
+		if (raw_health == Kernel::ChlorinatorHealth::Unknown)
+		{
+			return std::nullopt;
+		}
+
+		// The first decodable reading is shown immediately; the dwell governs only
+		// subsequent changes.
+		if (!m_HealthInitialised)
+		{
+			m_HealthInitialised = true;
+			m_DisplayedHealth = raw_health;
+			m_HealthCandidate = raw_health;
+			m_HealthCandidateCount = 0;
+			return raw_health;
+		}
+
+		if (raw_health == m_DisplayedHealth)
+		{
+			// Reading agrees with what we already show -> abandon any pending change.
+			m_HealthCandidate = raw_health;
+			m_HealthCandidateCount = 0;
+			return std::nullopt;
+		}
+
+		// A candidate change: count consecutive frames advocating the same new state.
+		if (raw_health == m_HealthCandidate)
+		{
+			++m_HealthCandidateCount;
+		}
+		else
+		{
+			m_HealthCandidate = raw_health;
+			m_HealthCandidateCount = 1;
+		}
+
+		// Clearing a warning/fault back to a benign state is deliberately slow
+		// (sticky); raising or switching between concerning states is fast.
+		const bool is_clearing = IsConcerningHealth(m_DisplayedHealth) && !IsConcerningHealth(raw_health);
+		const uint32_t threshold = is_clearing ? HEALTH_CLEAR_FRAMES : HEALTH_RAISE_FRAMES;
+
+		if (m_HealthCandidateCount >= threshold)
+		{
+			m_DisplayedHealth = raw_health;
+			m_HealthCandidateCount = 0;
+			return raw_health;
+		}
+
+		return std::nullopt;
+	}
+
 	void AquariteDevice::PushPPMToDataHub(const Messages::AquariteMessage_PPM& msg)
 	{
 		if (!m_DataHub)
@@ -223,7 +317,10 @@ namespace AqualinkAutomate::Devices
 		using namespace Kernel::AuxillaryTraitsTypes;
 		using namespace Units;
 
-		m_DataHub->SaltLevel(static_cast<double>(msg.SaltConcentrationPPM()) * Units::ppm);
+		// Publish a median-smoothed salt level so the cell's transient ppm spikes
+		// do not sawtooth the salt graph / salt-low alert.
+		const PPM smoothed_salt = MedianFilteredSalt(msg.SaltConcentrationPPM());
+		m_DataHub->SaltLevel(static_cast<double>(smoothed_salt) * Units::ppm);
 
 		EnsureChlorinatorDeviceExists();
 
@@ -234,9 +331,17 @@ namespace AqualinkAutomate::Devices
 		}
 
 		auto& device = chlorinators.front();
-		device->AuxillaryTraits.Set(ChlorinatorHealthTrait{}, ConvertToChlorinatorHealthStatus(msg.Status()));
 
-		// Update operating status from AquaRite wire status.
+		// Apply the asymmetric dwell and only write the health trait on a real
+		// (dwelled) transition, so the indicator stops flapping between OK and a
+		// momentary warning when the cell sits on its low-salt boundary.
+		if (auto displayed = DwellChlorinatorHealth(ConvertToChlorinatorHealthStatus(msg.Status())); displayed.has_value())
+		{
+			device->AuxillaryTraits.Set(ChlorinatorHealthTrait{}, displayed.value());
+		}
+
+		// Operating status (On/Off) follows the raw wire status directly: it is a
+		// distinct, stable signal that does not exhibit the boundary flapping.
 		auto operating_status = (msg.Status() == Messages::AquariteStatuses::Off || msg.Status() == Messages::AquariteStatuses::TurningOff)
 			? Kernel::ChlorinatorStatuses::Off
 			: Kernel::ChlorinatorStatuses::On;

--- a/src/jandy/devices/aquarite_device.h
+++ b/src/jandy/devices/aquarite_device.h
@@ -1,14 +1,18 @@
 #pragma once
 
+#include <array>
 #include <chrono>
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #include "devices/jandy_device.h"
 #include "devices/jandy_device_types.h"
 #include "devices/capabilities/restartable.h"
+#include "kernel/auxillary_devices/chlorinator_status.h"
 #include "kernel/data_hub.h"
 #include "kernel/hub_locator.h"
 #include "messages/aquarite/aquarite_message_getid.h"
@@ -79,6 +83,28 @@ namespace AqualinkAutomate::Devices
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };
 
 	private:
+		// --- Output smoothing (publish-to-DataHub path ONLY) -----------------
+		// A borderline AquaRite cell flaps both its salt reading and its low-salt
+		// status flag around the cell's own internal threshold.  Observed live
+		// (test/fixtures captures): ~87% of frames report "2900 ppm / Low Salt"
+		// interleaved with short "4000 ppm / OK" bursts up to ~9 frames long, at
+		// roughly 2-3 frames/sec.  The raw Reported* getters above stay
+		// unsmoothed; the following state smooths only what is published so the
+		// salt graph and the chlorinator-health indicator stop strobing.
+		inline static constexpr std::size_t SALT_MEDIAN_WINDOW{ 5 };
+		inline static constexpr uint32_t HEALTH_RAISE_FRAMES{ 2 };    // ~1 s: surface a warning/fault quickly
+		inline static constexpr uint32_t HEALTH_CLEAR_FRAMES{ 15 };   // ~6 s: clear slowly (sticky)
+
+		std::array<PPM, SALT_MEDIAN_WINDOW> m_SaltWindow{};
+		std::size_t m_SaltWindowCount{ 0 };
+		std::size_t m_SaltWindowNext{ 0 };
+
+		Kernel::ChlorinatorHealth m_DisplayedHealth{ Kernel::ChlorinatorHealth::Ok };
+		Kernel::ChlorinatorHealth m_HealthCandidate{ Kernel::ChlorinatorHealth::Ok };
+		uint32_t m_HealthCandidateCount{ 0 };
+		bool m_HealthInitialised{ false };
+
+	private:
 		void Slot_Aquarite_GetId(const Messages::AquariteMessage_GetId& msg);
 		void Slot_Aquarite_Percent(const Messages::AquariteMessage_Percent& msg);
 		void Slot_Aquarite_PPM(const Messages::AquariteMessage_PPM& msg);
@@ -87,6 +113,17 @@ namespace AqualinkAutomate::Devices
 		void EnsureChlorinatorDeviceExists();
 		void PushPercentToDataHub(const Messages::AquariteMessage_Percent& msg);
 		void PushPPMToDataHub(const Messages::AquariteMessage_PPM& msg);
+
+		// Returns the median of the last SALT_MEDIAN_WINDOW raw salt samples,
+		// rejecting the cell's transient single-frame ppm spikes.
+		PPM MedianFilteredSalt(PPM raw_sample);
+
+		// Asymmetric dwell over the reported health: surface a new warning/fault
+		// quickly (HEALTH_RAISE_FRAMES) but clear back to a benign state only
+		// after it persists (HEALTH_CLEAR_FRAMES), so a momentary "OK" blip
+		// cannot wipe a genuine Low-Salt warning.  Returns the health to publish
+		// when the displayed state changes, std::nullopt when it should be held.
+		std::optional<Kernel::ChlorinatorHealth> DwellChlorinatorHealth(Kernel::ChlorinatorHealth raw_health);
 	};
 
 }

--- a/test/unit/alerting/test_alert_monitor.cpp
+++ b/test/unit/alerting/test_alert_monitor.cpp
@@ -143,6 +143,64 @@ BOOST_AUTO_TEST_CASE(ChlorinatorFault_RaisesOnGeneralFault_ClearsOnOk)
 	BOOST_CHECK_EQUAL(rec.CountFor(ConditionKeys::ChlorinatorFault), 2u);
 }
 
+// chlorinator_warning raises on ANY cell warning (not just low salt), names the
+// specific warning in the detail, and clears on recovery — without tripping the
+// hard-fault condition.
+BOOST_AUTO_TEST_CASE(ChlorinatorWarning_RaisesOnWarning_NamesIt_ClearsOnOk)
+{
+	boost::asio::io_context io;
+	Options::Alerting::AlertingSettings settings;
+
+	AlertMonitor monitor(io, *this, settings);
+	SinkRecorder rec;
+	monitor.AddSink(rec.AsSink());
+
+	auto data_hub = Find<Kernel::DataHub>();
+	auto chlor = MakeChlorinator(Kernel::ChlorinatorHealth::Ok);
+	data_hub->Devices.Add(chlor);
+
+	monitor.EvaluateChlorinatorWarning();
+	BOOST_CHECK(!monitor.IsRaised(ConditionKeys::ChlorinatorWarning));
+
+	// A No-Flow warning (NOT low salt) must still be surfaced and named.
+	chlor->AuxillaryTraits.Set(Kernel::AuxillaryTraitsTypes::ChlorinatorHealthTrait{}, Kernel::ChlorinatorHealth::Warning_NoFlow);
+	monitor.EvaluateChlorinatorWarning();
+	monitor.EvaluateChlorinatorFault();
+	BOOST_CHECK(monitor.IsRaised(ConditionKeys::ChlorinatorWarning));
+	BOOST_CHECK(!monitor.IsRaised(ConditionKeys::ChlorinatorFault));   // a warning is not a fault
+	BOOST_REQUIRE_EQUAL(rec.CountFor(ConditionKeys::ChlorinatorWarning), 1u);
+	BOOST_CHECK(rec.transitions.back().detail.find("No flow") != std::string::npos);
+
+	// Recovery clears it.
+	chlor->AuxillaryTraits.Set(Kernel::AuxillaryTraitsTypes::ChlorinatorHealthTrait{}, Kernel::ChlorinatorHealth::Ok);
+	monitor.EvaluateChlorinatorWarning();
+	BOOST_CHECK(!monitor.IsRaised(ConditionKeys::ChlorinatorWarning));
+	BOOST_CHECK_EQUAL(rec.CountFor(ConditionKeys::ChlorinatorWarning), 2u);
+}
+
+// A hard fault raises chlorinator_fault but NOT chlorinator_warning, so the two
+// severities stay distinct; the fault detail names the specific fault.
+BOOST_AUTO_TEST_CASE(ChlorinatorWarning_NotRaisedByHardFault)
+{
+	boost::asio::io_context io;
+	Options::Alerting::AlertingSettings settings;
+
+	AlertMonitor monitor(io, *this, settings);
+	SinkRecorder rec;
+	monitor.AddSink(rec.AsSink());
+
+	auto data_hub = Find<Kernel::DataHub>();
+	auto chlor = MakeChlorinator(Kernel::ChlorinatorHealth::Error_CheckPCB);
+	data_hub->Devices.Add(chlor);
+
+	monitor.EvaluateChlorinatorWarning();
+	monitor.EvaluateChlorinatorFault();
+
+	BOOST_CHECK(!monitor.IsRaised(ConditionKeys::ChlorinatorWarning));
+	BOOST_CHECK(monitor.IsRaised(ConditionKeys::ChlorinatorFault));
+	BOOST_CHECK(rec.transitions.back().detail.find("Check PCB") != std::string::npos);
+}
+
 // service_mode tracks the DataHub equipment mode.
 BOOST_AUTO_TEST_CASE(ServiceMode_TracksEquipmentMode)
 {
@@ -221,6 +279,7 @@ BOOST_AUTO_TEST_CASE(BuildStateJson_ReflectsLatchedState)
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::ServiceMode }], "true");
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::SaltLow }], "false");
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::ChlorinatorFault }], "false");
+	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::ChlorinatorWarning }], "false");
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::SerialCommsLoss }], "false");
 }
 

--- a/test/unit/devices/test_devices_aquarite.cpp
+++ b/test/unit/devices/test_devices_aquarite.cpp
@@ -10,6 +10,7 @@
 #include "jandy/messages/jandy_message_ids.h"
 
 #include "kernel/auxillary_devices/chlorinator_boost_mode.h"
+#include "kernel/auxillary_devices/chlorinator_status.h"
 #include "kernel/auxillary_traits/auxillary_traits_types.h"
 
 #include "support/unit_test_hublocatorinjector.h"
@@ -292,6 +293,131 @@ BOOST_AUTO_TEST_CASE(PercentServiceSentinel_ClampsDutyCycleToZero)
 	auto generating = chlorinators.front()->AuxillaryTraits.TryGet(GeneratingPercentageTrait{});
 	BOOST_REQUIRE(generating.has_value());
 	BOOST_CHECK_EQUAL(generating.value(), static_cast<uint8_t>(0));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// AQUARITE_PPM output-smoothing regression tests (sticky low-salt).
+//
+// A borderline AquaRite cell flaps its salt reading AND its low-salt status
+// flag around the cell's own internal threshold.  Captured live, the wire
+// alternated between "2900 ppm / Warning_LowSalt" (the dominant, true state)
+// and short "4000 ppm / On(Ok)" bursts up to ~9 frames long, which the app used
+// to surface raw — strobing the salt graph and the chlorinator-health
+// indicator.  AquariteDevice now smooths the publish path: a median over the
+// last few salt samples, plus an asymmetric dwell on health (raise a warning
+// fast, clear it only after it persists).  These tests drive synthetic PPM
+// frames matching the capture through the full Jandy decode stack and assert
+// the published DataHub state no longer flaps.
+//=============================================================================
+
+namespace
+{
+	constexpr uint8_t AQUARITE_PPM_DEST = 0x00;   // AQUARITE_PPM is sent SWG -> Master (0x00).
+	const uint8_t CMD_AQUARITE_PPM = static_cast<uint8_t>(AqualinkAutomate::Messages::JandyMessageIds::AQUARITE_PPM);
+
+	constexpr uint8_t SALT_BYTE_LOW = 0x1d;   // 0x1d * 100 = 2900 ppm (the borderline-low reading).
+	constexpr uint8_t SALT_BYTE_OK  = 0x28;   // 0x28 * 100 = 4000 ppm (the transient spike reading).
+	constexpr uint8_t STATUS_LOWSALT = 0x02;  // AquariteStatuses::Warning_LowSalt
+	constexpr uint8_t STATUS_ON      = 0x00;  // AquariteStatuses::On
+
+	std::vector<uint8_t> MakePpmFrame(uint8_t salt_byte, uint8_t status_byte)
+	{
+		return Test::MessageBuilder::CreateValidChecksummedMessage(AQUARITE_PPM_DEST, CMD_AQUARITE_PPM, { salt_byte, status_byte });
+	}
+
+	void AppendFrames(std::vector<std::vector<uint8_t>>& out, std::size_t count, uint8_t salt_byte, uint8_t status_byte)
+	{
+		for (std::size_t i = 0; i < count; ++i)
+		{
+			out.push_back(MakePpmFrame(salt_byte, status_byte));
+		}
+	}
+
+	Kernel::ChlorinatorHealth HealthOf(const Test::MockReplayHarness& harness)
+	{
+		auto chlorinators = harness.DataHub()->Chlorinators();
+		BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+		auto health = chlorinators.front()->AuxillaryTraits.TryGet(AuxillaryTraitsTypes::ChlorinatorHealthTrait{});
+		BOOST_REQUIRE(health.has_value());
+		return health.value();
+	}
+}
+
+BOOST_AUTO_TEST_SUITE(AquariteDevice_PpmSmoothing_TestSuite)
+
+BOOST_AUTO_TEST_CASE(IsolatedSaltSpike_IsMedianFiltered_HealthHeldLowSalt)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 4x low-salt, a single OK spike, then 4x low-salt — exactly the kind of
+	// one-frame blip the cell emits on its boundary.
+	std::vector<std::vector<uint8_t>> frames;
+	AppendFrames(frames, 4, SALT_BYTE_LOW, STATUS_LOWSALT);
+	AppendFrames(frames, 1, SALT_BYTE_OK,  STATUS_ON);
+	AppendFrames(frames, 4, SALT_BYTE_LOW, STATUS_LOWSALT);
+	harness.Replay(frames);
+
+	// The single 4000 spike is outvoted in the median window -> salt reads 2900.
+	BOOST_CHECK_CLOSE(harness.DataHub()->SaltLevel().value(), 2900.0, 0.0001);
+
+	// A one-frame OK cannot clear the (sticky) Low-Salt warning.
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_LowSalt);
+}
+
+BOOST_AUTO_TEST_CASE(ShortOkBurst_DoesNotClearLowSalt)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// A 10-frame OK burst is below the clear threshold (15) -> warning must hold.
+	std::vector<std::vector<uint8_t>> frames;
+	AppendFrames(frames, 5,  SALT_BYTE_LOW, STATUS_LOWSALT);
+	AppendFrames(frames, 10, SALT_BYTE_OK,  STATUS_ON);
+	AppendFrames(frames, 5,  SALT_BYTE_LOW, STATUS_LOWSALT);
+	harness.Replay(frames);
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_LowSalt);
+}
+
+BOOST_AUTO_TEST_CASE(SustainedRecovery_ClearsLowSaltAndSaltTracks)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// A genuinely sustained recovery (20 OK frames > 15) DOES clear the warning,
+	// and the salt median tracks up to the new sustained value.
+	std::vector<std::vector<uint8_t>> frames;
+	AppendFrames(frames, 5,  SALT_BYTE_LOW, STATUS_LOWSALT);
+	AppendFrames(frames, 20, SALT_BYTE_OK,  STATUS_ON);
+	harness.Replay(frames);
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Ok);
+	BOOST_CHECK_CLOSE(harness.DataHub()->SaltLevel().value(), 4000.0, 0.0001);
+}
+
+BOOST_AUTO_TEST_CASE(WarningRaisesQuickly)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// Starting from OK, a warning is surfaced after only a couple of frames.
+	std::vector<std::vector<uint8_t>> frames;
+	AppendFrames(frames, 3, SALT_BYTE_OK,  STATUS_ON);
+	AppendFrames(frames, 2, SALT_BYTE_LOW, STATUS_LOWSALT);
+	harness.Replay(frames);
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_LowSalt);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/http/test_http_chlorinator.cpp
+++ b/test/unit/http/test_http_chlorinator.cpp
@@ -69,7 +69,7 @@ namespace
 			req.body() = body;
 			req.prepare_payload();
 
-			auto msg = route.OnRequest(req);
+			HTTP::Message msg = route.OnRequest(req);
 
 			boost::asio::io_context ioc;
 			auto exec = ioc.get_executor();

--- a/test/unit/http/test_http_diagnostics_recording.cpp
+++ b/test/unit/http/test_http_diagnostics_recording.cpp
@@ -78,7 +78,7 @@ namespace
 	// the GET-only shared helper does not support.
 	HTTP::Response InvokeRoute(HTTP::WebRoute_Diagnostics_Recording& route, HTTP::Request& req)
 	{
-		auto msg = route.OnRequest(req);
+		HTTP::Message msg = route.OnRequest(req);
 
 		boost::asio::io_context ioc;
 		auto exec = ioc.get_executor();

--- a/test/unit/http/test_http_security.cpp
+++ b/test/unit/http/test_http_security.cpp
@@ -38,7 +38,7 @@ namespace
 	class TestOkRoute : public Interfaces::IWebRoute<OK_ROUTE_URL>
 	{
 	public:
-		HTTP::Message OnRequest(const HTTP::Request& req) override
+		HTTP::Response OnRequest(const HTTP::Request& req) override
 		{
 			HTTP::Response res{ boost::beast::http::status::ok, req.version() };
 			res.keep_alive(req.keep_alive());

--- a/test/unit/http/test_http_setpoints.cpp
+++ b/test/unit/http/test_http_setpoints.cpp
@@ -77,7 +77,7 @@ namespace
 			req.body() = body;
 			req.prepare_payload();
 
-			auto msg = route.OnRequest(req);
+			HTTP::Message msg = route.OnRequest(req);
 
 			boost::asio::io_context ioc;
 			auto exec = ioc.get_executor();

--- a/test/unit/support/unit_test_ostream_support.cpp
+++ b/test/unit/support/unit_test_ostream_support.cpp
@@ -56,6 +56,12 @@ namespace AqualinkAutomate::Kernel
         return os;
     }
 
+    std::ostream& boost_test_print_type(std::ostream& os, ChlorinatorHealth const& right)
+    {
+        os << magic_enum::enum_name(right);
+        return os;
+    }
+
     std::ostream& boost_test_print_type(std::ostream& os, HeaterStatuses const& right)
     {
         os << magic_enum::enum_name(right);

--- a/test/unit/support/unit_test_ostream_support.h
+++ b/test/unit/support/unit_test_ostream_support.h
@@ -56,6 +56,7 @@ namespace AqualinkAutomate::Kernel
 {
     std::ostream& boost_test_print_type(std::ostream& os, AuxillaryStatuses const& right);
     std::ostream& boost_test_print_type(std::ostream& os, ChlorinatorStatuses const& right);
+    std::ostream& boost_test_print_type(std::ostream& os, ChlorinatorHealth const& right);
     std::ostream& boost_test_print_type(std::ostream& os, HeaterStatuses const& right);
     std::ostream& boost_test_print_type(std::ostream& os, PumpStatuses const& right);
     std::ostream& boost_test_print_type(std::ostream& os, PoolConfigurations const& right);


### PR DESCRIPTION
Promotes develop to main for the v0.2.0-beta.3 pre-release. (v0.2.0-beta.2 was tagged but never published — its Windows package job stalled on a saturated runner; beta.3 supersedes it.)

Changes since v0.2.0-beta.1:
- fix(chlorinator): smooth AquaRite salt / cell-health flapping and surface cell warnings.
- fix(webui): network-first service worker serves fresh assets; no-store on dynamic API responses + build-stamped SW cache (no stale UI after an update).
- fix(cicd): Docker base-image pulls resilient to Docker Hub rate limits / CDN timeouts.
- refactor(webui): Schedules form uses its own .sched-input class.
- fix(cicd): runner template thin provisioning + unique machine-id/hostname.

The release pipeline rebuilds, tests and smoke-tests all 3 platforms before publishing.