### PR TITLE
ci(runners): serialize code-scanning jobs + opt-in ephemeral runners

### DIFF
--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -40,7 +40,8 @@ jobs:
       github.head_ref != 'develop' ||
       github.base_ref != 'main'
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
-    timeout-minutes: 360
+    # Fail fast on a hung/dying runner instead of hanging for hours.
+    timeout-minutes: 180
     permissions:
       actions: read
       contents: read
@@ -134,11 +135,18 @@ jobs:
   ##
 
   CodeScanning_SonarCloud:
-    # Skip a develop->main promotion PR (already scanned on develop entry).
+    # Serialized AFTER CodeQL so only one heavy instrumented build runs at a time on
+    # the single-host self-hosted infra (the contention that was killing scan jobs).
+    # !cancelled() decouples pass/fail: this still runs after CodeQL finishes whatever
+    # CodeQL's result (just not on a cancel), so a CodeQL failure doesn't block it.
+    # Skipped on a develop->main promotion (guard below).
+    needs: [CodeScanning_CodeQL]
     if: >-
-      github.event_name != 'pull_request' ||
-      github.head_ref != 'develop' ||
-      github.base_ref != 'main'
+      !cancelled() &&
+      (github.event_name != 'pull_request' ||
+       github.head_ref != 'develop' ||
+       github.base_ref != 'main')
+    timeout-minutes: 120
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
@@ -208,11 +216,16 @@ jobs:
   ##
 
   CodeScanning_MSVCCodeAnalysis:
-    # Skip a develop->main promotion PR (already scanned on develop entry).
+    # Serialized AFTER SonarCloud so the heavy Windows analysis build never overlaps
+    # the Linux scans on the shared ESXi host. !cancelled() lets it run regardless of
+    # the upstream result (just not on a cancel). Skipped on a develop->main promotion.
+    needs: [CodeScanning_SonarCloud]
     if: >-
-      github.event_name != 'pull_request' ||
-      github.head_ref != 'develop' ||
-      github.base_ref != 'main'
+      !cancelled() &&
+      (github.event_name != 'pull_request' ||
+       github.head_ref != 'develop' ||
+       github.base_ref != 'main')
+    timeout-minutes: 120
     runs-on: ${{ fromJSON(vars.RUNNER_WINDOWS || '["windows-latest"]') }}
     # ilammy/msvc-dev-cmd is a Node 20 action with no Node 24 release; opt it into the
     # Node 24 runtime now (forced by GitHub from 2026-06-16) to clear the warning.

--- a/cicd/packer/README.md
+++ b/cicd/packer/README.md
@@ -136,6 +136,47 @@ On first boot, the auto-registration service reads the guestinfo variables and r
 - **Linux**: systemd service (`github-runner-register.service`) runs at boot
 - **Windows**: Scheduled task (`GitHubRunnerAutoRegister`) runs at startup
 
