### PR TITLE
Release v0.3.0-beta.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ needs.resolve-version.outputs.version_tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.resolve-version.outputs.version_tag }}
             type=raw,value=latest,enable=${{ needs.resolve-version.outputs.is_prerelease != 'true' }}
+            type=raw,value=edge,enable=${{ needs.resolve-version.outputs.is_prerelease == 'true' }}
 
       # Stage the prebuilt Linux install tree (built + version-stamped by
       # build-packages on the Ubuntu-25.04 runner) into the build context so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ See [docs/releasing.md](docs/releasing.md) for how releases and version numbers 
 
 ## [0.3.0-beta.2] - 2026-06-17
 
+### Changed
+
+- **Prerelease Docker images are tagged `edge`.** Stable releases continue to move the `latest` tag on GHCR; prereleases now move a rolling `edge` tag (in addition to the exact `<version>` tag), so you can track the newest prerelease with `ghcr.io/<owner>/aqualink-automate:edge`.
+
 ### Fixed
 
 - **Trends chart renders when the page opens.** The Trends graph could appear blank when the app opened directly on that view, because the chart tried to draw before its panel had been laid out. It now draws as soon as the panel has a size, and redraws on window resize.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.3.0-beta.2] - 2026-06-17
+
+### Fixed
+
+- **Trends chart renders when the page opens.** The Trends graph could appear blank when the app opened directly on that view, because the chart tried to draw before its panel had been laid out. It now draws as soon as the panel has a size, and redraws on window resize.
+- **Trends selections survive a reload.** The chosen metrics, time range, and the show-inactive toggle are remembered across page reloads.
+
 ## [0.3.0-beta.1] - 2026-06-17
 
 ### Added

