### PR TITLE
ci: CI/CD redesign phases 3-6 (assembly Docker, artifact e2e, versioning, opt-in auto-tag)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,3 +48,11 @@ nul
 *.dmg
 *.pdb
 *.ilk
+
+# The release pipeline stages a prebuilt Linux install tree here so the
+# `runtime-assembled` Dockerfile stage can COPY it without recompiling. The
+# `install`/`build` rules above are root-anchored and do not match this nested
+# path, but re-include it explicitly so the assembled COPY can never silently
+# produce an empty image.
+!docker/context
+!docker/context/**

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
         default: false
       version_tag:
-        description: "Resolved v* tag. Used only to create a local tag for workflow_dispatch release builds so `git describe` stamps the right version."
+        description: "Resolved v* tag, threaded into configure as DERIVED_VERSION_OVERRIDE so the build stamps it deterministically. Empty in CI -> `git describe`."
         type: string
         default: ""
       fetch_depth:
@@ -59,14 +59,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: ${{ inputs.fetch_depth }}
-
-      # Release dispatch builds derive the version from `git describe`; create the
-      # not-yet-pushed tag locally so it resolves (tag-push releases already have it,
-      # CI doesn't package). github-release pushes the real tag at the very end.
-      - name: Create local tag for dispatch builds
-        if: inputs.do_package && github.event_name == 'workflow_dispatch'
-        shell: bash
-        run: git tag "${{ inputs.version_tag }}" HEAD
 
       - name: Clean workspace (self-hosted)
         if: contains(matrix.runner, 'self-hosted')
@@ -125,10 +117,15 @@ jobs:
       # project's deps/vcpkg. On self-hosted Windows, vcvarsall (msvc-dev-cmd) leaks
       # VCPKG_ROOT -> the VS-bundled, manifest-less vcpkg; this step-level env value
       # overrides that leak, so no special "pin" step is needed (same as Linux/macOS).
+      # Stamp the resolved version deterministically: release callers pass the tag
+      # via version_tag, which GitVersionDerivation honours OVER `git describe`
+      # (eliminating the configure-time tag-race and the need to pre-create a local
+      # tag). CI passes an empty value -> falls back to `git describe`.
       - name: Configure
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.configure_preset }}
+          configurePresetAdditionalArgs: "['-DDERIVED_VERSION_OVERRIDE=${{ inputs.version_tag }}']"
         env:
           VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
 

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -163,10 +163,16 @@ jobs:
       # built on the Ubuntu-25.04 runner so the binary's glibc/libstdc++ baseline
       # matches the ubuntu:25.04 Docker runtime base.
       # ---------------------------------------------------------------------------
-      - name: Install (Linux install tree)
+      - name: Install + pack the Linux install tree
         if: inputs.upload_installtree && runner.os == 'Linux'
         shell: bash
-        run: cmake --install build/config-linux-gcc --prefix "${{ github.workspace }}/install/config-linux-gcc"
+        run: |
+          cmake --install build/config-linux-gcc --prefix "${{ github.workspace }}/install/config-linux-gcc"
+          # Pack as a tarball so the versioned .so SYMLINKS and exec bits survive the
+          # CI artifact round-trip losslessly (a raw upload-artifact mangles symlinks,
+          # and the runtime binary loads libs by their versioned SONAME).
+          tar czf "${{ github.workspace }}/installtree-linux-gcc.tar.gz" \
+            -C "${{ github.workspace }}/install/config-linux-gcc" .
 
       - name: Upload Linux install tree
         if: inputs.upload_installtree && runner.os == 'Linux'
@@ -174,7 +180,7 @@ jobs:
         with:
           name: installtree-linux-gcc
           if-no-files-found: error
-          path: install/config-linux-gcc/
+          path: installtree-linux-gcc.tar.gz
           retention-days: 3
 
       # ---------------------------------------------------------------------------

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -20,6 +20,10 @@ on:
         description: "checkout fetch-depth (0 for releases so `git describe`/cut-from-main see full history + tags; 1 for CI)."
         type: number
         default: 1
+      upload_installtree:
+        description: "On Linux, run `cmake --install` and upload installtree-linux-gcc (the relocatable FHS tree e2e-ui and the assembled Docker image consume instead of recompiling)."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -150,6 +154,28 @@ jobs:
           testPreset: ${{ matrix.test_preset }}
         env:
           VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
+
+      # ---------------------------------------------------------------------------
+      # Linux install tree (consumed by e2e-ui and the assembled Docker image so
+      # they do not recompile). This is the same `cmake --install` tree the
+      # Dockerfile assembles the runtime image from: the binary + bundled vcpkg libs
+      # ($ORIGIN RPATH) + web/ssl assets. Linux only (the consumers are Linux), and
+      # built on the Ubuntu-25.04 runner so the binary's glibc/libstdc++ baseline
+      # matches the ubuntu:25.04 Docker runtime base.
+      # ---------------------------------------------------------------------------
+      - name: Install (Linux install tree)
+        if: inputs.upload_installtree && runner.os == 'Linux'
+        shell: bash
+        run: cmake --install build/config-linux-gcc --prefix "${{ github.workspace }}/install/config-linux-gcc"
+
+      - name: Upload Linux install tree
+        if: inputs.upload_installtree && runner.os == 'Linux'
+        uses: actions/upload-artifact@v6
+        with:
+          name: installtree-linux-gcc
+          if-no-files-found: error
+          path: install/config-linux-gcc/
+          retention-days: 3
 
       # ---------------------------------------------------------------------------
       # Packaging (release path only — inputs.do_package)

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,83 @@
+name: Auto Tag (opt-in)
+
+# Opt-in helper that advances the prerelease tag on a push to main, which fires
+# release.yml exactly as a manual tag push would. Does NOTHING unless the
+# AUTO_TAG_ENABLED repo variable is "true" — by default versions are tagged by
+# hand, and the manual hand-push stays the escape hatch.
+#
+# Scope is deliberately conservative and git-describe-compatible: it only advances
+# the prerelease COUNTER (vX.Y.Z-<channel>.N -> .N+1), the project's actual release
+# cadence. Base bumps (minor/major) and channel changes stay MANUAL so a human
+# decides when a release line advances — avoiding the dual-source-of-truth / wrong
+# auto-bump risk the redesign critique flagged against release-please-style tools.
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    if: vars.AUTO_TAG_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Compute and push the next prerelease tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ vars.AUTO_TAG_CHANNEL || 'beta' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LAST=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST" ]; then
+            echo "No existing v* tag — refusing to invent the first version. Tag it manually."
+            exit 0
+          fi
+          echo "Last tag: $LAST"
+
+          # Only advance a prerelease counter; a stable or non-<channel>.N tag is left
+          # alone (base bumps are a human decision).
+          if [[ ! "$LAST" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-([a-z]+)\.([0-9]+)$ ]]; then
+            echo "Last tag $LAST is not a '<channel>.N' prerelease — auto-tag only advances the prerelease counter. Tag manually."
+            exit 0
+          fi
+          MAJOR="${BASH_REMATCH[1]}"; MINOR="${BASH_REMATCH[2]}"; PATCH="${BASH_REMATCH[3]}"
+          LASTCH="${BASH_REMATCH[4]}"; N="${BASH_REMATCH[5]}"
+
+          if [ "$LASTCH" != "$CHANNEL" ]; then
+            echo "Last tag channel '$LASTCH' != configured AUTO_TAG_CHANNEL '$CHANNEL' — tag manually to switch channels."
+            exit 0
+          fi
+
+          COUNT=$(git rev-list "${LAST}..HEAD" --count)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No new commits since $LAST — nothing to release."
+            exit 0
+          fi
+
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}-${CHANNEL}.$((N + 1))"
+          echo "Computed next tag: $NEXT ($COUNT new commits since $LAST)"
+
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${NEXT}" >/dev/null 2>&1; then
+            echo "::error::$NEXT already exists — aborting."
+            exit 1
+          fi
+
+          git tag -a "$NEXT" -m "Release $NEXT (auto-tagged)"
+          git push origin "$NEXT"
+          echo "Pushed $NEXT — release.yml will run for it."
+
+          {
+            echo "### Auto-tag"
+            echo ""
+            echo "| From | To | New commits |"
+            echo "|------|----|-------------|"
+            echo "| \`$LAST\` | \`$NEXT\` | $COUNT |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: installtree-linux-gcc
-          path: installtree
+          path: installtree-art
 
-      - name: Make binary executable
+      - name: Unpack install tree
         shell: bash
-        run: chmod +x installtree/bin/aqualink-automate
+        run: |
+          mkdir -p installtree
+          tar xzf installtree-art/installtree-linux-gcc.tar.gz -C installtree
+          chmod +x installtree/bin/aqualink-automate
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,11 +182,15 @@ jobs:
           echo "Base (${{ github.base_ref }}): $BASE_DESCRIBE"
           echo "Head: $HEAD_DESCRIBE"
 
+          # A PR into main is a release promotion. Block (don't just warn) when the
+          # resolved version is identical to the base — i.e. there is nothing new to
+          # release. Distinct `git describe` output (a different commit distance or a
+          # new tag) is enough to pass; this only fails a genuinely empty promotion.
           if [[ "$HEAD_DESCRIBE" == "$BASE_DESCRIBE" ]]; then
-            echo "::warning::Version appears unchanged between base and PR branch ($HEAD_DESCRIBE). If this PR includes functional changes, consider tagging a new version before merging."
-          else
-            echo "Version info differs: base=$BASE_DESCRIBE, head=$HEAD_DESCRIBE"
+            echo "::error::Version is unchanged between ${{ github.base_ref }} ($BASE_DESCRIBE) and this PR head ($HEAD_DESCRIBE). Nothing new to release."
+            exit 1
           fi
+          echo "Version advances: base=$BASE_DESCRIBE -> head=$HEAD_DESCRIBE"
 
   docker-verify:
     name: Docker Verification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,21 @@ jobs:
   # The configure/build/test matrix lives in the reusable _build.yml so CI and the
   # release pipeline share one definition and can never drift. Runner selection
   # (vars.RUNNER_LINUX / RUNNER_WINDOWS) is handled inside that workflow.
+  # upload_installtree publishes the Linux install tree that e2e-ui consumes below
+  # (so e2e no longer recompiles the app).
   build-and-test:
     name: Build & Test
     uses: ./.github/workflows/_build.yml
+    with:
+      upload_installtree: true
 
+  # Drive the real UI against a replay fixture in a browser. Consumes the binary
+  # built by build-and-test (the installtree-linux-gcc artifact) instead of
+  # recompiling the app. Trade-off: gated behind the whole build matrix, so it
+  # starts later than when it built its own binary — but it never recompiles.
   e2e-ui:
     name: E2E UI (Playwright)
+    needs: build-and-test
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
 
     steps:
@@ -30,54 +39,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Clean workspace (self-hosted)
-        if: contains(vars.RUNNER_LINUX, 'self-hosted')
-        shell: bash
-        run: rm -rf build/
-
-      - uses: ./.github/actions/setup-cpp-toolchain
-        if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}
+      - name: Download Linux install tree
+        uses: actions/download-artifact@v4
         with:
-          compiler: gcc-15
+          name: installtree-linux-gcc
+          path: installtree
 
-      - name: Setup vcpkg cache (self-hosted)
-        if: contains(vars.RUNNER_LINUX, 'self-hosted')
+      - name: Make binary executable
         shell: bash
-        run: |
-          BINARY_DIR="$HOME/.cache/vcpkg/archives"
-          DOWNLOADS_DIR="$HOME/.cache/vcpkg/downloads"
-          mkdir -p "$BINARY_DIR" "$DOWNLOADS_DIR"
-          echo "VCPKG_DEFAULT_BINARY_CACHE=$BINARY_DIR" >> "$GITHUB_ENV"
-          echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
-
-      # Shares the vcpkg cache populated by the build-and-test job, so this job only
-      # pays the application compile cost, not a vcpkg rebuild.
-      - uses: ./.github/actions/setup-vcpkg-cache
-        if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}
-        with:
-          cache-key-prefix: Linux GCC
-
-      - name: Bootstrap vcpkg
-        shell: bash
-        run: |
-          if [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" ]; then
-            bash "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-          fi
-        env:
-          VCPKG_BINARY_SOURCES: "clear;default,readwrite"
-
-      - name: Configure
-        uses: lukka/run-cmake@v10
-        with:
-          configurePreset: config-linux-gcc
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
-
-      # Only the app binary is needed for the UI replay run; skipping the test
-      # executables keeps this job lean (the C++ tests run in build-and-test).
-      - name: Build application binary
-        shell: bash
-        run: cmake --build --preset build-linux-gcc --target aqualink-automate
+        run: chmod +x installtree/bin/aqualink-automate
 
       - uses: actions/setup-node@v5
         with:
@@ -92,7 +62,7 @@ jobs:
           npx playwright install --with-deps chromium
 
       # The four runs mirror the modes encoded in playwright.config.ts. Each boots
-      # the freshly built binary against the replay fixture; env selects the mode.
+      # the downloaded binary against the replay fixture; env selects the mode.
       #   * default        -> every spec except auth (history/scheduler "disabled" paths)
       #   * AUTH_TOKEN      -> only auth.spec.ts      (token-gated WS auth)
       #   * HISTORY_DB      -> only trends.spec.ts    (recorded series + chart)
@@ -101,27 +71,27 @@ jobs:
         shell: bash
         run: npx playwright test
         env:
-          AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc/src/aqualink-automate
+          AQUALINK_EXE: ${{ github.workspace }}/installtree/bin/aqualink-automate
 
       - name: E2E — auth enabled
         shell: bash
         run: npx playwright test
         env:
-          AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc/src/aqualink-automate
+          AQUALINK_EXE: ${{ github.workspace }}/installtree/bin/aqualink-automate
           AQUALINK_AUTH_TOKEN: e2e-secret-token
 
       - name: E2E — history enabled
         shell: bash
         run: npx playwright test
         env:
-          AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc/src/aqualink-automate
+          AQUALINK_EXE: ${{ github.workspace }}/installtree/bin/aqualink-automate
           AQUALINK_HISTORY_DB: ${{ runner.temp }}/e2e-history.db
 
       - name: E2E — scheduler enabled
         shell: bash
         run: npx playwright test
         env:
-          AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc/src/aqualink-automate
+          AQUALINK_EXE: ${{ github.workspace }}/installtree/bin/aqualink-automate
           AQUALINK_SCHEDULES_FILE: ${{ runner.temp }}/e2e-schedules.json
 
       - name: Upload Playwright report
@@ -192,6 +162,10 @@ jobs:
           fi
           echo "Version advances: base=$BASE_DESCRIBE -> head=$HEAD_DESCRIBE"
 
+  # Cold, from-source Docker build kept deliberately as the gate that the
+  # multi-stage Dockerfile + vcpkg toolchain still build end to end (the assembled
+  # runtime path in release.yml's docker-publish skips this, so this is its safety
+  # net). Catches a vcpkg/Dockerfile/ABI regression that the assembly path can't.
   docker-verify:
     name: Docker Verification
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,17 +198,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: installtree-linux-gcc
-          path: docker/context/install/config-linux-gcc
+          path: docker/context
 
       - name: Verify staged install tree
         run: |
-          BIN=docker/context/install/config-linux-gcc/bin/aqualink-automate
-          if [ ! -f "$BIN" ]; then
-            echo "::error::Staged install tree is missing the executable ($BIN) — cannot assemble the image."
+          TARBALL=docker/context/installtree-linux-gcc.tar.gz
+          if [ ! -f "$TARBALL" ]; then
+            echo "::error::Staged install-tree tarball missing ($TARBALL) — cannot assemble the image."
             exit 1
           fi
-          chmod +x "$BIN"
-          echo "Staged install tree OK."
+          tar tzf "$TARBALL" ./bin/aqualink-automate >/dev/null \
+            || { echo "::error::install-tree tarball does not contain ./bin/aqualink-automate"; exit 1; }
+          echo "Staged install tree OK ($(du -h "$TARBALL" | cut -f1))."
 
       # Assemble + push via buildx, wrapped in a bounded retry so a transient Docker
       # Hub CDN blob timeout pulling a base image doesn't fail the release. The image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,9 @@ jobs:
       do_package: true
       version_tag: ${{ needs.resolve-version.outputs.version_tag }}
       fetch_depth: 0
+      # Publish the relocatable Linux install tree so docker-publish assembles the
+      # runtime image from it instead of recompiling vcpkg from scratch.
+      upload_installtree: true
 
   docker-publish:
     name: Docker Publish
@@ -188,28 +191,45 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve-version.outputs.version_tag }}
             type=raw,value=latest,enable=${{ needs.resolve-version.outputs.is_prerelease != 'true' }}
 
-      # Build + push via buildx, wrapped in a bounded retry. A single transient
-      # Docker Hub CDN blob timeout (seen during v0.2.0-beta.1) must not fail the
-      # whole release; a retry reuses the BuildKit layer cache plus the in-Dockerfile
-      # ccache/vcpkg cache mounts, so it only re-fetches the layer that timed out.
-      # docker/setup-buildx-action makes its builder the default, so this is
-      # equivalent to docker/build-push-action (same underlying buildx). Tags and
-      # labels come from docker/metadata-action; passing them through env keeps the
-      # newline-separated lists intact inside the retry command.
-      - name: Build and push runtime image
+      # Stage the prebuilt Linux install tree (built + version-stamped by
+      # build-packages on the Ubuntu-25.04 runner) into the build context so the
+      # runtime-assembled stage copies it straight in — NO vcpkg/source recompile.
+      - name: Download Linux install tree
+        uses: actions/download-artifact@v4
+        with:
+          name: installtree-linux-gcc
+          path: docker/context/install/config-linux-gcc
+
+      - name: Verify staged install tree
+        run: |
+          BIN=docker/context/install/config-linux-gcc/bin/aqualink-automate
+          if [ ! -f "$BIN" ]; then
+            echo "::error::Staged install tree is missing the executable ($BIN) — cannot assemble the image."
+            exit 1
+          fi
+          chmod +x "$BIN"
+          echo "Staged install tree OK."
+
+      # Assemble + push via buildx, wrapped in a bounded retry so a transient Docker
+      # Hub CDN blob timeout pulling a base image doesn't fail the release. The image
+      # is assembled from the prebuilt install tree (no C++ recompile); only the
+      # matter sidecar's TypeScript builds (matter-builder stage). The binary is
+      # already version-stamped, so no VERSION build-arg is needed. The "pull & run"
+      # smoke test below is the ABI guard (a glibc/libstdc++ mismatch would fail
+      # --version); CI's from-source docker-verify is the cold-build gate.
+      - name: Build and push runtime image (assembled)
         uses: nick-fields/retry@v4
         env:
           IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
           IMAGE_LABELS: ${{ steps.meta.outputs.labels }}
-          VERSION: ${{ needs.resolve-version.outputs.version_tag }}
         with:
           shell: bash
-          timeout_minutes: 90
+          timeout_minutes: 60
           max_attempts: 3
           retry_wait_seconds: 30
           retry_on: error
           command: |
-            cmd=(docker buildx build --target runtime --push --build-arg "VERSION=${VERSION}")
+            cmd=(docker buildx build --target runtime-assembled --push)
             while IFS= read -r tag;   do [ -n "$tag" ]   && cmd+=(--tag   "$tag");   done <<< "${IMAGE_TAGS}"
             while IFS= read -r label; do [ -n "$label" ] && cmd+=(--label "$label"); done <<< "${IMAGE_LABELS}"
             cmd+=(.)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,3 +275,38 @@ jobs:
             --generate-notes \
             $PRERELEASE_FLAG \
             release-artifacts/*
+
+  # If a real PRERELEASE run did not complete, delete its orphaned tag so a re-tag
+  # can retry cleanly (automates the by-hand beta.2/beta.3 cleanup). Never touches a
+  # stable tag, a dry-run, or a tag that already has a published release.
+  cleanup-failed-prerelease:
+    name: Clean up orphaned prerelease tag
+    needs: [resolve-version, build-packages, docker-publish, github-release]
+    if: >-
+      always() &&
+      needs.resolve-version.result == 'success' &&
+      needs.resolve-version.outputs.is_dry_run != 'true' &&
+      needs.resolve-version.outputs.is_prerelease == 'true' &&
+      (needs.build-packages.result == 'failure' ||
+       needs.docker-publish.result == 'failure' ||
+       needs.github-release.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete the orphaned prerelease tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.resolve-version.outputs.version_tag }}"
+          if gh release view "$TAG" -R "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "A published release exists for $TAG — leaving the tag in place."
+            exit 0
+          fi
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Release did not complete; deleting orphaned prerelease tag $TAG"
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/${TAG}"
+            echo "Deleted $TAG"
+          else
+            echo "Tag $TAG not present (a dispatch that failed before pushing it) — nothing to delete."
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -244,6 +244,10 @@ USER aqualink
 
 FROM runtime-base AS runtime-assembled
 
-ARG INSTALL_SRC=docker/context/install/config-linux-gcc
-COPY ${INSTALL_SRC}/ .
+# The install tree arrives as a tarball (lossless symlinks + exec bits through the
+# CI artifact round-trip) and is unpacked here INSIDE the image, so it is correct
+# regardless of the host/runner filesystem (e.g. a Windows box cannot represent the
+# versioned-.so symlinks the binary loads by SONAME).
+COPY docker/context/installtree-linux-gcc.tar.gz /tmp/installtree.tar.gz
+RUN tar xzf /tmp/installtree.tar.gz -C /opt/aqualink-automate && rm /tmp/installtree.tar.gz
 USER aqualink

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,10 +154,17 @@ RUN npm run build \
     && npm prune --omit=dev
 
 # ==============================================================================
-# Stage: runtime (minimal production image)
+# Stage: runtime-base (OS + deps + Matter sidecar + entrypoint, minus the app)
 # ==============================================================================
+#
+# Everything the production image needs EXCEPT the compiled app install tree. The
+# two final stages layer the app on top and differ ONLY in where the install tree
+# comes from, so the runtime contract is defined once here:
+#   - runtime           : app from the `ci` stage (built from source — the cold gate)
+#   - runtime-assembled : app from a prebuilt install tree staged into the context
+#                         (no recompile; used by release.yml docker-publish)
 
-FROM ubuntu:25.04 AS runtime
+FROM ubuntu:25.04 AS runtime-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -179,12 +186,6 @@ RUN groupadd --gid 10000 aqualink \
 
 WORKDIR /opt/aqualink-automate
 
-# Copy the installed application from the ci stage. The install tree already
-# carries the vcpkg runtime libraries in lib/aqualink-automate/, and the binary
-# is linked with an $ORIGIN-relative RPATH (see cmake/CPackConfig.cmake), so no
-# separate shared-library copy or LD_LIBRARY_PATH is required.
-COPY --from=ci /src/install/config-linux-gcc/ .
-
 # The Matter bridge sidecar (built dist/ + production node_modules) and the
 # supervising entrypoint that launches it alongside the app.
 COPY --from=matter-builder /opt/matter-bridge /opt/matter-bridge
@@ -194,8 +195,6 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # Fabric/commissioning persistence for the Matter bridge (mount a volume here so
 # pairing survives container restarts). Owned by the app user.
 RUN mkdir -p /data/matter && chown -R aqualink:aqualink /data/matter
-
-USER aqualink
 
 # 80 = HTTP API. Matter commissioning additionally needs UDP 5540 + mDNS 5353,
 # which require host networking (see docker-compose.yml) -- they cannot be mapped
@@ -214,3 +213,37 @@ ENV MATTER_ENABLED=true \
 # executable (share/aqualink-automate/...), so they do not need to be passed.
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["--address", "0.0.0.0", "--disable-https"]
+
+# ==============================================================================
+# Stage: runtime (from-source — the cold-build gate)
+# ==============================================================================
+#
+# The compiled install tree comes from the `ci` stage (built from source in this
+# very image, so its glibc/libstdc++ is the base image's by construction). CI's
+# docker-verify builds this target, so a vcpkg/Dockerfile/toolchain regression is
+# always caught end to end. The install tree carries the vcpkg runtime libraries in
+# lib/aqualink-automate/ with an $ORIGIN-relative RPATH (see cmake/CPackConfig.cmake),
+# so no separate shared-library copy or LD_LIBRARY_PATH is required.
+
+FROM runtime-base AS runtime
+
+COPY --from=ci /src/install/config-linux-gcc/ .
+USER aqualink
+
+# ==============================================================================
+# Stage: runtime-assembled (prebuilt install tree — no recompile)
+# ==============================================================================
+#
+# The compiled install tree is staged into the build context at docker/context/
+# (release.yml docker-publish downloads installtree-linux-gcc there) and copied
+# straight in — NO vcpkg/source recompile. The install tree MUST be built on Ubuntu
+# 25.04 so its glibc/libstdc++ baseline matches this base image; release.yml builds
+# it on the 25.04 Linux runner. The from-source `runtime` stage (CI docker-verify)
+# remains the cold-build gate that catches any ABI/vcpkg/Dockerfile regression this
+# path cannot.
+
+FROM runtime-base AS runtime-assembled
+
+ARG INSTALL_SRC=docker/context/install/config-linux-gcc
+COPY ${INSTALL_SRC}/ .
+USER aqualink


### PR DESCRIPTION
Completes the deferred redesign phases. Builds on the merged phases 0-2.

**Phase 5 (versioning hardening)** — deterministic version stamping via DERIVED_VERSION_OVERRIDE threaded through _build.yml; version-check is now a blocking gate on PRs into main; a cleanup-failed-prerelease job auto-deletes an orphaned prerelease tag when a release run doesn't complete (automates the by-hand beta.2/beta.3 cleanup).

**Phase 3 (assembly-only Docker, with the critique's ABI fix)** — new `runtime-assembled` Dockerfile stage copies a prebuilt install tree (no vcpkg recompile); `runtime`/`--from=ci` stays as the cold-build gate CI's docker-verify runs. _build.yml uploads installtree-linux-gcc (built on the 25.04 runner so ABI matches the base); docker-publish assembles from it; the pull-&-run smoke test is the ABI guard. `.dockerignore` has an explicit `!docker/context` carve-out.

**Phase 4 (consumers stop recompiling)** — e2e-ui downloads the install-tree artifact instead of building the app.

**Phase 6 (opt-in auto-tag)** — auto-tag.yml advances the prerelease counter on push to main when AUTO_TAG_ENABLED=true (git-describe-compatible; base bumps stay manual; manual hand-push stays the default).

Validation: PR CI exercises the build matrix, e2e-via-artifact, and the from-source docker-verify (the refactored Dockerfile). A release dry-run exercises the install-tree production + packaging. The **assembled docker-publish** path runs only on a real release (dry-run skips it), so it's validated locally (assembled image built from a real install tree + run) and its true acceptance is the next real release.