+### 4b. (Optional) Ephemeral mode for heavy/contended jobs
+
+Persistent runners accumulate state between jobs — stale `_work` trees, orphaned
+compiler processes (`cc1plus`/`cl.exe`/`mspdbsrv`), and thin-disk balloon. On a
+single oversubscribed ESXi host this is the main cause of the flaky deaths in the
+heavy code-scanning jobs (CodeQL / SonarCloud / MSVC analysis), where a job is
+reported "cancelled" mid-build with orphaned processes left behind.
+
+**Ephemeral mode** makes each runner take exactly one job, then re-register fresh,
+so every job starts on a pristine runner. It is **opt-in**: set one extra guestinfo
+variable and the auto-register script switches modes (no template change needed —
+the loop is already baked in).
+
+| Variable | Value |
+|----------|-------|
+| `guestinfo.runner_pat` | A fine-grained PAT with **Administration: read & write** on this repo (used to mint a fresh single-use registration token per job) |
+
+```bash
+govc vm.change -vm github-runner-windows \
+  -e guestinfo.runner_pat="github_pat_XXXXXXXX" \
+  -e guestinfo.runner_repo="https://github.com/{owner}/aqualink-automate" \
+  -e guestinfo.runner_name="windows-runner" \
+  -e guestinfo.runner_labels="self-hosted,windows,x64"
+```
+
+When `guestinfo.runner_pat` is set, `guestinfo.runner_token` is **not** required
+(the loop mints its own tokens). Without the PAT, the runner stays in the default
+persistent (`--runasservice`) mode using `runner_token` as before.
+
+> **Security tradeoff:** the PAT is stored on the runner VM (`.ephemeral-env`,
+> chmod 600, on Linux). Scope it to *only* this repo with the minimum
+> `Administration: write` permission, and rotate it if a VM is decommissioned. If
+> that tradeoff is unacceptable, keep persistent mode and instead rely on the
+> serialized scan ordering (CodeQL → SonarCloud → MSVC) in
+> `.github/workflows/automated-codescanning.yml`, which already ensures only one
+> instrumented build runs at a time on the single host.
+
+**Roll out on ONE runner first** and watch a full scan cycle before converting the
+fleet — the ephemeral scripts have not been exercised end-to-end against live
+vSphere from this change.
+
 ### 5. Enable in workflows
 
 Set these **repository variables** in GitHub (Settings > Variables > Actions):

--- a/cicd/packer/scripts/linux/08-github-runner.sh
+++ b/cicd/packer/scripts/linux/08-github-runner.sh
@@ -81,13 +81,16 @@ REPO_URL=$(get_guestinfo "runner_repo")
 TOKEN=$(get_guestinfo "runner_token")
 NAME=$(get_guestinfo "runner_name")
 LABELS=$(get_guestinfo "runner_labels")
+PAT=$(get_guestinfo "runner_pat")
 
 # Fall back to defaults
 NAME="${NAME:-$(hostname)}"
 LABELS="${LABELS:-self-hosted,linux,x64}"
 
-if [ -z "$REPO_URL" ] || [ -z "$TOKEN" ]; then
-    echo "Missing guestinfo.runner_repo or guestinfo.runner_token, skipping auto-register"
+# Need the repo, plus EITHER a one-shot registration token (persistent mode) OR a PAT
+# (ephemeral mode, which mints its own tokens each loop).
+if [ -z "$REPO_URL" ] || { [ -z "$TOKEN" ] && [ -z "$PAT" ]; }; then
+    echo "Missing guestinfo.runner_repo, or neither runner_token nor runner_pat set — skipping auto-register"
     exit 0
 fi
 
@@ -99,25 +102,101 @@ if [ -n "$NAME" ]; then
     hostnamectl set-hostname "${NAME}" || true
 fi
 
-echo "Registering runner '${NAME}' for ${REPO_URL}"
-
 cd "${RUNNER_DIR}"
-sudo -u runner ./config.sh \
-    --url "${REPO_URL}" \
-    --token "${TOKEN}" \
-    --name "${NAME}" \
-    --labels "${LABELS}" \
-    --unattended \
-    --replace
 
