### PR TITLE
ci: CI/CD redesign — plan + phases 0-2 + Node-20 action sweep

### DIFF
--- a/.github/actions/setup-vcpkg-cache/action.yml
+++ b/.github/actions/setup-vcpkg-cache/action.yml
@@ -29,7 +29,7 @@ runs:
         echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
 
     - name: Cache vcpkg downloads
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/vcpkg/downloads
         key: vcpkg-downloads-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json') }}
@@ -43,7 +43,7 @@ runs:
     # shared cache. vcpkg names archives by ABI hash, so multiple triplets would
     # coexist safely in a single cache dir even if a job introduced one.
     - name: Cache vcpkg binaries
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/vcpkg/archives
         key: vcpkg-${{ runner.os }}-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg/triplets/**', 'cmake/vcpkg/overlays/**') }}

--- a/.github/actions/setup-vcpkg-cache/action.yml
+++ b/.github/actions/setup-vcpkg-cache/action.yml
@@ -3,8 +3,13 @@ description: Configure vcpkg binary and download caching with proper cache keys
 
 inputs:
   cache-key-prefix:
-    description: Platform/compiler identifier for cache key (e.g. "Linux GCC")
-    required: true
+    # Retained for backward compatibility with existing callers only. The vcpkg
+    # BINARY cache is now keyed by runner OS, NOT by this per-job prefix, so jobs
+    # that share a triplet (build-and-test + CodeQL + SonarCloud all use the same
+    # x64-linux-gcc triplet) share one cache instead of four disjoint copies.
+    description: "Deprecated/ignored: the binary cache is keyed by runner OS."
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -32,14 +37,19 @@ runs:
           vcpkg-downloads-${{ steps.vcpkg-version.outputs.hash }}-
           vcpkg-downloads-
 
+    # Keyed by runner OS (which maps 1:1 to the vcpkg triplet in use here), NOT by
+    # the per-job prefix. This collapses the previously disjoint "Linux GCC" /
+    # "CodeQL" / "SonarCloud" / "MSVCAnalysis" caches (all x64-linux-gcc) into one
+    # shared cache. vcpkg names archives by ABI hash, so multiple triplets would
+    # coexist safely in a single cache dir even if a job introduced one.
     - name: Cache vcpkg binaries
       uses: actions/cache@v4
       with:
         path: ~/.cache/vcpkg/archives
-        key: vcpkg-${{ inputs.cache-key-prefix }}-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg/triplets/**', 'cmake/vcpkg/overlays/**') }}
+        key: vcpkg-${{ runner.os }}-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg/triplets/**', 'cmake/vcpkg/overlays/**') }}
         restore-keys: |
-          vcpkg-${{ inputs.cache-key-prefix }}-${{ steps.vcpkg-version.outputs.hash }}-
-          vcpkg-${{ inputs.cache-key-prefix }}-
+          vcpkg-${{ runner.os }}-${{ steps.vcpkg-version.outputs.hash }}-
+          vcpkg-${{ runner.os }}-
 
     - name: Run vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,214 @@
+# Reusable build/test(/package) workflow — the single definition of how the C++
+# project is configured, built, tested and (optionally) packaged on each platform.
+# Called by ci.yml (build-and-test) and release.yml (build-packages) so the two
+# can never drift. Behaviour is identical to the two matrix jobs it replaces; the
+# only parameters are whether to also package (release) and the checkout depth.
+name: Reusable Build
+
+on:
+  workflow_call:
+    inputs:
+      do_package:
+        description: "Also run cpack + the install/extract smoke test + upload packages (release path)."
+        type: boolean
+        default: false
+      version_tag:
+        description: "Resolved v* tag. Used only to create a local tag for workflow_dispatch release builds so `git describe` stamps the right version."
+        type: string
+        default: ""
+      fetch_depth:
+        description: "checkout fetch-depth (0 for releases so `git describe`/cut-from-main see full history + tags; 1 for CI)."
+        type: number
+        default: 1
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ fromJSON(matrix.runner) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Linux GCC"
+            runner: ${{ vars.RUNNER_LINUX || '["ubuntu-latest"]' }}
+            compiler: gcc-15
+            configure_preset: config-linux-gcc
+            build_preset: build-linux-gcc
+            test_preset: test-linux-gcc
+            package_preset: pack-linux-gcc
+          - name: "Windows MSVC"
+            runner: ${{ vars.RUNNER_WINDOWS || '["windows-latest"]' }}
+            compiler: msvc
+            configure_preset: config-windows-msvc
+            build_preset: build-windows-msvc
+            test_preset: test-windows-msvc
+            package_preset: pack-windows-msvc
+          - name: "macOS Clang"
+            runner: '["macos-latest"]'
+            compiler: llvm
+            configure_preset: config-macos-llvm
+            build_preset: build-macos-llvm
+            test_preset: test-macos-llvm
+            package_preset: pack-macos-llvm
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: ${{ inputs.fetch_depth }}
+
+      # Release dispatch builds derive the version from `git describe`; create the
+      # not-yet-pushed tag locally so it resolves (tag-push releases already have it,
+      # CI doesn't package). github-release pushes the real tag at the very end.
+      - name: Create local tag for dispatch builds
+        if: inputs.do_package && github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: git tag "${{ inputs.version_tag }}" HEAD
+
+      - name: Clean workspace (self-hosted)
+        if: contains(matrix.runner, 'self-hosted')
+        shell: bash
+        run: rm -rf build/
+
+      - uses: ./.github/actions/setup-cpp-toolchain
+        if: ${{ !contains(matrix.runner, 'self-hosted') }}
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      # Self-hosted Windows images bake in the VS Build Tools but do not expose the
+      # MSVC environment (cl.exe, INCLUDE/LIB) on the default PATH; load it so the
+      # Configure step can find the compiler.
+      - name: Setup MSVC environment (self-hosted)
+        if: contains(matrix.runner, 'self-hosted') && runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install NSIS (Windows packaging)
+        if: inputs.do_package && runner.os == 'Windows' && !contains(matrix.runner, 'self-hosted')
+        run: choco install nsis -y
+
+      - name: Setup vcpkg cache (self-hosted)
+        if: contains(matrix.runner, 'self-hosted')
+        shell: bash
+        run: |
+          BINARY_DIR="$HOME/.cache/vcpkg/archives"
+          DOWNLOADS_DIR="$HOME/.cache/vcpkg/downloads"
+          mkdir -p "$BINARY_DIR" "$DOWNLOADS_DIR"
+          # Convert Git bash paths to native Windows paths for CMake/vcpkg
+          # (vcpkg rejects an MSYS-style VCPKG_DEFAULT_BINARY_CACHE like /c/...).
+          if command -v cygpath >/dev/null 2>&1; then
+            BINARY_DIR=$(cygpath -w "$BINARY_DIR")
+            DOWNLOADS_DIR=$(cygpath -w "$DOWNLOADS_DIR")
+          fi
+          echo "VCPKG_DEFAULT_BINARY_CACHE=$BINARY_DIR" >> "$GITHUB_ENV"
+          echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
+
+      - uses: ./.github/actions/setup-vcpkg-cache
+        if: ${{ !contains(matrix.runner, 'self-hosted') }}
+        with:
+          cache-key-prefix: ${{ matrix.name }}
+
+      - name: Bootstrap vcpkg
+        shell: bash
+        run: |
+          if [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" ]; then
+            bash "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+          elif [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.bat" ]; then
+            "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
+          fi
+        env:
+          VCPKG_BINARY_SOURCES: "clear;default,readwrite"
+
+      # VCPKG_ROOT points lukka/run-cmake (and the in-tree vcpkg toolchain) at the
+      # project's deps/vcpkg. On self-hosted Windows, vcvarsall (msvc-dev-cmd) leaks
+      # VCPKG_ROOT -> the VS-bundled, manifest-less vcpkg; this step-level env value
+      # overrides that leak, so no special "pin" step is needed (same as Linux/macOS).
+      - name: Configure
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: ${{ matrix.configure_preset }}
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
+
+      - name: Build
+        uses: lukka/run-cmake@v10
+        with:
+          buildPreset: ${{ matrix.build_preset }}
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
+
+      - name: Show build errors on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "::group::CMake build retry (verbose)"
+          cmake --build --preset ${{ matrix.build_preset }} -- -k 1 2>&1 | tail -200 || true
+          echo "::endgroup::"
+
+      - name: Test
+        uses: lukka/run-cmake@v10
+        with:
+          testPreset: ${{ matrix.test_preset }}
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
+
+      # ---------------------------------------------------------------------------
+      # Packaging (release path only — inputs.do_package)
+      # ---------------------------------------------------------------------------
+      - name: Package
+        if: inputs.do_package
+        run: cpack --preset=${{ matrix.package_preset }}
+
+      # Install/extract the freshly built package on a clean target and run the
+      # binary. This catches missing runtime dependencies (the exact failure mode of
+      # an unbundled dynamic build) BEFORE the package is published.
+      - name: Smoke test — install package & run (Linux)
+        if: inputs.do_package && runner.os == 'Linux'
+        run: |
+          docker run --rm -v "$PWD/packages:/pkg:ro" ubuntu:25.04 bash -c '
+            set -e
+            apt-get update -qq
+            apt-get install -y -qq /pkg/*.deb
+            aqualink-automate --version'
+
+      - name: Smoke test — extract ZIP & run (Windows)
+        if: inputs.do_package && runner.os == 'Windows'
+        # Windows PowerShell (always present on self-hosted + GitHub-hosted), NOT
+        # pwsh/PowerShell 7 which the self-hosted runner image does not ship.
+        shell: powershell
+        run: |
+          $zip = Get-ChildItem packages/*.zip | Select-Object -First 1
+          if (-not $zip) { throw "No ZIP package was produced" }
+          Expand-Archive -Path $zip.FullName -DestinationPath smoke -Force
+          $exe = Get-ChildItem -Path smoke -Recurse -Filter aqualink-automate.exe | Select-Object -First 1
+          if (-not $exe) { throw "aqualink-automate.exe not found in the package" }
+          & $exe.FullName --version
+          if ($LASTEXITCODE -ne 0) { throw "Binary exited with code $LASTEXITCODE" }
+
+      - name: Smoke test — extract TGZ & run (macOS)
+        if: inputs.do_package && runner.os == 'macOS'
+        run: |
+          set -e
+          mkdir -p smoke
+          tar xzf packages/*.tar.gz -C smoke
+          BIN="$(find smoke -name aqualink-automate -type f -perm +111 | head -1)"
+          if [ -z "$BIN" ]; then echo "::error::binary not found in package"; exit 1; fi
+          "$BIN" --version
+
+      - name: Upload packages
+        if: inputs.do_package
+        uses: actions/upload-artifact@v6
+        with:
+          name: packages-${{ matrix.configure_preset }}
+          if-no-files-found: error
+          path: |
+            packages/*.deb
+            packages/*.rpm
+            packages/*.tar.gz
+            packages/*.zip
+            packages/*.exe
+            packages/*.dmg
+            packages/*.sha512
+          retention-days: 30

--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -1,12 +1,22 @@
 name: Automated Code Scanning
 
 on:
-  push:
-    branches: [ "main", "feature/**", "bug/**" ]
+  # Code scanning is SLOW (full per-platform builds), so only scan code where it
+  # is genuinely NEW:
+  #   * pull_request into develop -> feature work entering the integration branch
+  #   * pull_request into main    -> code arriving on the release branch, EXCEPT a
+  #       develop->main promotion (skipped per-job below: that code was already
+  #       scanned when it entered develop, so re-scanning the promotion is pure
+  #       duplication and was the long redundant run we removed)
+  #   * schedule -> weekly baseline of the default branch (Security tab)
+  #   * workflow_dispatch -> on demand
+  # The former `push: [main, feature/**, bug/**]` triggers re-scanned the
+  # post-merge main commit and every WIP feature push, all already covered above.
   pull_request:
     branches: [ "develop", "main" ]
   schedule:
     - cron: '42 21 * * 2'
+  workflow_dispatch:
 
 concurrency:
   group: code-scanning-${{ github.event.pull_request.number || github.ref }}
@@ -23,6 +33,12 @@ jobs:
   ##
 
   CodeScanning_CodeQL:
+    # Skip a develop->main promotion PR (already scanned on develop entry); run for
+    # everything else (PR into develop, non-develop PR into main, schedule, dispatch).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.head_ref != 'develop' ||
+      github.base_ref != 'main'
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
     timeout-minutes: 360
     permissions:
@@ -118,6 +134,11 @@ jobs:
   ##
 
   CodeScanning_SonarCloud:
+    # Skip a develop->main promotion PR (already scanned on develop entry).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.head_ref != 'develop' ||
+      github.base_ref != 'main'
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
@@ -187,6 +208,11 @@ jobs:
   ##
 
   CodeScanning_MSVCCodeAnalysis:
+    # Skip a develop->main promotion PR (already scanned on develop entry).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.head_ref != 'develop' ||
+      github.base_ref != 'main'
     runs-on: ${{ fromJSON(vars.RUNNER_WINDOWS || '["windows-latest"]') }}
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,123 +14,19 @@ permissions:
   contents: read
 
 jobs:
-  # Runner selection: set RUNNER_LINUX / RUNNER_WINDOWS repository variables
-  # to use self-hosted runners (e.g. '["self-hosted","linux","x64"]').
-  # Leave unset to fall back to GitHub-hosted runners.
+  # The configure/build/test matrix lives in the reusable _build.yml so CI and the
+  # release pipeline share one definition and can never drift. Runner selection
+  # (vars.RUNNER_LINUX / RUNNER_WINDOWS) is handled inside that workflow.
   build-and-test:
-    name: ${{ matrix.name }}
-    runs-on: ${{ fromJSON(matrix.runner) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "Linux GCC"
-            runner: ${{ vars.RUNNER_LINUX || '["ubuntu-latest"]' }}
-            compiler: gcc-15
-            configure_preset: config-linux-gcc
-            build_preset: build-linux-gcc
-            test_preset: test-linux-gcc
-          - name: "Windows MSVC"
-            runner: ${{ vars.RUNNER_WINDOWS || '["windows-latest"]' }}
-            compiler: msvc
-            configure_preset: config-windows-msvc
-            build_preset: build-windows-msvc
-            test_preset: test-windows-msvc
-          - name: "macOS Clang"
-            runner: '["macos-latest"]'
-            compiler: llvm
-            configure_preset: config-macos-llvm
-            build_preset: build-macos-llvm
-            test_preset: test-macos-llvm
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Clean workspace (self-hosted)
-        if: contains(matrix.runner, 'self-hosted')
-        shell: bash
-        run: rm -rf build/
-
-      - uses: ./.github/actions/setup-cpp-toolchain
-        if: ${{ !contains(matrix.runner, 'self-hosted') }}
-        with:
-          compiler: ${{ matrix.compiler }}
-
-      - name: Setup MSVC environment (self-hosted)
-        if: contains(matrix.runner, 'self-hosted') && runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Setup vcpkg cache (self-hosted)
-        if: contains(matrix.runner, 'self-hosted')
-        shell: bash
-        run: |
-          BINARY_DIR="$HOME/.cache/vcpkg/archives"
-          DOWNLOADS_DIR="$HOME/.cache/vcpkg/downloads"
-          mkdir -p "$BINARY_DIR" "$DOWNLOADS_DIR"
-          # Convert Git bash paths to native Windows paths for CMake/vcpkg
-          if command -v cygpath >/dev/null 2>&1; then
-            BINARY_DIR=$(cygpath -w "$BINARY_DIR")
-            DOWNLOADS_DIR=$(cygpath -w "$DOWNLOADS_DIR")
-          fi
-          echo "VCPKG_DEFAULT_BINARY_CACHE=$BINARY_DIR" >> "$GITHUB_ENV"
-          echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
-
-      - uses: ./.github/actions/setup-vcpkg-cache
-        if: ${{ !contains(matrix.runner, 'self-hosted') }}
-        with:
-          cache-key-prefix: ${{ matrix.name }}
-
-      - name: Bootstrap vcpkg
-        shell: bash
-        run: |
-          if [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" ]; then
-            bash "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-          elif [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.bat" ]; then
-            "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
-          fi
-        env:
-          VCPKG_BINARY_SOURCES: "clear;default,readwrite"
-
-      # VCPKG_ROOT points lukka/run-cmake (and the in-tree vcpkg toolchain) at the
-      # project's deps/vcpkg. On self-hosted Windows, vcvarsall (msvc-dev-cmd) leaks
-      # VCPKG_ROOT -> the VS-bundled, manifest-less vcpkg; this step-level env value
-      # overrides that leak, so no special "pin" step is needed (same as Linux/macOS).
-      - name: Configure
-        uses: lukka/run-cmake@v10
-        with:
-          configurePreset: ${{ matrix.configure_preset }}
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
-
-      - name: Build
-        uses: lukka/run-cmake@v10
-        with:
-          buildPreset: ${{ matrix.build_preset }}
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
-
-      - name: Show build errors on failure
-        if: failure()
-        run: |
-          echo "::group::CMake build retry (verbose)"
-          cmake --build --preset ${{ matrix.build_preset }} -- -k 1 2>&1 | tail -200 || true
-          echo "::endgroup::"
-
-      - name: Test
-        uses: lukka/run-cmake@v10
-        with:
-          testPreset: ${{ matrix.test_preset }}
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
+    name: Build & Test
+    uses: ./.github/workflows/_build.yml
 
   e2e-ui:
     name: E2E UI (Playwright)
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -154,8 +50,8 @@ jobs:
           echo "VCPKG_DEFAULT_BINARY_CACHE=$BINARY_DIR" >> "$GITHUB_ENV"
           echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
 
-      # Shares the "Linux GCC" vcpkg cache populated by the build-and-test job, so
-      # this job only pays the application compile cost, not a vcpkg rebuild.
+      # Shares the vcpkg cache populated by the build-and-test job, so this job only
+      # pays the application compile cost, not a vcpkg rebuild.
       - uses: ./.github/actions/setup-vcpkg-cache
         if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}
         with:
@@ -183,7 +79,7 @@ jobs:
         shell: bash
         run: cmake --build --preset build-linux-gcc --target aqualink-automate
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -230,7 +126,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: playwright-report/
@@ -244,9 +140,9 @@ jobs:
         working-directory: matter-bridge
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm
@@ -270,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -301,11 +197,11 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       # Authenticate to Docker Hub when credentials are configured so base-image
       # pulls (ubuntu:25.04, node:22-bookworm-slim) use the higher authenticated
@@ -313,7 +209,7 @@ jobs:
       # receive no secrets) still build anonymously.
       - name: Login to Docker Hub
         if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -326,7 +222,7 @@ jobs:
       # its builder the default, so `docker buildx build` here is equivalent to the
       # docker/build-push-action invocations it replaces.
       - name: Build CI target
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           shell: bash
           timeout_minutes: 90
@@ -336,7 +232,7 @@ jobs:
           command: docker buildx build --target ci .
 
       - name: Build runtime target
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           shell: bash
           timeout_minutes: 90

--- a/.github/workflows/cleanup-branch-caches.yml
+++ b/.github/workflows/cleanup-branch-caches.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Clean Up Caches
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       # Needed for the "cut from main" guard below (merge-base ancestry check).
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -123,180 +123,17 @@ jobs:
             exit 1
           fi
 
+  # Build + test + package on every platform via the same reusable workflow CI
+  # uses, so the suites can never diverge between CI and release. do_package adds
+  # cpack + the per-OS install/extract smoke test + the package artifact upload.
   build-packages:
-    name: Package — ${{ matrix.name }}
+    name: Package
     needs: [resolve-version]
-    runs-on: ${{ fromJSON(matrix.runner) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "Linux GCC"
-            runner: ${{ vars.RUNNER_LINUX || '["ubuntu-latest"]' }}
-            compiler: gcc-15
-            configure_preset: config-linux-gcc
-            build_preset: build-linux-gcc
-            test_preset: test-linux-gcc
-            package_preset: pack-linux-gcc
-          - name: "Windows MSVC"
-            runner: ${{ vars.RUNNER_WINDOWS || '["windows-latest"]' }}
-            compiler: msvc
-            configure_preset: config-windows-msvc
-            build_preset: build-windows-msvc
-            test_preset: test-windows-msvc
-            package_preset: pack-windows-msvc
-          - name: "macOS Clang"
-            runner: '["macos-latest"]'
-            compiler: llvm
-            configure_preset: config-macos-llvm
-            build_preset: build-macos-llvm
-            test_preset: test-macos-llvm
-            package_preset: pack-macos-llvm
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Create local tag for dispatch builds
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: |
-          git tag "${{ needs.resolve-version.outputs.version_tag }}" HEAD
-
-      - name: Clean workspace (self-hosted)
-        if: contains(matrix.runner, 'self-hosted')
-        shell: bash
-        run: rm -rf build/
-
-      - uses: ./.github/actions/setup-cpp-toolchain
-        if: ${{ !contains(matrix.runner, 'self-hosted') }}
-        with:
-          compiler: ${{ matrix.compiler }}
-
-      # Self-hosted Windows images bake in the VS Build Tools but do not expose
-      # the MSVC environment (cl.exe, INCLUDE/LIB) on the default PATH; mirror
-      # the CI workflow and load it so the Configure step can find the compiler.
-      - name: Setup MSVC environment (self-hosted)
-        if: contains(matrix.runner, 'self-hosted') && runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Install NSIS
-        if: runner.os == 'Windows' && !contains(matrix.runner, 'self-hosted')
-        run: choco install nsis -y
-
-      - name: Setup vcpkg cache (self-hosted)
-        if: contains(matrix.runner, 'self-hosted')
-        shell: bash
-        run: |
-          BINARY_DIR="$HOME/.cache/vcpkg/archives"
-          DOWNLOADS_DIR="$HOME/.cache/vcpkg/downloads"
-          mkdir -p "$BINARY_DIR" "$DOWNLOADS_DIR"
-          # Convert Git bash paths to native Windows paths for CMake/vcpkg
-          # (vcpkg rejects an MSYS-style VCPKG_DEFAULT_BINARY_CACHE like /c/...).
-          if command -v cygpath >/dev/null 2>&1; then
-            BINARY_DIR=$(cygpath -w "$BINARY_DIR")
-            DOWNLOADS_DIR=$(cygpath -w "$DOWNLOADS_DIR")
-          fi
-          echo "VCPKG_DEFAULT_BINARY_CACHE=$BINARY_DIR" >> "$GITHUB_ENV"
-          echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
-
-      - uses: ./.github/actions/setup-vcpkg-cache
-        if: ${{ !contains(matrix.runner, 'self-hosted') }}
-        with:
-          cache-key-prefix: ${{ matrix.name }}
-
-      - name: Bootstrap vcpkg
-        shell: bash
-        run: |
-          if [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" ]; then
-            bash "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-          elif [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.bat" ]; then
-            "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.bat" -disableMetrics
-          fi
-        env:
-          VCPKG_BINARY_SOURCES: "clear;default,readwrite"
-
-      # VCPKG_ROOT points lukka/run-cmake (and the in-tree vcpkg toolchain) at the
-      # project's deps/vcpkg. On self-hosted Windows, vcvarsall (msvc-dev-cmd) leaks
-      # VCPKG_ROOT -> the VS-bundled, manifest-less vcpkg; this step-level env value
-      # overrides that leak, so no special "pin" step is needed (same as Linux/macOS).
-      - name: Configure
-        uses: lukka/run-cmake@v10
-        with:
-          configurePreset: ${{ matrix.configure_preset }}
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
-
-      - name: Build
-        uses: lukka/run-cmake@v10
-        with:
-          buildPreset: ${{ matrix.build_preset }}
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
-
-      - name: Test
-        uses: lukka/run-cmake@v10
-        with:
-          testPreset: ${{ matrix.test_preset }}
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
-
-      - name: Package
-        run: cpack --preset=${{ matrix.package_preset }}
-
-      # Install/extract the freshly built package on a clean target and run the
-      # binary. This catches missing runtime dependencies (the exact failure
-      # mode of an unbundled dynamic build) BEFORE the package is published.
-      - name: Smoke test — install package & run (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          docker run --rm -v "$PWD/packages:/pkg:ro" ubuntu:25.04 bash -c '
-            set -e
-            apt-get update -qq
-            apt-get install -y -qq /pkg/*.deb
-            aqualink-automate --version'
-
-      - name: Smoke test — extract ZIP & run (Windows)
-        if: runner.os == 'Windows'
-        # Windows PowerShell (always present on self-hosted + GitHub-hosted), NOT
-        # pwsh/PowerShell 7 which the self-hosted runner image does not ship.
-        # All cmdlets used here (Expand-Archive, Get-ChildItem, ...) exist in 5.1.
-        shell: powershell
-        run: |
-          $zip = Get-ChildItem packages/*.zip | Select-Object -First 1
-          if (-not $zip) { throw "No ZIP package was produced" }
-          Expand-Archive -Path $zip.FullName -DestinationPath smoke -Force
-          $exe = Get-ChildItem -Path smoke -Recurse -Filter aqualink-automate.exe | Select-Object -First 1
-          if (-not $exe) { throw "aqualink-automate.exe not found in the package" }
-          & $exe.FullName --version
-          if ($LASTEXITCODE -ne 0) { throw "Binary exited with code $LASTEXITCODE" }
-
-      - name: Smoke test — extract TGZ & run (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          set -e
-          mkdir -p smoke
-          tar xzf packages/*.tar.gz -C smoke
-          BIN="$(find smoke -name aqualink-automate -type f -perm +111 | head -1)"
-          if [ -z "$BIN" ]; then echo "::error::binary not found in package"; exit 1; fi
-          "$BIN" --version
-
-      - name: Upload packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: packages-${{ matrix.configure_preset }}
-          if-no-files-found: error
-          path: |
-            packages/*.deb
-            packages/*.rpm
-            packages/*.tar.gz
-            packages/*.zip
-            packages/*.exe
-            packages/*.dmg
-            packages/*.sha512
-          retention-days: 30
+    uses: ./.github/workflows/_build.yml
+    with:
+      do_package: true
+      version_tag: ${{ needs.resolve-version.outputs.version_tag }}
+      fetch_depth: 0
 
   docker-publish:
     name: Docker Publish
@@ -313,11 +150,11 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       # The Dockerfile's base images (ubuntu:25.04, node:22-bookworm-slim) are
       # pulled from Docker Hub. Anonymous pulls share the runner's egress IP and
@@ -327,14 +164,14 @@ jobs:
       # credential-less runs still build anonymously. See docs/releasing.md.
       - name: Login to Docker Hub
         if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -342,7 +179,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -360,7 +197,7 @@ jobs:
       # labels come from docker/metadata-action; passing them through env keeps the
       # newline-separated lists intact inside the retry command.
       - name: Build and push runtime image
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
           IMAGE_LABELS: ${{ steps.meta.outputs.labels }}
@@ -407,7 +244,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Push tag for dispatch builds
         if: github.event_name == 'workflow_dispatch'
@@ -415,6 +252,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git tag "${{ needs.resolve-version.outputs.version_tag }}" HEAD && git push origin "${{ needs.resolve-version.outputs.version_tag }}"
 
+      # actions/download-artifact has no Node 24 release yet, so it stays on v4
+      # (bumping would not clear the Node 20 warning and risks breaking changes).
       - name: Download all package artifacts
         uses: actions/download-artifact@v4
         with:

--- a/docs/cicd-redesign.md
+++ b/docs/cicd-redesign.md
@@ -1,0 +1,243 @@
+# CI/CD Redesign — Build-Once → Promote
+
+> Produced by a multi-agent analysis of the GitHub CI / release / packaging / tagging flow
+> (2026-06-15). The **plan** (synthesis) is followed by an **adversarial critique** that corrects
+> several over-claims. Read both — the critique's MUST-FIX items qualify the plan.
+
+## TL;DR — recommended order
+
+- **Ship now (pure wins, low risk):** CTest LABELS (Phase 0) and a triplet/OS-keyed vcpkg binary
+  cache (Phase 1). The critique calls the cache re-keying *"the highest-true-value change in the plan."*
+  Both are implemented in the same PR as this doc.
+- **The "13→3 builds" headline is overstated** — honest count is ~13→7 for a release (3 builds +
+  SonarCloud coverage + CodeQL + MSVC analysis + matter TypeScript all still compile). The genuine
+  prize is eliminating duplicate **vcpkg** builds via one shared cache, not eliminating compiles.
+- **Two plan pillars are wrong as written** and need the critique's fixes first: "assembly-only
+  Docker" rests on an undocumented runner-OS == Docker-base ABI coincidence (breaks on the
+  `ubuntu-latest` fallback), and scanners **cannot** consume prebuilt CMake build trees (CodeQL /
+  SonarCloud / MSVC analysis must observe a live compile).
+
+---
+
+# Plan (synthesis)
+
+## 1. The core problem
+
+For a **single release**, the C++ app and its full vcpkg dependency set are compiled from cold
+roughly **13 times** across jobs that share zero artifacts: `ci.yml build-and-test` (×3
+Linux/Windows/macOS) + `ci.yml e2e-ui` (rebuilds the Linux app) + `ci.yml docker-verify` (rebuilds
+vcpkg+app inside the Docker `ci` stage) + `automated-codescanning.yml` (CodeQL, SonarCloud-coverage,
+MSVC-analysis = ×3) + `release.yml build-packages` (×3 again) + `release.yml docker-publish`
+(rebuilds the `ci` stage from scratch inside Docker). Root causes are structural: **no build
+artifact ever crosses a job or workflow boundary** (every job re-runs `configure → vcpkg → build`),
+the Docker `runtime` stage does `COPY --from=ci /src/install/config-linux-gcc/` so the `ci` stage
+recompiles everything (`Dockerfile:186` / `:100-133`), and the three CTest cases —
+`AqualinkAutomateUnitTests` (`test/CMakeLists.txt:223`), `AqualinkAutomateIntegrationTests` (`:354`),
+`AqualinkAutomatePerfTests` (`:407`) — carry **no labels**, so `ctest --preset test-linux-gcc` runs
+the slow integration binary in *both* CI and release with no way to gate it on a PR. Consequences
+seen this week: hours-long releases; Docker Hub CDN/rate-limit flakiness; self-hosted runner
+saturation (a beta stuck `queued` ~2h); and a real beta that **failed at `ctest` during
+`release.yml`** because the author never ran the integration target locally and the failure first
+surfaced *after* packaging. Tagging is fully manual (admin-merge develop→main, hand-push `v*`),
+leaving orphaned beta tags.
+
+**Base design chosen:** "build-once-promote" as the spine — its `workflow_call` reusable build,
+`DERIVED_VERSION_OVERRIDE` threading, and triplet-keyed cache are the strongest, lowest-risk core.
+Grafted in: **CTest LABELS** (Phase 0, cheapest highest-value fix), an explicit `.dockerignore`
+carve-out + dedicated Docker context, and a **concurrency guard excluding `main`/`develop`**.
+Deliberately **deferred** (scope-creep / dual-source-of-truth risk): release-please / auto-tag-on-merge
+and a checked-in `VERSION` file — kept as an optional, last, opt-in phase.
+
+## 2. Target architecture
+
+### Workflow / job graph
+
+```
+_build.yml  (NEW — workflow_call; THE ONLY PLACE A COMPILER RUNS)
+ └─ build  [matrix: linux-gcc / windows-msvc / macos-llvm]      runs-on: RUNNER_HEAVY (self-hosted)
+      checkout(submodules,fetch-depth:0) → setup-runner → setup-vcpkg-cache
+      → configure config-<plat>  (-DDERIVED_VERSION_OVERRIDE=${{inputs.version_override}})
+      → build build-<plat>  (app + test targets)
+      → ctest test-<plat> -L unit         (always)
+      → ctest test-<plat> -L integration  (if inputs.run_integration)
+      → cmake --install build/config-<plat>
+      → cpack pack-<plat>   (if inputs.do_package)
+      uploads:  installtree-<plat>  (always),  buildtree-<plat>  (if upload_buildtree),
+                packages-config-<plat> (if do_package),  test-results-<plat>
+
+ci.yml      (PR → develop/main; push → develop)        concurrency: cancel PRs only, never main/develop
+ ├─ build         uses: ./_build.yml   run_integration=true, upload_buildtree=(linux,windows)
+ ├─ e2e-ui        needs build → download installtree-linux-gcc → AQUALINK_EXE=… → Playwright ×4   [LIGHT]
+ ├─ docker-verify needs build → download installtree-linux-gcc → docker build --target runtime    [LIGHT]
+ ├─ scan-linux    needs build → CodeQL + SonarCloud (shares vcpkg cache; still compiles)          [HEAVY*]
+ ├─ scan-windows  needs build → msvc-code-analysis-action (shares vcpkg cache; still compiles)     [LIGHT]
+ ├─ matter-bridge (Node-only, independent)                                                         [LIGHT]
+ └─ version-check (PR→main only, BLOCKING)                                                         [LIGHT]
+
+release.yml (push tag v*; or workflow_dispatch)        concurrency: per-version, cancel-in-progress:false
+ ├─ resolve-version  validate tag, cut-from-main guard, existing-tag guard
+ ├─ build            uses: ./_build.yml  with: version_override=<tag>, do_package=true, run_integration=true
+ ├─ docker-publish   needs [resolve-version, build] → download installtree-linux-gcc
+ │                    → docker build --target runtime --push (no C++ recompile; matter TS still builds)
+ └─ github-release   needs [resolve-version, build, docker-publish]
+                      → download packages-config-* → gh release create → (dispatch) push tag LAST
+
+automated-codescanning.yml  →  DELETED  (jobs absorbed into ci.yml scan-linux/scan-windows; weekly cron moves there)
+```
+\* `scan-linux` still compiles (SonarCloud needs a `config-linux-gcc-coverage` build; CodeQL must
+observe a compile) — see §5 and critique #3/#4.
+
+### Build-once artifact data-flow (PR → main → tag → release)
+
+```
+PR (→develop/→main): ci.yml runs _build.yml ONCE (×3). e2e/docker consume artifacts.
+   Required checks: build(×3), integration tests (in build), e2e-ui, docker-verify, scan-linux, scan-windows.
+        ▼ merge develop → main (admin/merge-queue; version-check BLOCKING on →main)
+   Tag push  v<M>.<M>.<P>[-(alpha|beta|rc).<N>]   (manual today; optional auto-tag deferred)
+        ▼
+   release.yml: resolve-version → _build.yml(version_override=tag, do_package) → docker-publish → github-release
+```
+
+The "build once" boundary is the `build` node **inside each workflow run** — within a single
+release run the bits packaged into `.deb/.rpm/.tgz/.zip/.exe/.dmg`, the install tree that becomes the
+Docker image, and the test results are the *same compiled objects*. Honest scope: reuse is
+**per-run, not cross-run** — `release.yml` still runs `_build.yml` once because the SHA differs after
+the develop→main merge.
+
+## 3. Concrete per-file changes
+
+- **`test/CMakeLists.txt` (Phase 0, ship first):** add `set_tests_properties(... LABELS unit|integration|perf)`
+  after the three `add_test` calls. Enables `ctest --preset <p> -L unit` (fast) vs `-L integration`.
+  Pure CMake, locally verifiable, zero workflow risk. *(Caveat: labels only help once the ctest
+  invocation passes `-L`; the presets have no filter, so add the `-L` to the ctest step.)*
+- **`.github/workflows/_build.yml` (NEW):** `workflow_call` with inputs
+  `platform, configure_preset, build_preset, test_preset, package_preset, version_override, run_integration, do_package, upload_buildtree`.
+  One matrix job: configure → build → `ctest -L unit` → `ctest -L integration` (gated) → install →
+  cpack (gated) → smoke (gated) → uploads. Threads `-DDERIVED_VERSION_OVERRIDE`.
+- **`ci.yml` (rewritten):** `build-and-test` becomes a one-line `uses: ./_build.yml`; `e2e-ui` and
+  `docker-verify` drop their builds and download `installtree-linux-gcc`; scanners absorbed; add the
+  concurrency guard excluding `main`/`develop`.
+- **`release.yml` (rewritten):** `build-packages` → `uses: ./_build.yml` (same reusable build as CI,
+  so integration can't diverge); `docker-publish` consumes the install artifact; `github-release`
+  pushes the tag only after docker+packages succeed, with an `if: failure()` finalizer that deletes a
+  *prerelease* tag whose release didn't complete (kills orphaned betas).
+- **`Dockerfile` + `.dockerignore`:** add an assembly-only `runtime` path that `COPY`s a pre-built
+  install tree from a dedicated, un-ignored `docker/context/` dir (`.dockerignore` adds `!docker/context/`).
+  Keep the from-source `ci` stage for local/dev + a scheduled cold-build check. *(See critique #1/#2.)*
+- **`cmake/CPackConfig.cmake` / `cmake/GitVersionDerivation.cmake` / `CMakePresets.json`:** unchanged.
+- **`.github/actions/setup-vcpkg-cache/action.yml` (Phase 1):** re-key the binary cache on
+  triplet/runner-OS, dropping the per-job `cache-key-prefix` (which produced 4 disjoint
+  `x64-linux-gcc` caches). Coverage and release legitimately share vcpkg binaries.
+
+## 4. Caching + reliability
+
+- **vcpkg binaries** — `actions/cache`, OS/triplet-keyed, restored only inside the build job; one
+  cache per triplet shared across build + coverage scan.
+- **Docker / BuildKit** — runtime build assembly-only on the hot path; add `type=gha` buildx cache so
+  apt + matter `npm ci` layers survive retries/eviction.
+- **`cleanup-branch-caches.yml`** — stop deleting the content-addressed vcpkg caches on PR close.
+- **Retries scoped to network only** (`nick-fields/retry` around Docker pulls + vcpkg bootstrap);
+  **never** retry compile/ctest. `fail-fast: false` on the build matrix.
+- **Integration tests become a blocking PR gate**, run by the same `_build.yml` the release uses —
+  the exact beta-killer fix.
+- **Runner split** `RUNNER_HEAVY` (compile + coverage scan) vs `RUNNER_LIGHT` (e2e/docker/release/
+  scan-windows) — peak heavy jobs per commit drop from ~6 to 3.
+
+## 5. Security-scan placement
+
+Delete `automated-codescanning.yml`; fold into `ci.yml` as `scan-linux` (CodeQL + SonarCloud) and
+`scan-windows` (MSVC analysis). Drop the noisy `push: feature/**, bug/**` triggers; scan on
+`pull_request: [develop, main]` + `push: [main]` + the weekly cron; make CodeQL + SonarCloud required
+PR checks. **They still compile** (see critique #3/#4) — the win is sharing the triplet-keyed vcpkg
+cache and consolidating runners, not eliminating the compile.
+
+## 6. Phased migration (each phase independently shippable & green)
+
+| Phase | Change | Risk |
+|---|---|---|
+| **0** | `test/CMakeLists.txt` LABELS; `docs/releasing.md` `ctest -L` note. Pure CMake. **Ship now.** | very low |
+| **1** | OS/triplet-key the vcpkg binary cache; narrow `cleanup-branch-caches.yml`. | low |
+| **2** | Extract `_build.yml` (`workflow_call`); `ci`/`release` call it (compile count unchanged — one build *definition*). | medium |
+| **3** | Assembly-only Docker (`!docker/context/` carve-out; `type=gha` cache); re-prove the smoke tests. | medium |
+| **4** | Consumers stop compiling: `e2e-ui`/`docker-verify` download artifacts; fold scanners; delete codescanning; narrow triggers. | low–med |
+| **5** | Versioning hardening: thread `version_override`; shared parse-version action; `version-check` blocking; orphan-tag finalizer; tag-after-success; concurrency guard; required checks. | medium |
+| **6 (optional)** | Auto-tag-on-merge + `gh release create --notes-file`. Opt-in; manual hand-push stays. **Defer.** | medium-high |
+
+## 7. Trade-offs & risks (plan's own list — see critique for corrections)
+
+- CodeQL `build-mode:none` is unvalidated against this repo's Boost/template load.
+- Reuse is per-run, not per-commit (release re-builds the merge commit).
+- Reduced cold-path coverage once docker/e2e/release consume artifacts (mitigate with a scheduled
+  — better, per-release — cold build gate).
+- `.dockerignore` `!docker/context/` carve-out is a footgun (empty image if wrong).
+- Required-check hardening trades release-time flakiness for merge-time flakiness — sequence it after
+  the retry/cache work.
+
+---
+
+# Adversarial critique
+
+Verified against the repo: CTest labels genuinely absent (`test/CMakeLists.txt:223/354/407`); CPack
+reads `${CMAKE_BINARY_DIR}/vcpkg_installed/` (`CPackConfig.cmake:26-27`); `DERIVED_VERSION_OVERRIDE`
+honored (`GitVersionDerivation.cmake:48`); `.dockerignore:12-15` excludes `install`/`build`/`vcpkg_installed`;
+`COPY --from=ci` at `Dockerfile:186`. The plan's factual anchors hold, but several **feasibility**
+claims do not.
+
+## MUST-FIX gaps
+
+1. **[CRITICAL] Assembly-only Docker rests on an undocumented glibc/ABI coupling and silently breaks
+   on the GitHub-hosted fallback.** The install tree bundles only the vcpkg `.so`s into
+   `lib/aqualink-automate/` (`CPackConfig.cmake:99`) — **not** `libstdc++`/`libc`, resolved from the
+   runtime base image. This works *today* only because the self-hosted Linux runner is Ubuntu 25.04 /
+   GCC 15 — identical to the `ubuntu:25.04` runtime base. The instant `_build.yml` runs on
+   `ubuntu-latest` (24.04: glibc 2.39, GCC 13 — the documented fallback), the artifact's
+   `libstdc++`/`GLIBCXX`/`CXXABI` skew surfaces only at *container runtime, after publish*. **Fix:**
+   build the Linux artifact *inside* an `ubuntu:25.04` `container:` (pin the ABI baseline regardless of
+   host), or forbid the GitHub-hosted Linux fallback for the Docker-feeding artifact and assert
+   runner-OS == runtime-base.
+2. **[CRITICAL] The matter sidecar is not in the install tree** — `docker build --target runtime` still
+   builds the `matter-builder` stage (`npm ci` + `tsc`) from source every time. "No recompile" is true
+   only for the C++ half; the buildx context must still carry `matter-bridge/` + `docker-entrypoint.sh`.
+3. **[HIGH] Scanners cannot consume prebuilt build trees.** A CMake build tree is not relocatable
+   (`compile_commands.json`, `.ninja_deps`, response files embed absolute build-runner paths);
+   CodeQL's DB is built by *observing the compiler run*. So `scan-linux`/`scan-windows` must compile
+   in-job. The only shareable thing is the triplet-keyed **vcpkg binary cache** (config/path-independent).
+   This collapses "scanners stop compiling" to "scanners stop *rebuilding vcpkg*."
+4. **[HIGH] CodeQL + SonarCloud cannot share one compilation** — SonarCloud needs the
+   `build-wrapper`-wrapped coverage build; CodeQL needs its own traced build; they are mutually
+   exclusive wrappers on different configs. Folding into one job means **two compiles in one job**.
+5. **[HIGH] "13→3" is materially overstated.** A single `release.yml` run still does 3× `_build.yml` +
+   SonarCloud coverage + CodeQL + MSVC analysis + matter TypeScript ≈ **7 compiles**. The defensible
+   win is killing duplicate **vcpkg** builds (the expensive part) via one shared cache + stopping the
+   e2e/docker app-recompiles.
+
+## SHOULD-FIX
+
+6. **[MEDIUM]** `installtree-<plat>` upload/download (hundreds of MB of vcpkg `.so`s + assets) is added
+   to the **critical path** of every PR (e2e + docker `needs:` it) — net latency may not improve as
+   much as the compile-count drop suggests.
+7. **[MEDIUM]** The bumped actions' Node24 runtime vs the self-hosted runner agent (`2.331.0`) is
+   plausibly fine but **unverified** — add a runner-agent assertion or pin.
+8. **[MEDIUM]** Docker smoke coverage shrinks: the cold from-source container build (which is exactly
+   what would catch gap #1) only runs weekly under the plan. **Fix:** run it on every `main` push or
+   every release tag as a blocking parallel check.
+9. **[MEDIUM]** Per-run (not per-commit) reuse means the tagged merge commit is first built *at
+   release*. The robust beta-killer fix is gating the develop→main **merge commit** with full CI
+   (merge queue), which `version-check`-blocking does not do.
+
+## MINOR / correct-as-claimed
+
+10. CTest LABELS (Phase 0) — correct & low-risk; remember to add `-L` to the ctest *invocation*
+    (presets have no filter, so labels alone change nothing in CI until then).
+11. `.dockerignore` `!docker/context/` carve-out — sound but a footgun; smoke tests are the guardrail.
+12. **OS/triplet-keying the vcpkg binary cache + dropping the per-job prefix is the highest-true-value
+    change in the plan** and is correct — vcpkg binaries are config-independent.
+13. Concurrency guard excluding main/develop + the orphan-prerelease-tag finalizer are correct and
+    low-risk. Deferring release-please/auto-tag (fights the `git describe` + cut-from-main model) is right.
+
+## Overall verdict
+
+**Directionally sound and worth doing — but the plan oversells "build once," and two load-bearing
+pillars (assembly-only Docker, scanners reusing build trees) are wrong as written.** Ship the
+vcpkg-cache-keying and label work (the genuine wins) first; fix gaps #1–#4 before any
+artifact-promotion claims; keep a per-release cold Docker build as a blocking gate.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -221,6 +221,9 @@ target_link_libraries(
 )
 
 add_test(NAME AqualinkAutomateUnitTests COMMAND testaqualink-automate WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+# Label so callers can gate suites: `ctest --preset <p> -L unit` (fast, local /
+# PR) vs `-L integration` (the slower fixture-replay suite). See docs/releasing.md.
+set_tests_properties(AqualinkAutomateUnitTests PROPERTIES LABELS "unit")
 
 if(ENABLE_COVERAGE)
 
@@ -352,6 +355,7 @@ target_link_libraries(
 )
 
 add_test(NAME AqualinkAutomateIntegrationTests COMMAND intaqualink-automate WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(AqualinkAutomateIntegrationTests PROPERTIES LABELS "integration")
 
 if(ENABLE_SANITIZERS)
 target_enable_sanitizers(intaqualink-automate)
@@ -405,6 +409,7 @@ target_link_libraries(
 )
 
 add_test(NAME AqualinkAutomatePerfTests COMMAND perfaqualink-automate WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(AqualinkAutomatePerfTests PROPERTIES LABELS "perf")
 
 if(ENABLE_SANITIZERS)
 target_enable_sanitizers(perfaqualink-automate)


### PR DESCRIPTION
Supersedes #12 (contains its commits). Lands the CI/CD redesign doc and phases 0-2, plus a repo-wide Node-20 action bump.

**Docs** — `docs/cicd-redesign.md`: the build-once plan + the adversarial critique correcting its over-claims.

**Phase 0** — CTest labels (unit/integration/perf) so `ctest -L` can gate the integration suite.

**Phase 1** — vcpkg binary cache keyed by runner OS, collapsing the 4 disjoint same-triplet caches into one.

**Phase 2** — new reusable `.github/workflows/_build.yml` (`workflow_call`): the single configure/build/test(/package) matrix. `ci.yml build-and-test` and `release.yml build-packages` now both call it, so the integration suite can never diverge between CI and release again. Behaviour is identical (net -51 lines); `do_package` adds cpack + the per-OS smoke test + the package upload.

**Action sweep (Node 20 deprecation)** — checkout v4→v5, setup-node v4→v5, cache v4→v5, upload-artifact v4→v6; docker/setup-buildx v3→v4, docker/login v3→v4, docker/metadata v5→v6, nick-fields/retry v3→v4. `download-artifact` stays v4 (no Node 24 release exists yet — noted inline).

Validation: PR CI exercises the ci.yml build path on all 3 platforms; a release `dry_run` (triggered on this branch) exercises the build-packages path. Later phases (assembly-only Docker, scanner consolidation) are deferred per the critique.