### PR TITLE
Release v0.2.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ No tagged release has been cut yet, so everything below lives under **Unreleased
 - **Scheduler.** Run time-based automation from a schedules file with `--schedules-file`, managed over a CRUD API: `GET`/`POST /api/schedules` (POST creates a schedule, returning `201` plus the new entity) and `GET/PUT/DELETE /api/schedules/{uuid}`.
 - **Preferences and equipment cache.** Persist user preferences with `--preferences-file` (exposed at `/api/preferences`) and cache discovered equipment with `--equipment-cache-file`. When the respective file option is empty, the feature stays in memory only or disabled.
 - **Alerting.** Raise alerts on low salt and serial communications loss, and POST every alert transition to a webhook with `--alert-webhook-url`.
+- **Configurable container user (`PUID`/`PGID`).** The Docker image runs the app as a configurable uid:gid instead of a hard-coded `10000`. Set `PUID`/`PGID` (defaults `10000`); the entrypoint starts as root, remaps its user, chowns `/data`, then drops privileges to that user via `gosu`. `PUID=0` keeps it running as root. Bind-mounted read-only config still needs to be readable by the chosen uid on the host.
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,12 +171,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ca-certificates for TLS; curl for the container HEALTHCHECK (also used here to
 # import the NodeSource signing key); tini as a tiny init that reaps zombies and
 # forwards signals to docker-entrypoint.sh (which supervises the app + Matter
-# sidecar); Node.js 22 (NodeSource) to run the Matter bridge sidecar. gnupg is only
+# sidecar); Node.js 22 (NodeSource) to run the Matter bridge sidecar; gosu so the
+# entrypoint can drop from root to the configurable PUID/PGID. gnupg is only
 # needed to import the key, so it is purged afterwards; curl is intentionally kept
 # (a few hundred KB) so the HEALTHCHECK and compose examples can use the standard
 # `curl --fail` probe.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl gnupg tini \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg tini gosu \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
@@ -205,9 +206,14 @@ RUN mkdir -p /data/matter && chown -R aqualink:aqualink /data/matter
 # through Docker's bridge driver, so EXPOSE alone is insufficient for Matter.
 EXPOSE 80
 
+# PUID/PGID: the uid:gid the app is run as. The entrypoint (started as root) remaps
+# the bundled `aqualink` user to these, chowns the writable paths, then drops to them
+# via gosu. Override per-deployment; PUID=0 keeps the container running as root.
 ENV MATTER_ENABLED=true \
     MATTER_STORAGE_PATH=/data/matter \
-    AQUALINK_API_URL=http://127.0.0.1:80
+    AQUALINK_API_URL=http://127.0.0.1:80 \
+    PUID=10000 \
+    PGID=10000
 
 # Container liveness probe: GET /api/health (unauthenticated by design, so it works
 # even when --api-auth-token is set). `curl --fail` exits non-zero on any status >= 400
@@ -242,7 +248,8 @@ CMD ["--address", "0.0.0.0", "--disable-https"]
 FROM runtime-base AS runtime
 
 COPY --from=ci /src/install/config-linux-gcc/ .
-USER aqualink
+# No USER directive: the image starts as root so the entrypoint can apply PUID/PGID
+# and drop privileges via gosu (set PUID=0 to stay root). See docker-entrypoint.sh.
 
 # ==============================================================================
 # Stage: runtime-assembled (prebuilt install tree — no recompile)
@@ -264,4 +271,5 @@ FROM runtime-base AS runtime-assembled
 # versioned-.so symlinks the binary loads by SONAME).
 COPY docker/context/installtree-linux-gcc.tar.gz /tmp/installtree.tar.gz
 RUN tar xzf /tmp/installtree.tar.gz -C /opt/aqualink-automate && rm /tmp/installtree.tar.gz
-USER aqualink
+# No USER directive: starts as root; the entrypoint applies PUID/PGID then drops
+# privileges via gosu (set PUID=0 to stay root). See docker-entrypoint.sh.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,9 @@
 # Container entrypoint: launch the Matter bridge sidecar (unless opted out) and the
 # aqualink-automate app, supervise both, forward termination signals to both, and
 # bring the container down if EITHER exits. tini is PID 1 (see the Dockerfile
-# ENTRYPOINT) and reaps zombies + forwards signals to this script.
+# ENTRYPOINT) and reaps zombies + forwards signals to this script. When started as
+# root it first applies the configurable PUID/PGID (default 10000) and drops
+# privileges to that user via gosu.
 #
 # Opt out of Matter with MATTER_ENABLED=false (mirrors the app's --matter false).
 # Everything after the script name is forwarded verbatim to the app (the image CMD).
@@ -12,6 +14,30 @@ set -euo pipefail
 
 APP=/opt/aqualink-automate/bin/aqualink-automate
 SIDECAR=/opt/matter-bridge/dist/index.js
+
+# ── Privilege drop (configurable PUID/PGID) ─────────────────────────────────
+# The image starts as root. Remap the bundled `aqualink` user to the requested
+# PUID/PGID (defaults 10000), fix ownership of the writable paths, then re-exec
+# this script as that unprivileged user via gosu. Set PUID=0 to stay root.
+# If the container is started as non-root (e.g. via the compose `user:` directive)
+# this branch is skipped and the caller is responsible for owning the bind mounts.
+PUID="${PUID:-10000}"
+PGID="${PGID:-10000}"
+
+if [ "$(id -u)" = "0" ]; then
+    if [ "$PUID" != "0" ]; then
+        groupmod -o -g "$PGID" aqualink
+        usermod  -o -u "$PUID" -g "$PGID" aqualink
+    fi
+    # /etc/aqualink is a read-only config mount, so it is intentionally NOT chowned
+    # here; the config must be readable by PUID on the host instead.
+    chown -R "$PUID:$PGID" /data /home/aqualink 2>/dev/null || true
+    if [ "$PUID" != "0" ]; then
+        echo "[entrypoint] dropping privileges to ${PUID}:${PGID}"
+        exec gosu "$PUID:$PGID" "$0" "$@"
+    fi
+    echo "[entrypoint] PUID=0 requested; continuing as root"
+fi
 
 pids=""
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 #
-# Container entrypoint: launch the Matter bridge sidecar (unless opted out) and the
-# aqualink-automate app, supervise both, forward termination signals to both, and
-# bring the container down if EITHER exits. tini is PID 1 (see the Dockerfile
-# ENTRYPOINT) and reaps zombies + forwards signals to this script. When started as
-# root it first applies the configurable PUID/PGID (default 10000) and drops
-# privileges to that user via gosu.
+# Container entrypoint: launch the aqualink-automate app (authoritative) plus the
+# Matter bridge sidecar (supervised, restartable, NON-fatal), forward termination
+# signals to both, and bring the container down ONLY when the app exits. tini is
+# PID 1 (see the Dockerfile ENTRYPOINT) and reaps zombies + forwards signals to this
+# script. When started as root it first applies the configurable PUID/PGID (default
+# 10000) and drops privileges to that user via gosu.
+#
+# Process model:
+#   - The APP is the primary service: when it exits, the container exits with the
+#     app's status (and the orchestrator's restart policy reacts).
+#   - The Matter SIDECAR is secondary: if it crashes it is restarted with capped
+#     backoff, and a sidecar failure never takes the pool controller (the app)
+#     offline -- a Matter/mDNS hiccup must not knock out pool automation.
 #
 # Opt out of Matter with MATTER_ENABLED=false (mirrors the app's --matter false).
 # Everything after the script name is forwarded verbatim to the app (the image CMD).
@@ -39,36 +46,90 @@ if [ "$(id -u)" = "0" ]; then
     echo "[entrypoint] PUID=0 requested; continuing as root"
 fi
 
-pids=""
+BACKOFF_MAX=15   # cap the sidecar restart backoff (seconds)
 
+app_pid=""
+sidecar_pid=""
+matter_enabled=0
+shutting_down=0
+status=0
+
+start_sidecar() {
+    node "$SIDECAR" &
+    sidecar_pid=$!
+    echo "[entrypoint] Matter bridge sidecar started (pid $sidecar_pid)"
+}
+
+# SIGTERM/SIGINT: forward to both children and stop supervising. The app's own
+# shutdown then drives the exit below.
 terminate() {
-    # Forward the signal to every child; ignore "no such process" races.
-    [ -n "$pids" ] && kill -TERM $pids 2>/dev/null || true
+    shutting_down=1
+    [ -n "$sidecar_pid" ] && kill -TERM "$sidecar_pid" 2>/dev/null || true
+    [ -n "$app_pid" ]     && kill -TERM "$app_pid" 2>/dev/null || true
 }
 trap terminate TERM INT
 
-if [ "${MATTER_ENABLED:-true}" != "false" ]; then
-    if command -v node >/dev/null 2>&1 && [ -f "$SIDECAR" ]; then
-        echo "[entrypoint] starting Matter bridge sidecar"
-        node "$SIDECAR" &
-        pids="$pids $!"
-    else
-        echo "[entrypoint] Matter enabled but the sidecar/node runtime is missing; skipping"
-    fi
-else
-    echo "[entrypoint] Matter disabled (MATTER_ENABLED=false); not starting the sidecar"
-fi
+# Interruptible sleep: an incoming signal runs the trap and unblocks the wait
+# immediately (a foreground `sleep` would keep blocking for its full duration).
+nap() {
+    sleep "$1" &
+    wait $! 2>/dev/null || true
+}
 
 echo "[entrypoint] starting aqualink-automate"
 "$APP" "$@" &
-pids="$pids $!"
+app_pid=$!
 
-# Exit as soon as ANY supervised process exits, so a crashed app or sidecar takes
-# the container down (and the orchestrator's restart policy can react).
-wait -n
-status=$?
+if [ "${MATTER_ENABLED:-true}" = "false" ]; then
+    echo "[entrypoint] Matter disabled (MATTER_ENABLED=false); not starting the sidecar"
+elif ! command -v node >/dev/null 2>&1 || [ ! -f "$SIDECAR" ]; then
+    echo "[entrypoint] Matter enabled but the sidecar/node runtime is missing; skipping (the app runs without it)"
+else
+    matter_enabled=1
+    start_sidecar
+fi
 
-echo "[entrypoint] a supervised process exited (status $status); stopping the rest"
+# Supervise: wait for whichever child exits next (-p records which). The app exiting
+# is terminal; the sidecar exiting is recoverable (restart with capped backoff), so a
+# Matter failure never takes the container (the pool controller) down.
+backoff=1
+while :; do
+    # `wait -p` UNSETS the variable when no job is reaped (e.g. a signal interrupts
+    # the wait), so normalise it afterwards to stay safe under `set -u`.
+    if wait -n -p reaped; then rc=0; else rc=$?; fi
+    reaped="${reaped:-}"
+
+    # A signal interrupted the wait (nothing actually reaped). If the app is gone,
+    # fall through to shutdown; otherwise keep supervising.
+    if [ -z "$reaped" ]; then
+        kill -0 "$app_pid" 2>/dev/null || break
+        continue
+    fi
+
+    if [ "$reaped" = "$app_pid" ]; then
+        status=$rc
+        app_pid=""
+        echo "[entrypoint] aqualink-automate exited (status $status); stopping the container"
+        break
+    fi
+
+    if [ "$matter_enabled" -eq 1 ] && [ "$reaped" = "$sidecar_pid" ]; then
+        sidecar_pid=""
+        [ "$shutting_down" -eq 0 ] || break
+        echo "[entrypoint] Matter sidecar exited (status $rc); restarting in ${backoff}s (the app keeps running)"
+        nap "$backoff"
+        [ "$shutting_down" -eq 0 ] || break
+        # Only restart while the app is still alive. If the app died during the
+        # backoff, do NOT break here: loop back so `wait -n` reaps its real exit
+        # status (breaking here would lose it and exit the container with 0).
+        if kill -0 "$app_pid" 2>/dev/null; then
+            backoff=$(( backoff < BACKOFF_MAX ? backoff * 2 : BACKOFF_MAX ))
+            start_sidecar
+        fi
+    fi
+done
+
+echo "[entrypoint] shutting down; stopping any remaining supervised process"
 terminate
-wait || true
+wait 2>/dev/null || true
 exit "$status"

--- a/matter-bridge/src/bridge.ts
+++ b/matter-bridge/src/bridge.ts
@@ -15,7 +15,6 @@ import {
   TemperatureSensorDevice,
 } from "@matter/main/devices";
 import { BridgedDeviceBasicInformationServer } from "@matter/main/behaviors/bridged-device-basic-information";
-import { ThermostatServer } from "@matter/main/behaviors/thermostat";
 import { Thermostat } from "@matter/main/clusters";
 
 import type { BridgeConfig } from "./config.js";
@@ -25,6 +24,7 @@ import {
   type TemperatureSensorSpec,
   MatterKind,
 } from "./device-map.js";
+import { AqualinkIdentifyServer, AqualinkThermostatServer } from "./matter-servers.js";
 
 /** Celsius -> Matter centi-degrees (1/100 °C), the wire unit for measured/setpoint. */
 const toCenti = (c: number): number => Math.round(c * 100);
@@ -181,7 +181,7 @@ export class MatterBridge {
   }
 
   private async addOnOff(device: BridgedDevice): Promise<void> {
-    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(BridgedDeviceBasicInformationServer), {
+    const endpoint = new Endpoint(OnOffPlugInUnitDevice.with(BridgedDeviceBasicInformationServer, AqualinkIdentifyServer), {
       id: MatterBridge.endpointId("aux", device.uuid),
       bridgedDeviceBasicInformation: this.bridgedBasicInfo(device),
       onOff: { onOff: device.on },
@@ -203,7 +203,7 @@ export class MatterBridge {
 
   private async addChlorinator(device: BridgedDevice): Promise<void> {
     const level = Math.max(0, Math.min(254, device.level ?? 0));
-    const endpoint = new Endpoint(DimmablePlugInUnitDevice.with(BridgedDeviceBasicInformationServer), {
+    const endpoint = new Endpoint(DimmablePlugInUnitDevice.with(BridgedDeviceBasicInformationServer, AqualinkIdentifyServer), {
       id: MatterBridge.endpointId("swg", device.uuid),
       bridgedDeviceBasicInformation: this.bridgedBasicInfo(device),
       onOff: { onOff: device.on },
@@ -225,7 +225,7 @@ export class MatterBridge {
   private async addThermostat(device: BridgedDevice): Promise<void> {
     // A heat-only thermostat: localTemperature (read) + occupiedHeatingSetpoint (write).
     const endpoint = new Endpoint(
-      ThermostatDevice.with(BridgedDeviceBasicInformationServer, ThermostatServer.with("Heating")),
+      ThermostatDevice.with(BridgedDeviceBasicInformationServer, AqualinkIdentifyServer, AqualinkThermostatServer),
       {
         id: MatterBridge.endpointId("heat", device.uuid),
         bridgedDeviceBasicInformation: this.bridgedBasicInfo(device),
@@ -299,7 +299,7 @@ export class MatterBridge {
         await setState(existing, { temperatureMeasurement: { measuredValue: measured } });
         continue;
       }
-      const endpoint = new Endpoint(TemperatureSensorDevice.with(BridgedDeviceBasicInformationServer), {
+      const endpoint = new Endpoint(TemperatureSensorDevice.with(BridgedDeviceBasicInformationServer, AqualinkIdentifyServer), {
         id: `temp-${spec.id}`,
         bridgedDeviceBasicInformation: {
           nodeLabel: spec.label,

--- a/matter-bridge/src/matter-servers.ts
+++ b/matter-bridge/src/matter-servers.ts
@@ -1,0 +1,93 @@
+/**
+ * Custom matter.js cluster servers that implement the mandatory command handlers the
+ * stock matter.js servers leave unimplemented.
+ *
+ * matter.js's `ValidatedElements` logs a warning for every mandatory command whose
+ * handler is still the default `Behavior.unimplemented` stub (which throws if a
+ * controller ever invokes it). Two such commands land on our bridged endpoints:
+ *
+ *   - Identify.triggerEffect       - on every endpoint (they all carry Identify)
+ *   - Thermostat.setpointRaiseLower - on every heater (Thermostat) endpoint
+ *
+ * Each previously produced, once per endpoint at startup:
+ *   WARN ValidatedElements  Error in IdentifyServer.triggerEffect: Throws unimplemented exception
+ *   WARN ValidatedElements  Error in ThermostatServer.setpointRaiseLower: Throws unimplemented exception
+ *
+ * Supplying real handlers both silences those warnings AND makes the commands work
+ * when a Matter controller (Apple Home / Google Home / Alexa / SmartThings) sends them.
+ */
+
+import { IdentifyServer } from "@matter/main/behaviors/identify";
+import { ThermostatServer } from "@matter/main/behaviors/thermostat";
+import { Identify, Thermostat } from "@matter/main/clusters";
+
+/**
+ * Identify server that accepts (and ignores) `triggerEffect`.
+ *
+ * `triggerEffect` asks a device to show a transient visual effect (blink / breathe /
+ * okay). Our endpoints are *bridged* pool equipment with no physical indicator to
+ * flash, so the spec-compliant behaviour is to accept the command as a no-op (§1.2.6.2
+ * leaves the effect entirely up to the implementer). The base `IdentifyServer` already
+ * implements the mandatory `identify` command; we only fill in the missing
+ * `triggerEffect`.
+ */
+export class AqualinkIdentifyServer extends IdentifyServer {
+  override triggerEffect(_request: Identify.TriggerEffectRequest): void {
+    // No physical identifier on a bridged device: accept the command and do nothing.
+  }
+}
+
+/**
+ * Compute the new heating setpoint (in centi-°C) for a relative SetpointRaiseLower.
+ *
+ * Per the Matter spec (§4.3.10.1) the `Amount` field is a signed value in steps of
+ * 0.1 °C that is *added* to the current setpoint, and the result is clamped to the
+ * configured limits (clamping is explicitly not an error). Setpoints are stored in
+ * centi-°C (0.01 °C), so one Amount step == 10 centi-°C.
+ *
+ * Pure (no matter.js state) so it can be unit-tested in isolation.
+ */
+export function raiseLowerHeatingSetpoint(opts: {
+  /** Current occupiedHeatingSetpoint, centi-°C. */
+  currentCenti: number;
+  /** Signed Amount field, in 0.1 °C steps. */
+  amountSteps: number;
+  /** minHeatSetpointLimit, centi-°C. */
+  minCenti: number;
+  /** maxHeatSetpointLimit, centi-°C. */
+  maxCenti: number;
+}): number {
+  const next = opts.currentCenti + opts.amountSteps * 10;
+  return Math.max(opts.minCenti, Math.min(opts.maxCenti, next));
+}
+
+// Matter spec defaults for the heat-setpoint limits, used only as a fallback if the
+// attributes are somehow unset (the bridge always configures explicit limits).
+const SPEC_DEFAULT_MIN_HEAT_CENTI = 700; // 7.00 °C
+const SPEC_DEFAULT_MAX_HEAT_CENTI = 3000; // 30.00 °C
+
+/**
+ * Heat-only Thermostat server implementing the mandatory `setpointRaiseLower` command.
+ *
+ * It moves `occupiedHeatingSetpoint` by the relative amount and clamps to the
+ * configured heating limits. Mutating the attribute fires `occupiedHeatingSetpoint$Changed`,
+ * which `bridge.ts` already forwards to the aqualink-automate setpoint API - so a
+ * relative adjustment from a controller reaches the pool controller exactly like an
+ * absolute one. The Heating feature is baked in here so `this.state` exposes the
+ * heat-setpoint attributes.
+ */
+export class AqualinkThermostatServer extends ThermostatServer.with("Heating") {
+  override setpointRaiseLower({ mode, amount }: Thermostat.SetpointRaiseLowerRequest): void {
+    // Heating-only endpoint: a Cool-only adjustment has no setpoint to move.
+    if (mode === Thermostat.SetpointRaiseLowerMode.Cool) {
+      return;
+    }
+
+    this.state.occupiedHeatingSetpoint = raiseLowerHeatingSetpoint({
+      currentCenti: this.state.occupiedHeatingSetpoint ?? 0,
+      amountSteps: amount,
+      minCenti: this.state.minHeatSetpointLimit ?? SPEC_DEFAULT_MIN_HEAT_CENTI,
+      maxCenti: this.state.maxHeatSetpointLimit ?? SPEC_DEFAULT_MAX_HEAT_CENTI,
+    });
+  }
+}

--- a/matter-bridge/test/matter-servers.test.ts
+++ b/matter-bridge/test/matter-servers.test.ts
@@ -1,0 +1,42 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { raiseLowerHeatingSetpoint } from "../src/matter-servers.js";
+
+// Setpoints + limits are centi-°C; Amount is in 0.1 °C steps (so 1 step == 10 centi).
+const LIMITS = { minCenti: 100, maxCenti: 4000 }; // matches bridge.ts addThermostat (1 °C .. 40 °C)
+
+test("raiseLowerHeatingSetpoint adds a positive amount", () => {
+  assert.equal(
+    raiseLowerHeatingSetpoint({ currentCenti: 2800, amountSteps: 5, ...LIMITS }),
+    2850, // 28.0 °C + 0.5 °C
+  );
+});
+
+test("raiseLowerHeatingSetpoint subtracts a negative amount", () => {
+  assert.equal(
+    raiseLowerHeatingSetpoint({ currentCenti: 2800, amountSteps: -10, ...LIMITS }),
+    2700, // 28.0 °C - 1.0 °C
+  );
+});
+
+test("raiseLowerHeatingSetpoint clamps to the max heat limit", () => {
+  assert.equal(
+    raiseLowerHeatingSetpoint({ currentCenti: 3950, amountSteps: 20, ...LIMITS }),
+    4000, // 39.5 + 2.0 = 41.5 -> clamped to 40.0 (not an error per spec)
+  );
+});
+
+test("raiseLowerHeatingSetpoint clamps to the min heat limit", () => {
+  assert.equal(
+    raiseLowerHeatingSetpoint({ currentCenti: 150, amountSteps: -20, ...LIMITS }),
+    100, // 1.5 - 2.0 = -0.5 -> clamped to 1.0
+  );
+});
+
+test("raiseLowerHeatingSetpoint is a no-op for amount 0", () => {
+  assert.equal(
+    raiseLowerHeatingSetpoint({ currentCenti: 2800, amountSteps: 0, ...LIMITS }),
+    2800,
+  );
+});

--- a/src/core/logging/logging_initialise.cpp
+++ b/src/core/logging/logging_initialise.cpp
@@ -33,6 +33,14 @@ void Initialise()
 	boost::shared_ptr<std::ostream> stream(&std::clog, boost::null_deleter());
 	sink->locked_backend()->add_stream(stream);
 
+	// Flush the underlying stream after every record. std::clog is fully buffered,
+	// so without this the records sit in the C++ stream buffer and are not written
+	// to stderr until the buffer fills or the process exits. Under a container
+	// (stdout/stderr is a pipe, not a TTY) that buffering makes `docker logs` appear
+	// to stall or truncate mid-startup and loses any buffered tail on a crash.
+	// auto_flush trades a little throughput for real-time, crash-safe log delivery.
+	sink->locked_backend()->auto_flush(true);
+
 	boost::log::add_common_attributes();
 	boost::log::core::get()->add_global_attribute("Scope", boost::log::attributes::named_scope());
 }


### PR DESCRIPTION
Cut v0.2.0-beta.4 from develop. Changes since v0.2.0-beta.3:

- feat(docker): configurable PUID/PGID; entrypoint drops privileges via gosu
- fix(docker): app-authoritative supervision; Matter sidecar non-fatal with capped-backoff restart
- fix(matter): implement Identify.triggerEffect and Thermostat.setpointRaiseLower
- fix(logging): flush std::clog after every record for real-time container logs

CI and a dry-run release both passed on develop.