### PR TITLE
Release v0.2.0-beta.2

### DIFF
--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -35,7 +35,7 @@ jobs:
         language: [ 'c-cpp' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -49,7 +49,7 @@ jobs:
         compiler: gcc-15
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
@@ -88,7 +88,7 @@ jobs:
         VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         upload: false
 
@@ -102,12 +102,12 @@ jobs:
         output: '../results/cpp.sarif'
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         category: "/language:${{ matrix.language }}"
 
     - name: Upload Analysis as a Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: sarif-results
         path: sarif-results
@@ -123,7 +123,7 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         submodules: recursive
@@ -138,7 +138,7 @@ jobs:
         compiler: gcc-15
 
     - name: Install build-wrapper
-      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
+      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v8
 
     - name: Setup vcpkg cache (self-hosted)
       if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
@@ -172,7 +172,7 @@ jobs:
         build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build --preset=build-linux-gcc-coverage
 
     - name: Run SonarCloud scan
-      uses: SonarSource/sonarqube-scan-action@v6
+      uses: SonarSource/sonarqube-scan-action@v8
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -193,7 +193,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
 
@@ -265,12 +265,12 @@ jobs:
         ignoredPaths: ${{ github.workspace }}/deps;${{ github.workspace }}/src/version;${{ github.workspace }}/test
 
     - name: Upload SARIF to GitHub
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ steps.run-analysis.outputs.sarif }}
 
     - name: Upload SARIF as an Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: sarif-file
         path: ${{ steps.run-analysis.outputs.sarif }}

--- a/test/integration/flows/test_flow_fixture_replay.cpp
+++ b/test/integration/flows/test_flow_fixture_replay.cpp
@@ -86,6 +86,13 @@ BOOST_AUTO_TEST_CASE(Replay_SampleSession_PopulatesChlorinatorInDataHub)
 // The richer fixture (chlorinator_transitions.cap) changes the generating
 // level and salt twice; the decoded state must reflect the LAST frame of each
 // kind (40% -> 60%, 3200 -> 3000 PPM), proving every frame is applied in order.
+//
+// NOTE: the hub-level SaltLevel is median-of-5 smoothed on the publish path
+// (AquariteDevice::MedianFilteredSalt) so a borderline cell does not sawtooth the
+// graph -- it is therefore NOT simply the last raw frame. With this fixture's two
+// salt readings [3200, 3000] the median (upper-middle for an even count) is 3200.
+// The raw, un-smoothed value still tracks the LAST frame (3000) and is asserted
+// via the device's ReportedSaltConcentration API below.
 //-----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(Replay_TransitionsSession_DecodesFinalStateAfterMultipleUpdates)
 {
@@ -107,9 +114,12 @@ BOOST_AUTO_TEST_CASE(Replay_TransitionsSession_DecodesFinalStateAfterMultipleUpd
 	BOOST_REQUIRE(percentage_trait.has_value());
 	BOOST_CHECK_EQUAL(percentage_trait.value(), static_cast<uint8_t>(60));
 
-	// Final salt level is the SECOND PPM frame's value (3000 PPM).
-	BOOST_CHECK_EQUAL(harness.DataHub()->SaltLevel().value(), 3000.0);
+	// Hub SaltLevel is median-smoothed: the median of the two readings [3200, 3000]
+	// is the upper-middle element, 3200 PPM (see AquariteDevice::MedianFilteredSalt).
+	BOOST_CHECK_EQUAL(harness.DataHub()->SaltLevel().value(), 3200.0);
 
+	// The raw device API is NOT smoothed, so it still reflects the LAST frame
+	// (3000 PPM) -- this is what proves every frame was applied in order.
 	BOOST_CHECK_EQUAL(device.ReportedSaltConcentration().value, static_cast<uint16_t>(3000));
 }
 


### PR DESCRIPTION
Promotes develop to main for the v0.2.0-beta.2 pre-release.

Changes since v0.1.0-beta.1:
- fix(chlorinator): smooth AquaRite salt / cell-health flapping and surface cell warnings.
- fix(webui): network-first service worker serves fresh assets; no-store on dynamic API responses + build-stamped SW cache.
- fix(cicd): Docker base-image pulls resilient to Docker Hub rate limits / CDN timeouts (authenticated pulls + retry).
- refactor(webui): Schedules form uses its own .sched-input class.
- fix(cicd): runner template thin provisioning + unique machine-id/hostname.
- ci(codescanning): actions moved off the deprecated Node 20 runtime.
- test(integration): align fixture-replay with median-smoothed salt (fixes the integration-target regression).

develop CI is green on this tree (all platforms + e2e + docker-verify); Docker Hub auth secrets are configured so docker-publish authenticates and retries.