--- a/assets/web/scripts/views/trends-view.js
+++ b/assets/web/scripts/views/trends-view.js
@@ -95,9 +95,29 @@ function trendsView() {
         _model: [],          // full model incl. hidden/inactive
 
         onShown() {
-            if (this._loaded) { this.render(); return; }
+            if (this._loaded) { this.refresh(); return; }
             this._loaded = true;
+            this._loadPrefs();
             this.loadSeries();
+        },
+
+        // Restore the last-used range / selection / inactive toggle across reloads.
+        _loadPrefs() {
+            try {
+                const p = JSON.parse(localStorage.getItem('aqualink.trends.prefs') || '{}');
+                if (typeof p.rangeSeconds === 'number') this.rangeSeconds = p.rangeSeconds;
+                if (typeof p.showInactive === 'boolean') this.showInactive = p.showInactive;
+                if (p.selected && typeof p.selected === 'object') this.selected = { ...p.selected };
+            } catch (_) { /* corrupt prefs — fall back to defaults */ }
+        },
+        _savePrefs() {
+            try {
+                localStorage.setItem('aqualink.trends.prefs', JSON.stringify({
+                    rangeSeconds: this.rangeSeconds,
+                    showInactive: this.showInactive,
+                    selected: this.selected,
+                }));
+            } catch (_) { /* storage unavailable — non-fatal */ }
         },
 
         // --- data ---------------------------------------------------------
@@ -199,9 +219,9 @@ function trendsView() {
 
         // --- interaction --------------------------------------------------
 
-        setRange(seconds) { this.rangeSeconds = seconds; this.refresh(); },
-        toggleSeries(key) { this.selected[key] = !this.selected[key]; this.refresh(); },
-        toggleInactive() { this.showInactive = !this.showInactive; this.refresh(); },
+        setRange(seconds) { this.rangeSeconds = seconds; this._savePrefs(); this.refresh(); },
+        toggleSeries(key) { this.selected[key] = !this.selected[key]; this._savePrefs(); this.refresh(); },
+        toggleInactive() { this.showInactive = !this.showInactive; this._savePrefs(); this.refresh(); },
 
         // Latest fetched value for a selected series (chip / used by stats).
         currentValue(key) {
@@ -238,6 +258,14 @@ function trendsView() {
                 this.$refs.trendsReadout.style.display = 'none';
                 this.draw();
             });
+            // The first draw can run while the view is still being laid out (the
+            // route just switched, so clientWidth is 0 and draw() bails). Redraw
+            // whenever the canvas gains or changes its layout size — this covers
+            // both the initial reveal and window resizes.
+            if (window.ResizeObserver) {
+                _trends.ro = new ResizeObserver(() => this.draw());
+                _trends.ro.observe(canvas);
+            }
         },
 
         // --- drawing ------------------------------------------------------
@@ -261,8 +289,14 @@ function trendsView() {
             const cssH = TOP + TH + GAP + CH + GAP + EH + AXH;
 
             const dpr = window.devicePixelRatio || 1;
-            canvas.width = cssW * dpr; canvas.height = cssH * dpr;
-            canvas.style.height = cssH + 'px';
+            // Only reassign the canvas size when it actually changes — resizing it
+            // alters its layout height and would re-trigger the ResizeObserver in a
+            // loop otherwise.
+            const wantW = Math.round(cssW * dpr), wantH = Math.round(cssH * dpr);
+            if (canvas.width !== wantW || canvas.height !== wantH) {
+                canvas.width = wantW; canvas.height = wantH;
+                canvas.style.height = cssH + 'px';
+            }
             ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
             ctx.clearRect(0, 0, cssW, cssH);
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -121,12 +121,13 @@ A dry run builds packages on all platforms without creating a GitHub Release or 
 
 After a release is published:
 
-1. **Curate the release notes to the established pattern (required).** The auto-generated body (`--generate-notes`) is only a starting point; rewrite it so the notes read as a coherent, user-facing changelog consistent with the previous releases. Use a prior release as the template (`gh release view v0.2.0-beta.1 --json body --jq .body`) and mirror the matching `## [x.y.z]` section of [CHANGELOG.md](../CHANGELOG.md). The pattern:
-   - A one-line **intro** summarising the release (e.g. "… on top of `v<prev>`").
-   - Thematic `##` **sections** — grouped by subsystem (e.g. *Trends*, *Web UI*) or as Added / Changed / Fixed — with **bold lead-in** bullets describing each change in user-facing terms (not raw commit subjects).
-   - An `## Artifacts` table (Linux / Windows / macOS / Docker, including the `ghcr.io/<owner>/aqualink-automate:<version>` image tag).
-   - The `**Full Changelog**: …/compare/v<prev>...v<this>` link (keep the one from the generated notes).
-   - For prereleases, a trailing `> Pre-release.` caveat blockquote (e.g. the unverified-Pentair-decoding caveat).
+1. **Curate the release notes to the established pattern (required).** The auto-generated body (`--generate-notes`) is only a starting point; rewrite it so the notes read as a coherent, user-facing changelog consistent with the previous releases. Use a prior release as the template (`gh release view v0.2.0-beta.1 --json body --jq .body`) and mirror the matching `## [x.y.z]` section of [CHANGELOG.md](../CHANGELOG.md). The structure, **in this order**:
+   1. `## What's Changed since v<prev>` heading (for the very first release: `## What's Changed`).
+   2. A one-line **summary** of the release.
+   3. The changes as `###` subsections — grouped by subsystem (e.g. *Trends*, *Web UI*) or as *Added* / *Changed* / *Fixed* — with **bold lead-in** bullets in user-facing terms (not raw commit subjects). A short release may use a flat **bold-lead-in** bullet list instead of subsections.
+   4. An `## Artifacts` section: the "Self-contained, SHA-512-summed" table (Linux / Windows / macOS / Docker, including the `ghcr.io/<owner>/aqualink-automate:<version>` image tag), then the `aqualink-automate --help` / [INSTALL.md](../INSTALL.md) pointer line.
+   5. The `**Full Changelog**: …/compare/v<prev>...v<this>` link (keep the one from the generated notes; omit for the first release).
+   6. For prereleases, a trailing `> **Pre-release.**` caveat blockquote (e.g. the unverified-Pentair-decoding caveat).
 
    Apply the curated body with:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -58,7 +58,7 @@ Before creating a release:
 1. CI is green on `main` (all platforms pass).
 2. All intended changes are merged to `main`. Real releases must be **cut from main**: the release commit has to be an ancestor of `origin/main`. The `resolve-version` job enforces this with `git merge-base --is-ancestor` and hard-fails any non-dry-run release whose commit is not contained in `main` (merge `develop` → `main` first, then tag `main`). Dry runs are exempt, so you can validate the pipeline from `develop`.
 3. Example configs in `examples/` are current.
-4. Release notes are reviewed. The `github-release` job auto-generates the notes with `gh release create --generate-notes` (from merged PRs and commits since the previous tag), so you do not hand-write them. Make sure [CHANGELOG.md](../CHANGELOG.md) and the relevant PR titles read well — that is what ends up in the generated notes. You can edit the published release body afterward if needed.
+4. Release notes are reviewed. The `github-release` job seeds the release body with `gh release create --generate-notes` (a flat list of merged PRs / commits since the previous tag) — treat that as a **first draft only**. Make sure [CHANGELOG.md](../CHANGELOG.md) and the PR titles read well (they feed the draft), then **curate the published body to the project's established pattern** — this is a required step, described under [Post-release](#post-release).
 5. Run a local build to verify version output: `./aqualink-automate --version`.
 
 ### Run the test suites by label
@@ -121,9 +121,22 @@ A dry run builds packages on all platforms without creating a GitHub Release or 
 
 After a release is published:
 
-1. Verify the GitHub Release page has all expected artifacts.
-2. Verify Docker images are published to GHCR.
-3. Verify the auto-generated release notes are accurate; edit the release body if anything reads poorly.
+1. **Curate the release notes to the established pattern (required).** The auto-generated body (`--generate-notes`) is only a starting point; rewrite it so the notes read as a coherent, user-facing changelog consistent with the previous releases. Use a prior release as the template (`gh release view v0.2.0-beta.1 --json body --jq .body`) and mirror the matching `## [x.y.z]` section of [CHANGELOG.md](../CHANGELOG.md). The pattern:
+   - A one-line **intro** summarising the release (e.g. "… on top of `v<prev>`").
+   - Thematic `##` **sections** — grouped by subsystem (e.g. *Trends*, *Web UI*) or as Added / Changed / Fixed — with **bold lead-in** bullets describing each change in user-facing terms (not raw commit subjects).
+   - An `## Artifacts` table (Linux / Windows / macOS / Docker, including the `ghcr.io/<owner>/aqualink-automate:<version>` image tag).
+   - The `**Full Changelog**: …/compare/v<prev>...v<this>` link (keep the one from the generated notes).
+   - For prereleases, a trailing `> Pre-release.` caveat blockquote (e.g. the unverified-Pentair-decoding caveat).
+
+   Apply the curated body with:
+
+   ```bash
+   gh release edit vX.Y.Z[-beta.N] --notes-file notes.md
+   ```
+
+2. Verify the GitHub Release page has all expected artifacts.
+3. Verify Docker images are published to GHCR.
+4. Verify the curated notes render correctly and read well; tweak the body if anything reads poorly.
 
 ## Release artifacts
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -153,7 +153,7 @@ Additionally:
 - **Checksums**: `.sha512` files for every package (`CPACK_PACKAGE_CHECKSUM SHA512`).
 - **Bundled runtime libraries**: the vcpkg-provided shared libraries ship inside each package (private lib dir with RPATH/loader-path), so the binary runs without a separate dependency install.
 - **Example configs**: the `examples/*.conf` files are bundled in each package.
-- **Docker image**: Published to `ghcr.io/<owner>/aqualink-automate` (the `latest` tag is only applied to non-prereleases).
+- **Docker image**: Published to `ghcr.io/<owner>/aqualink-automate`. A stable release also moves the `latest` tag; a prerelease moves the `edge` tag instead. Both carry the exact `<version>` tag (e.g. `0.3.0-beta.2`); prereleases do not move the `<major>.<minor>` tag.
 
 These packages are produced by CPack via the matching `pack-*` presets. `pack-*` presets exist only for the **Release** configure presets (those with no `-debug`/`-coverage` suffix), so swap the `config-` prefix for `pack-` only on a Release preset — for example `config-linux-gcc` → `pack-linux-gcc`. See [INSTALL.md](../INSTALL.md) for the local pack-* preset workflow.
 


### PR DESCRIPTION
Promotes develop to main for the 0.3.0-beta.2 prerelease.

### Fixed
- Trends chart renders when the page opens (was blank when opened directly on that view — drew before the panel had a size; now draws on size + window resize).
- Trends selections (metrics, time range, show-inactive) persist across reloads.

### Docs
- Releasing guide: specify the exact standard release-notes structure and make release-notes curation a required step.

Tag v0.3.0-beta.2 will be created on main after this merge.