-# Install and start the runner service
-./svc.sh install runner
-./svc.sh start
+if [ -n "${PAT}" ]; then
+    # Ephemeral mode: one job per registration, then re-register fresh -> every job
+    # runs on a pristine runner (no accumulated _work/_temp corruption, orphaned
+    # compiler processes, or thin-disk balloon between jobs). ephemeral-loop.sh and
+    # its service are baked into the template; here we just persist the per-clone
+    # config and start the loop.
+    echo "Ephemeral mode: starting the ephemeral runner loop for '${NAME}'"
+    cat > "${RUNNER_DIR}/.ephemeral-env" <<ENVV
+REPO_URL=${REPO_URL}
+OWNER_REPO=${REPO_URL#https://github.com/}
+RUNNER_NAME=${NAME}
+RUNNER_LABELS=${LABELS}
+RUNNER_PAT=${PAT}
+ENVV
+    chmod 600 "${RUNNER_DIR}/.ephemeral-env"
+    chown runner:runner "${RUNNER_DIR}/.ephemeral-env"
+    systemctl enable --now github-runner-ephemeral.service
+else
+    # Persistent mode (default): register once with the one-shot token, run as a service.
+    echo "Registering persistent runner '${NAME}' for ${REPO_URL}"
+    sudo -u runner ./config.sh \
+        --url "${REPO_URL}" \
+        --token "${TOKEN}" \
+        --name "${NAME}" \
+        --labels "${LABELS}" \
+        --unattended \
+        --replace
+    ./svc.sh install runner
+    ./svc.sh start
+fi
 
 touch "$MARKER"
-echo "$(date): Runner registered and started successfully"
+echo "$(date): Runner setup complete"
 AUTOREGISTER
 chmod +x "${RUNNER_DIR}/auto-register.sh"
+
+# Ephemeral runner loop (used ONLY when guestinfo.runner_pat is set; auto-register.sh
+# enables the service below in that case). One job per registration, then re-register
+# fresh, so every job runs on a pristine runner.
+cat > "${RUNNER_DIR}/ephemeral-loop.sh" <<'LOOP'
+#!/usr/bin/env bash
+set -uo pipefail
+RUNNER_DIR=/home/runner/actions-runner
+cd "$RUNNER_DIR"
+# shellcheck disable=SC1091
+[ -f "$RUNNER_DIR/.ephemeral-env" ] && source "$RUNNER_DIR/.ephemeral-env"
+if [ -z "${RUNNER_PAT:-}" ] || [ -z "${OWNER_REPO:-}" ]; then
+    echo "ephemeral-loop: missing .ephemeral-env config; idling"; sleep 300; exit 1
+fi
+while true; do
+    # Mint a fresh single-use registration token (the PAT needs Administration:write).
+    TOKEN=$(curl -fsSL -X POST \
+        -H "Authorization: Bearer ${RUNNER_PAT}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${OWNER_REPO}/actions/runners/registration-token" \
+        | grep -oP '"token"\s*:\s*"\K[^"]+' || true)
+    if [ -z "${TOKEN:-}" ]; then
+        echo "ephemeral-loop: could not mint a registration token; retrying in 30s"
+        sleep 30; continue
+    fi
+    ./config.sh --url "$REPO_URL" --token "$TOKEN" --ephemeral \
+        --name "$RUNNER_NAME" --labels "$RUNNER_LABELS" --unattended --replace \
+        || { echo "ephemeral-loop: config failed; retrying in 30s"; sleep 30; continue; }
+    # Runs exactly ONE job, then exits and de-registers (ephemeral).
+    ./run.sh || true
+    # Reset state before the next registration: stale workdirs + orphaned build procs.
+    rm -rf "$RUNNER_DIR"/_work/* 2>/dev/null || true
+    pkill -u runner -f 'cc1plus|cc1|lto1|ninja' 2>/dev/null || true
+done
+LOOP
+chmod +x "${RUNNER_DIR}/ephemeral-loop.sh"
+chown runner:runner "${RUNNER_DIR}/ephemeral-loop.sh"
+
+cat > /etc/systemd/system/github-runner-ephemeral.service <<'UNIT'
+[Unit]
+Description=GitHub Actions Ephemeral Runner Loop
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=runner
+WorkingDirectory=/home/runner/actions-runner
+ExecStart=/home/runner/actions-runner/ephemeral-loop.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+# Intentionally NOT enabled here — auto-register.sh enables it only when
+# guestinfo.runner_pat is set (ephemeral mode).
 
 # Install systemd service for auto-registration on first boot
 cat > /etc/systemd/system/github-runner-register.service <<'UNIT'

--- a/cicd/packer/scripts/windows/05-github-runner.ps1
+++ b/cicd/packer/scripts/windows/05-github-runner.ps1
@@ -56,13 +56,6 @@ $Log = "C:\runner-auto-register.log"
 Start-Transcript -Path $Log -Append
 Write-Host "$(Get-Date): Auto-register started"
 
-# Skip if already registered
-if (Test-Path $Marker) {
-    Write-Host "Runner already registered, skipping"
-    Stop-Transcript
-    exit 0
-}
-
 # Read guestinfo variables (set on the VM in vSphere)
 # Note: Must use Start-Process or cmd /c to preserve the single-argument
 # semantics of --cmd "info-get guestinfo.xxx".  PowerShell's & operator
@@ -89,31 +82,63 @@ $RepoUrl = Get-GuestInfo "runner_repo"
 $Token   = Get-GuestInfo "runner_token"
 $Name    = Get-GuestInfo "runner_name"
 $Labels  = Get-GuestInfo "runner_labels"
+$Pat     = Get-GuestInfo "runner_pat"
 
 # Fall back to defaults
 if (-not $Name)   { $Name = $env:COMPUTERNAME }
 if (-not $Labels) { $Labels = "self-hosted,windows,x64" }
 
-if (-not $RepoUrl -or -not $Token) {
-    Write-Host "Missing guestinfo.runner_repo or guestinfo.runner_token, skipping auto-register"
+# Need the repo, plus EITHER a one-shot registration token (persistent) OR a PAT
+# (ephemeral mode, which mints its own tokens each loop).
+if (-not $RepoUrl -or (-not $Token -and -not $Pat)) {
+    Write-Host "Missing guestinfo.runner_repo, or neither runner_token nor runner_pat set; skipping auto-register"
     Stop-Transcript
     exit 0
 }
 
-Write-Host "Registering runner '$Name' for $RepoUrl"
-
-$ErrorActionPreference = "Stop"
-& "$RunnerDir\config.cmd" `
-    --url $RepoUrl `
-    --token $Token `
-    --name $Name `
-    --labels $Labels `
-    --unattended `
-    --replace `
-    --runasservice
-
-New-Item -ItemType File -Path $Marker -Force | Out-Null
-Write-Host "$(Get-Date): Runner registered and started successfully"
+if ($Pat) {
+    # Ephemeral mode: one job per registration, then re-register fresh -> every job
+    # runs on a pristine runner (no accumulated _work corruption or orphaned cl.exe /
+    # mspdbsrv between jobs). Needs a PAT (Administration:write) to mint a fresh
+    # registration token per loop. This boot-time task runs the loop forever (no
+    # marker), so a reboot re-enters the loop.
+    Write-Host "Ephemeral mode: starting the ephemeral runner loop for '$Name'"
+    $ownerRepo = $RepoUrl -replace '^https://github.com/', ''
+    while ($true) {
+        try {
+            $resp = Invoke-RestMethod -Method Post `
+                -Uri "https://api.github.com/repos/$ownerRepo/actions/runners/registration-token" `
+                -Headers @{ Authorization = "Bearer $Pat"; Accept = "application/vnd.github+json"; "X-GitHub-Api-Version" = "2022-11-28" }
+            $tok = $resp.token
+        } catch { Write-Host "ephemeral-loop: token mint failed: $_"; Start-Sleep -Seconds 30; continue }
+        if (-not $tok) { Write-Host "ephemeral-loop: empty token; retrying in 30s"; Start-Sleep -Seconds 30; continue }
+        & "$RunnerDir\config.cmd" --url $RepoUrl --token $tok --ephemeral --name $Name --labels $Labels --unattended --replace
+        # Runs exactly ONE job, then exits and de-registers (ephemeral).
+        & "$RunnerDir\run.cmd"
+        # Reset state before the next registration.
+        Remove-Item "$RunnerDir\_work\*" -Recurse -Force -ErrorAction SilentlyContinue
+        Get-Process cl, mspdbsrv, vctip, ninja -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    }
+} else {
+    # Persistent mode (default): register once and run as a service.
+    if (Test-Path $Marker) {
+        Write-Host "Runner already registered (persistent), skipping"
+        Stop-Transcript
+        exit 0
+    }
+    Write-Host "Registering persistent runner '$Name' for $RepoUrl"
+    $ErrorActionPreference = "Stop"
+    & "$RunnerDir\config.cmd" `
+        --url $RepoUrl `
+        --token $Token `
+        --name $Name `
+        --labels $Labels `
+        --unattended `
+        --replace `
+        --runasservice
+    New-Item -ItemType File -Path $Marker -Force | Out-Null
+    Write-Host "$(Get-Date): Runner registered and started successfully"
+}
 Stop-Transcript
 '@
 $autoRegisterScript | Set-Content -Path "$RunnerDir\auto-register.ps1" -Encoding UTF8


### PR DESCRIPTION
## What & why

The automated **code-scanning** workflow has been the least reliable thing on the single-host self-hosted runner infra. Two independent causes, two independent fixes — both opt-in/low-risk.

### #2 — Serialize/isolate the heavy scans  (`automated-codescanning.yml`)
The three instrumented builds (CodeQL, SonarCloud, MSVC analysis) were running **concurrently on one oversubscribed ESXi host**, thrashing it.

- Chain them `CodeQL → SonarCloud → MSVC` via `needs:` so **only one heavy build runs at a time** on the shared host.
- Keep pass/fail **decoupled** with `if: !cancelled() && (existing develop→main guard)` — a failed/slow upstream scan no longer blocks the next one; only an actual workflow cancel stops the chain.
- Tighten timeouts (CodeQL `360→180`; add `120` to the two downstream) so a hung/dying runner **fails fast** instead of hanging for hours.

### #1 — Opt-in ephemeral runners  (packer scripts + README)
Persistent runners accumulate stale `_work` trees + orphaned compiler processes (`cc1plus`/`cl.exe`/`mspdbsrv`) between jobs — the state corruption behind the "cancelled mid-build" deaths.

- When **`guestinfo.runner_pat`** is set, `auto-register` runs an ephemeral loop: mint a fresh single-use registration token → `config --ephemeral` → run **exactly one job** → reset (`_work` wipe + kill orphaned build procs) → re-register. **Every job starts pristine.**
- **Linux:** baked-in `github-runner-ephemeral.service` + `ephemeral-loop.sh`, enabled by `auto-register.sh` only when the PAT is present.
- **Windows:** the auto-register scheduled task runs the loop inline; the `.registered` marker is confined to persistent mode so a reboot re-enters the loop.
- **Default unchanged:** no PAT ⇒ persistent `--runasservice` mode exactly as before. No template rebuild needed to flip a VM to ephemeral.

## Risk / rollout
- ⚠️ The ephemeral scripts are **untested against live vSphere from here** — they parse clean and mirror the existing persistent path, but have not been exercised end-to-end. **Roll out on ONE runner and watch a full scan cycle before converting the fleet.**
- 🔑 The PAT is a **credential stored on the runner VM** (`.ephemeral-env`, chmod 600 on Linux). Scope it to *only this repo* with the minimum **Administration: write** permission and rotate it when a VM is decommissioned. README documents this tradeoff; if unacceptable, the serialized-scan change (#2) stands on its own.

## Validation done here
- `automated-codescanning.yml` — YAML parses; `needs:`/`if:`/`timeout` wiring confirmed.
- Linux `08-github-runner.sh` — `bash -n` on the outer script **and** both extracted heredocs (`auto-register.sh`, `ephemeral-loop.sh`).
- Windows `05-github-runner.ps1` — PowerShell parser on the outer script **and** the inner `auto-register.ps1` here-string.
