### PR TITLE
Release v0.6.0-beta.1

### DIFF
--- a/.github/actions/setup-msvc-env/action.yml
+++ b/.github/actions/setup-msvc-env/action.yml
@@ -1,0 +1,73 @@
+name: Setup MSVC environment
+description: >-
+  Load the MSVC x64 developer environment (cl.exe, INCLUDE, LIB, PATH, ...) into
+  $GITHUB_ENV for subsequent steps. For self-hosted Windows runners that bake in
+  the VS Build Tools but do not expose the MSVC environment on the default PATH.
+  Pure PowerShell (no Node.js) — replaces the third-party ilammy/msvc-dev-cmd,
+  which only ships a deprecated Node 20 runtime.
+
+runs:
+  using: composite
+  steps:
+    - name: Load MSVC x64 environment
+      if: runner.os == 'Windows'
+      # Windows PowerShell (always present), NOT pwsh/PowerShell 7 which the
+      # self-hosted runner image does not ship.
+      shell: powershell
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        # Locate the VS install (the VS Installer always ships vswhere.exe here).
+        $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+        if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe not found at '$vswhere'. Is Visual Studio / Build Tools installed on this runner?"
+        }
+
+        $installPath = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+        if ([string]::IsNullOrWhiteSpace($installPath)) {
+            throw "vswhere found no Visual Studio install providing the VC.Tools.x86.x64 component."
+        }
+
+        $vcvars = Join-Path $installPath 'VC\Auxiliary\Build\vcvars64.bat'
+        if (-not (Test-Path $vcvars)) {
+            throw "vcvars64.bat not found at '$vcvars'."
+        }
+        Write-Host "Loading MSVC x64 environment from $vcvars"
+
+        # Snapshot the environment, source vcvars64.bat in a child cmd, snapshot
+        # again, and export only the variables vcvars added or changed.
+        function Read-CmdEnv([string]$command) {
+            $table = @{}
+            foreach ($line in (cmd /c $command)) {
+                if ($line -match '^([^=]+)=(.*)$') { $table[$matches[1]] = $matches[2] }
+            }
+            return $table
+        }
+
+        $before = Read-CmdEnv 'set'
+        $after  = Read-CmdEnv "`"$vcvars`" >nul 2>&1 && set"
+
+        if (-not $after.ContainsKey('VCToolsInstallDir')) {
+            cmd /c "`"$vcvars`""   # re-run unsuppressed so the banner/error reaches the log
+            throw "vcvars64.bat did not initialise the MSVC environment (VCToolsInstallDir unset)."
+        }
+
+        $lines = New-Object System.Collections.Generic.List[string]
+        foreach ($key in $after.Keys) {
+            $value = $after[$key]
+            if (-not $before.ContainsKey($key) -or $before[$key] -ne $value) {
+                # GITHUB_ENV is a single-line KEY=VALUE file; MSVC values never
+                # contain newlines, so the plain form is safe.
+                $lines.Add("$key=$value")
+            }
+        }
+
+        # UTF-8 without BOM so an appended BOM can't corrupt the first key.
+        [System.IO.File]::AppendAllLines(
+            $env:GITHUB_ENV,
+            [string[]]$lines,
+            (New-Object System.Text.UTF8Encoding $false))
+
+        Write-Host "Exported $($lines.Count) MSVC environment variable(s) to GITHUB_ENV."

--- a/.github/actions/setup-vcpkg-cache/action.yml
+++ b/.github/actions/setup-vcpkg-cache/action.yml
@@ -37,19 +37,21 @@ runs:
           vcpkg-downloads-${{ steps.vcpkg-version.outputs.hash }}-
           vcpkg-downloads-
 
-    # Keyed by runner OS (which maps 1:1 to the vcpkg triplet in use here), NOT by
-    # the per-job prefix. This collapses the previously disjoint "Linux GCC" /
-    # "CodeQL" / "SonarCloud" / "MSVCAnalysis" caches (all x64-linux-gcc) into one
-    # shared cache. vcpkg names archives by ABI hash, so multiple triplets would
-    # coexist safely in a single cache dir even if a job introduced one.
+    # Keyed by runner OS + arch (which maps 1:1 to the vcpkg triplet in use here),
+    # NOT by the per-job prefix. This collapses the previously disjoint "Linux GCC"
+    # / "CodeQL" / "SonarCloud" / "MSVCAnalysis" caches (all x64-linux-gcc) into one
+    # shared cache. The arch component keeps the x64 and arm64 Linux jobs (both
+    # runner.os == Linux) from racing on a single shared cache entry — they build
+    # disjoint archives and each gets its own cache. vcpkg names archives by ABI
+    # hash, so multiple triplets would coexist safely in a single cache dir anyway.
     - name: Cache vcpkg binaries
       uses: actions/cache@v5
       with:
         path: ~/.cache/vcpkg/archives
-        key: vcpkg-${{ runner.os }}-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg/triplets/**', 'cmake/vcpkg/overlays/**') }}
+        key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg/triplets/**', 'cmake/vcpkg/overlays/**') }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-${{ steps.vcpkg-version.outputs.hash }}-
-          vcpkg-${{ runner.os }}-
+          vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-version.outputs.hash }}-
+          vcpkg-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Run vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -32,12 +32,6 @@ jobs:
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ fromJSON(matrix.runner) }}
-    # ilammy/msvc-dev-cmd (self-hosted Windows MSVC env) is a Node 20 action with no
-    # Node 24 release; opt it into the Node 24 runtime now (what GitHub forces from
-    # 2026-06-16 anyway) so the deprecation warning clears. No-op for the other,
-    # already-Node-24 actions in this job.
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -82,10 +76,13 @@ jobs:
 
       # Self-hosted Windows images bake in the VS Build Tools but do not expose the
       # MSVC environment (cl.exe, INCLUDE/LIB) on the default PATH; load it so the
-      # Configure step can find the compiler.
+      # Configure step can find the compiler. Pure-PowerShell local composite (no
+      # Node) — replaces ilammy/msvc-dev-cmd, which only ships a deprecated Node 20
+      # runtime. (vcvars also leaks VCPKG_ROOT -> the VS-bundled vcpkg, same as the
+      # old action; the Configure/Build/Test steps override it per-step.)
       - name: Setup MSVC environment (self-hosted)
         if: contains(matrix.runner, 'self-hosted') && runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ./.github/actions/setup-msvc-env
 
       - name: Install NSIS (Windows packaging)
         if: inputs.do_package && runner.os == 'Windows' && !contains(matrix.runner, 'self-hosted')

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -49,6 +49,17 @@ jobs:
             build_preset: build-linux-gcc
             test_preset: test-linux-gcc
             package_preset: pack-linux-gcc
+          # Native arm64 build so the .deb/.rpm/.tgz install on a Raspberry Pi and
+          # other aarch64 hosts. ubuntu-24.04-arm is a GitHub-hosted arm64 runner
+          # (free for public repos); override RUNNER_LINUX_ARM to use a self-hosted
+          # arm runner. The triplet/toolchain target aarch64, so no cross-compile.
+          - name: "Linux GCC (arm64)"
+            runner: ${{ vars.RUNNER_LINUX_ARM || '["ubuntu-24.04-arm"]' }}
+            compiler: gcc-15
+            configure_preset: config-linux-gcc-arm64
+            build_preset: build-linux-gcc-arm64
+            test_preset: test-linux-gcc-arm64
+            package_preset: pack-linux-gcc-arm64
           - name: "Windows MSVC"
             runner: ${{ vars.RUNNER_WINDOWS || '["windows-latest"]' }}
             compiler: msvc
@@ -190,8 +201,10 @@ jobs:
       # built on the Ubuntu-25.04 runner so the binary's glibc/libstdc++ baseline
       # matches the ubuntu:25.04 Docker runtime base.
       # ---------------------------------------------------------------------------
+      # x64 only: the install tree feeds the (x64) Docker image + e2e-ui, and the
+      # artifact name is fixed, so the arm64 Linux entry must NOT also upload it.
       - name: Install + pack the Linux install tree
-        if: inputs.upload_installtree && runner.os == 'Linux'
+        if: inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc'
         shell: bash
         run: |
           cmake --install build/config-linux-gcc --prefix "${{ github.workspace }}/install/config-linux-gcc"
@@ -202,7 +215,7 @@ jobs:
             -C "${{ github.workspace }}/install/config-linux-gcc" .
 
       - name: Upload Linux install tree
-        if: inputs.upload_installtree && runner.os == 'Linux'
+        if: inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc'
         uses: actions/upload-artifact@v6
         with:
           name: installtree-linux-gcc

--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -214,10 +214,6 @@ jobs:
       github.head_ref != 'develop' ||
       github.base_ref != 'main'
     runs-on: ${{ fromJSON(vars.RUNNER_WINDOWS || '["windows-latest"]') }}
-    # ilammy/msvc-dev-cmd is a Node 20 action with no Node 24 release; opt it into the
-    # Node 24 runtime now (forced by GitHub from 2026-06-16) to clear the warning.
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       actions: read
       contents: read
@@ -237,9 +233,11 @@ jobs:
       with:
         compiler: msvc
 
+    # Pure-PowerShell local composite (no Node) — replaces ilammy/msvc-dev-cmd,
+    # which only ships a deprecated Node 20 runtime.
     - name: Setup MSVC environment (self-hosted)
       if: contains(vars.RUNNER_WINDOWS || '', 'self-hosted')
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ./.github/actions/setup-msvc-env
 
     - name: Setup vcpkg cache (self-hosted)
       if: contains(vars.RUNNER_WINDOWS || '', 'self-hosted')

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -188,6 +188,36 @@
     },
 
     {
+      "name": "config-linux-gcc-arm64",
+      "inherits": [ "release", "core" ],
+      "displayName": "Linux GCC Release (arm64)",
+      "description": "Native arm64 (aarch64) release build for Raspberry Pi and other arm64 hosts. Runs on an aarch64 Linux runner; the triplet/toolchain select the target arch, so the host condition is still Linux.",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64-linux-gcc",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/linux.gcc.toolchain.cmake"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "config-linux-gcc-arm64-debug",
+      "inherits": [ "debug", "core" ],
+      "displayName": "Linux GCC Debug (arm64)",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "arm64-linux-gcc",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/linux.gcc.toolchain.cmake"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+
+    {
       "name": "config-linux-llvm",
       "inherits": [ "release", "core" ],
       "displayName": "Linux LLVM Release",
@@ -298,6 +328,18 @@
       "targets": [ "coverage-testaqualink-automate" ]
     },
     {
+      "name": "build-linux-gcc-arm64",
+      "configurePreset": "config-linux-gcc-arm64",
+      "displayName": "Linux GCC Release (arm64)",
+      "configuration": "Release"
+    },
+    {
+      "name": "build-linux-gcc-arm64-debug",
+      "configurePreset": "config-linux-gcc-arm64-debug",
+      "displayName": "Linux GCC Debug (arm64)",
+      "configuration": "Debug"
+    },
+    {
       "name": "build-linux-llvm",
       "configurePreset": "config-linux-llvm",
       "displayName": "Linux LLVM Release",
@@ -381,6 +423,20 @@
       "execution": { "noTestsAction": "error", "stopOnFailure": false }
     },
     {
+      "name": "test-linux-gcc-arm64",
+      "configurePreset": "config-linux-gcc-arm64",
+      "displayName": "Linux GCC Release Tests (arm64)",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error", "stopOnFailure": false }
+    },
+    {
+      "name": "test-linux-gcc-arm64-debug",
+      "configurePreset": "config-linux-gcc-arm64-debug",
+      "displayName": "Linux GCC Debug Tests (arm64)",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error", "stopOnFailure": false }
+    },
+    {
       "name": "test-linux-llvm",
       "configurePreset": "config-linux-llvm",
       "displayName": "Linux LLVM Release Tests",
@@ -433,6 +489,13 @@
       "packageDirectory": "${sourceDir}/packages"
     },
     {
+      "name": "pack-linux-gcc-arm64",
+      "displayName": "Linux GCC Package (arm64)",
+      "configurePreset": "config-linux-gcc-arm64",
+      "generators": [ "TGZ", "DEB", "RPM" ],
+      "packageDirectory": "${sourceDir}/packages"
+    },
+    {
       "name": "pack-linux-llvm",
       "displayName": "Linux LLVM Package",
       "configurePreset": "config-linux-llvm",
@@ -477,6 +540,16 @@
         { "type": "build", "name": "build-linux-gcc" },
         { "type": "test", "name": "test-linux-gcc" },
         { "type": "package", "name": "pack-linux-gcc" }
+      ]
+    },
+    {
+      "name": "ci-linux-gcc-arm64",
+      "displayName": "Linux GCC CI Workflow (arm64)",
+      "steps": [
+        { "type": "configure", "name": "config-linux-gcc-arm64" },
+        { "type": "build", "name": "build-linux-gcc-arm64" },
+        { "type": "test", "name": "test-linux-gcc-arm64" },
+        { "type": "package", "name": "pack-linux-gcc-arm64" }
       ]
     },
     {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ Download the package for your platform from the [GitHub Releases](https://github
 | Platform | Package types | Notes |
 |----------|---------------|-------|
 | Windows  | `.exe` (NSIS installer), `.zip` | Run the installer, or unzip the portable build anywhere. |
-| Linux    | `.deb`, `.rpm`, `.tgz` | Install the `.deb`/`.rpm` with your package manager, or unpack the `.tgz`. |
+| Linux    | `.deb`, `.rpm`, `.tgz` | Built for **`amd64`** and **`arm64`** (Raspberry Pi 3/4/5 and other aarch64 hosts on a 64-bit OS). Pick the package matching your architecture (`dpkg --print-architecture` / `uname -m`), then install the `.deb`/`.rpm` with your package manager or unpack the `.tgz`. |
 | macOS    | `.dmg`, `.tgz` | Open the disk image and drag the app across, or unpack the `.tgz`. |
 
 Every release artifact ships with a matching `.sha512` checksum file. Verify the download before installing.

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1088,7 +1088,7 @@
                             <p class="text-muted text-xs mt-0 mb-1">
                                 Scan this code in Apple Home, Google Home, Alexa or SmartThings to add the pool.
                             </p>
-                            <div ref="matterQr" class="matter-qr mb-1" aria-label="Matter commissioning QR code"></div>
+                            <div x-ref="matterQr" class="matter-qr mb-1" aria-label="Matter commissioning QR code"></div>
                             <div class="emu-kv-grid">
                                 <span class="emu-kv-key">Manual code</span>
                                 <span class="emu-kv-val"><code x-text="matter.manual_code || '--'"></code></span>

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -89,11 +89,22 @@ if [[ "${PLATFORM_NAME}" == "macos" && "${COMPILER_NAME}" != "llvm" ]]; then
     exit 1
 fi
 
+# Detect the target architecture. Linux GCC is the only family with a non-x64
+# triplet (arm64), so a native build on an aarch64 host (e.g. a Raspberry Pi)
+# must select the -arm64 presets rather than the x64 default. Overridden by an
+# explicit --preset.
+ARCH_SUFFIX=""
+if [[ "${PLATFORM_NAME}" == "linux" && "${COMPILER_NAME}" == "gcc" ]]; then
+    case "$(uname -m)" in
+        aarch64|arm64) ARCH_SUFFIX="-arm64" ;;
+    esac
+fi
+
 # Build preset name if not explicitly provided
 if [[ -z "${PRESET}" ]]; then
     case "${BUILD_TYPE}" in
-        debug)   PRESET="config-${PLATFORM_NAME}-${COMPILER_NAME}-debug" ;;
-        release) PRESET="config-${PLATFORM_NAME}-${COMPILER_NAME}" ;;
+        debug)   PRESET="config-${PLATFORM_NAME}-${COMPILER_NAME}${ARCH_SUFFIX}-debug" ;;
+        release) PRESET="config-${PLATFORM_NAME}-${COMPILER_NAME}${ARCH_SUFFIX}" ;;
         *)
             echo "Error: Unknown build type '${BUILD_TYPE}'. Use debug or release."
             exit 1

--- a/cicd/validate-arm64-local.sh
+++ b/cicd/validate-arm64-local.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Validate the arm64 (Raspberry Pi) package build locally, with NO arm hardware,
+# by running the EXACT `config-linux-gcc-arm64` CI preset inside an emulated
+# linux/arm64 container (QEMU via Docker/binfmt). This reproduces the native
+# build the `ubuntu-24.04-arm` CI runner performs — same toolchain, same triplet,
+# same vcpkg deps, same CPack packaging — so a green run here means CI should pass.
+#
+# Requirements: Docker (Docker Desktop on Windows/WSL2, or a Linux engine) with
+# arm64 emulation registered. Verify with:
+#     docker run --rm --platform linux/arm64 ubuntu:25.04 uname -m   # -> aarch64
+# If that prints anything other than aarch64, register QEMU once:
+#     docker run --privileged --rm tonistiigi/binfmt --install arm64
+#
+# Notes:
+#   * The whole build (vcpkg deps + app) runs under emulation, so it is SLOW —
+#     Boost alone can take an hour+ on the first run. A named Docker volume caches
+#     the vcpkg binary archives, so re-runs only rebuild what actually changed.
+#   * The working tree (INCLUDING uncommitted changes) is streamed into the
+#     container over stdin — no bind mount — so it behaves identically from Git
+#     Bash, WSL2 or Linux and never writes the multi-GB build onto the host
+#     (keeps it off a tight Dev Drive). vcpkg is cloned fresh at the pinned SHA.
+#
+# Overrides (env): AQ_ARM64_IMAGE (base image), AQ_ARM64_CACHE_VOL (cache volume).
+#
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VCPKG_SHA="$(git -C "$REPO" ls-tree HEAD deps/vcpkg | awk '{print $3}')"
+IMAGE="${AQ_ARM64_IMAGE:-ubuntu:25.04}"
+CACHE_VOL="${AQ_ARM64_CACHE_VOL:-aqlauto-vcpkg-arm64}"
+
+if [ -z "$VCPKG_SHA" ]; then
+    echo "error: could not resolve the pinned deps/vcpkg SHA from git." >&2
+    exit 1
+fi
+
+echo "Repo root : $REPO"
+echo "vcpkg pin : $VCPKG_SHA"
+echo "Base image: $IMAGE"
+echo "Cache vol : $CACHE_VOL"
+echo
+
+# Stream the working tree (minus heavy/irrelevant dirs) into the container and run
+# the full configure -> build -> test -> package pipeline against the arm64 preset.
+tar -C "$REPO" \
+    --exclude=./.git --exclude=./.claude \
+    --exclude=./build --exclude=./packages --exclude=./packages-arm64 \
+    --exclude=./deps/vcpkg \
+    --exclude=./node_modules --exclude=./matter-bridge/node_modules \
+    --exclude=./test-results --exclude=./playwright-report \
+    -cf - . \
+| docker run -i --rm --platform linux/arm64 \
+    -v "$CACHE_VOL":/vcpkgcache \
+    -e VCPKG_SHA="$VCPKG_SHA" \
+    "$IMAGE" bash -euo pipefail -c '
+        export DEBIAN_FRONTEND=noninteractive
+        echo "::: installing toolchain (matches CI: gcc-15) :::"
+        apt-get update -qq
+        apt-get install -y -qq --no-install-recommends \
+            build-essential gcc-15 g++-15 make cmake ninja-build git ca-certificates \
+            autoconf autoconf-archive automake libtool pkg-config \
+            curl zip unzip tar rpm fakeroot file
+        # Point the default gcc/g++ at 15 so the toolchain (and every vcpkg port
+        # build) uses it rather than the image default.
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-15 100
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-15 100
+
+        echo "::: unpacking streamed source :::"
+        mkdir -p /work && tar -C /work -xpf -
+        cd /work
+
+        echo "::: fetching pinned vcpkg ($VCPKG_SHA) :::"
+        git clone -q https://github.com/microsoft/vcpkg deps/vcpkg
+        git -C deps/vcpkg checkout -q "$VCPKG_SHA"
+
+        export VCPKG_DEFAULT_BINARY_CACHE=/vcpkgcache
+        mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE"
+        ./deps/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+        echo "::: configure (vcpkg builds the deps here — the slow part) :::"
+        cmake --preset config-linux-gcc-arm64 -DDERIVED_VERSION_OVERRIDE=0.0.0-dev
+
+        echo "::: build :::"
+        cmake --build --preset build-linux-gcc-arm64
+
+        echo "::: test :::"
+        ctest --preset test-linux-gcc-arm64 --output-on-failure
+
+        echo "::: package :::"
+        cpack --preset pack-linux-gcc-arm64
+
+        echo "::: RESULT :::"
+        ls -1 packages/
+        echo "--- deb metadata ---"
+        dpkg --info packages/*arm64.deb | grep -iE "package|version|architecture|depends"
+    '
+
+echo
+echo "arm64 validation finished — see the deb metadata above (Architecture should be arm64)."

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -188,11 +188,24 @@ set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 
 # DEB/RPM architecture and metadata defaults. These come BEFORE the prerelease
 # block so a prerelease build can override CPACK_RPM_PACKAGE_RELEASE.
-set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+#
+# The architecture is DERIVED from the build's target processor (set by the
+# toolchain: x86_64 or aarch64) rather than hardcoded, so a native arm64 build
+# is labelled arm64/aarch64 — otherwise an arm64 .deb would be stamped amd64 and
+# apt would refuse to install it on a Raspberry Pi. DEB-DEFAULT/RPM-DEFAULT embed
+# this architecture in the package filename, so the two arches never collide.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(AQ_ARCH_LABEL "arm64")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "arm64")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE "aarch64")
+else()
+    set(AQ_ARCH_LABEL "amd64")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+endif()
 set(CPACK_DEBIAN_PACKAGE_SECTION "net")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_RPM_PACKAGE_RELEASE 1)
-set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
 
 # Encode any prerelease label (alpha/beta/rc) so prerelease packages do not
 # collide with — and sort BEFORE — their eventual final release.
@@ -206,6 +219,25 @@ if(PROJECT_VERSION_PRERELEASE)
     # before the final release's Release value (1).
     set(CPACK_RPM_PACKAGE_VERSION "${PROJECT_VERSION}")
     set(CPACK_RPM_PACKAGE_RELEASE "0.${PROJECT_VERSION_PRERELEASE}")
+endif()
+
+# Disambiguate the per-arch Linux archive (TGZ). The DEB/RPM names already embed
+# the architecture (via *-DEFAULT + CPACK_*_PACKAGE_ARCHITECTURE) and ignore
+# CPACK_PACKAGE_FILE_NAME, but the TGZ name is "<name>-<version>[-<pre>]-Linux"
+# with NO arch — so an x64 and an arm64 build would produce identically named
+# tarballs that clobber each other when every platform's packages are gathered
+# into a single GitHub release. Fold the arch into CPACK_PACKAGE_FILE_NAME on
+# Linux (this drives the TGZ name; deb/rpm are unaffected — verified empirically:
+# CPACK_ARCHIVE_FILE_NAME is NOT honoured by the archive generator here, the TGZ
+# follows CPACK_PACKAGE_FILE_NAME). Windows/macOS keep their single-arch names.
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    if(PROJECT_VERSION_PRERELEASE)
+        set(CPACK_PACKAGE_FILE_NAME
+            "${CPACK_PACKAGE_NAME}-${PROJECT_VERSION}-${PROJECT_VERSION_PRERELEASE}-${CMAKE_SYSTEM_NAME}-${AQ_ARCH_LABEL}")
+    else()
+        set(CPACK_PACKAGE_FILE_NAME
+            "${CPACK_PACKAGE_NAME}-${PROJECT_VERSION}-${CMAKE_SYSTEM_NAME}-${AQ_ARCH_LABEL}")
+    endif()
 endif()
 
 #------------------------------------------------------------------------------

--- a/cmake/toolchains/linux.gcc.toolchain.cmake
+++ b/cmake/toolchains/linux.gcc.toolchain.cmake
@@ -5,7 +5,32 @@
 message(STATUS "Configuring Linux Toolchain (GCC Variant)")
 
 set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+# Determine target architecture (mirrors the macOS toolchain). _LINUX_ARCH holds
+# the canonical processor name; the arch-specific compiler flags below derive
+# from it. vcpkg sets VCPKG_TARGET_ARCHITECTURE only while building a port for a
+# triplet — in the project's OWN configure scope it is empty, so fall back to the
+# host architecture there. Without this fallback a native aarch64 build would
+# default to x86_64 in the project scope and emit `-m64`, which an aarch64 gcc
+# rejects ("unrecognized command-line option '-m64'").
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    set(_LINUX_ARCH "aarch64")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(_LINUX_ARCH "x86_64")
+else()
+    execute_process(
+        COMMAND uname -m
+        OUTPUT_VARIABLE _HOST_ARCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_HOST_ARCH MATCHES "aarch64|arm64")
+        set(_LINUX_ARCH "aarch64")
+    else()
+        set(_LINUX_ARCH "x86_64")
+    endif()
+endif()
+
+set(CMAKE_SYSTEM_PROCESSOR ${_LINUX_ARCH})
+message(STATUS "Target architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 
 # Find GCC compilers. The C and C++ searches share the same install
 # locations, so the hint list is defined once and reused.
@@ -27,19 +52,24 @@ find_program(CMAKE_CXX_COMPILER g++
     REQUIRED
 )
 
-# Configure compiler flags
-set(CMAKE_C_FLAGS_INIT "-m64")
-set(CMAKE_CXX_FLAGS_INIT "-m64")
+# Configure compiler flags. -m64 selects the 64-bit x86 ABI and is rejected by
+# an aarch64 gcc, so it is x86-only; the arm host compiler already targets
+# aarch64 natively and needs no equivalent flag.
+if(_LINUX_ARCH STREQUAL "x86_64")
+    set(CMAKE_C_FLAGS_INIT "-m64")
+    set(CMAKE_CXX_FLAGS_INIT "-m64")
+endif()
 
 # Enable color diagnostics and better error messages
 add_compile_options(-fdiagnostics-color=always)
 
 # Opt-in raised-ISA baseline for release/benchmark builds (default OFF).
-# Targets the x86-64-v2 microarchitecture level (SSE4.2/POPCNT) so the hot
-# byte-scan and checksum loops can autovectorise. Left OFF by default to keep
-# the shipped binary runnable on generic x86-64 hardware; only enable for
-# builds validated against the benchmark suite.
-if(ENABLE_NATIVE_ARCH)
+# x86_64 only — targets the x86-64-v2 microarchitecture level (SSE4.2/POPCNT)
+# so the hot byte-scan and checksum loops can autovectorise. The arm64 baseline
+# already exceeds this, so the flag is skipped there. Left OFF by default to
+# keep the shipped binary runnable on generic hardware; only enable for builds
+# validated against the benchmark suite.
+if(ENABLE_NATIVE_ARCH AND _LINUX_ARCH STREQUAL "x86_64")
     add_compile_options(-march=x86-64-v2 -mtune=generic)
     message(STATUS "Raised-ISA baseline enabled (-march=x86-64-v2)")
 endif()

--- a/cmake/vcpkg/triplets/arm64-linux-gcc.cmake
+++ b/cmake/vcpkg/triplets/arm64-linux-gcc.cmake
@@ -1,0 +1,27 @@
+# Linkage policy: dynamic runtime + dynamic dependency libraries. This is the
+# distribution default — packaging (TGZ/DEB/RPM) integrates with the system's
+# shared libraries. A static-library variant (which would remove the PLT/GOT
+# indirection on Boost/OpenSSL/zlib hot paths) was evaluated and intentionally
+# DEFERRED: it would need its own non-distributable internal release/benchmark
+# triplet + preset rather than changing this shipped triplet. Keep dynamic here.
+#
+# arm64 counterpart of x64-linux-gcc — built natively on an aarch64 runner so
+# the resulting .deb/.rpm/.tgz install on a Raspberry Pi and other arm64 hosts.
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+set(VCPKG_ENV_PASSTHROUGH PATH)
+
+# Chainload policy (see also the Windows triplets and CMakePresets.json):
+# The project build always chainloads its toolchain via
+# VCPKG_CHAINLOAD_TOOLCHAIN_FILE in CMakePresets.json. On Linux/macOS we ALSO
+# chainload the same toolchain into the vcpkg port builds here, so the
+# dependencies are compiled with the identical gcc (and flags) as the project —
+# this avoids ABI/stdlib mismatches with libstdc++. The toolchain selects its
+# target arch from VCPKG_TARGET_ARCHITECTURE (set above), so the same file
+# serves both the x64 and arm64 Linux GCC triplets. The Windows triplets
+# deliberately omit this so vcpkg builds ports with the default MSVC toolset
+# (required by ports like OpenSSL); that asymmetry is intentional.
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../../toolchains/linux.gcc.toolchain.cmake")

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -69,17 +69,20 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 
 ### The matrix
 
-The job runs a three-row matrix with `fail-fast: false`, so one platform failing does not cancel the others:
+The job runs a four-row matrix with `fail-fast: false`, so one platform failing does not cancel the others:
 
 | Name | Compiler | Configure preset | Build preset | Test preset | Package preset |
 |------|----------|------------------|--------------|-------------|----------------|
 | Linux GCC | `gcc-15` | `config-linux-gcc` | `build-linux-gcc` | `test-linux-gcc` | `pack-linux-gcc` |
+| Linux GCC (arm64) | `gcc-15` | `config-linux-gcc-arm64` | `build-linux-gcc-arm64` | `test-linux-gcc-arm64` | `pack-linux-gcc-arm64` |
 | Windows MSVC | `msvc` | `config-windows-msvc` | `build-windows-msvc` | `test-windows-msvc` | `pack-windows-msvc` |
 | macOS Clang | `llvm` | `config-macos-llvm` | `build-macos-llvm` | `test-macos-llvm` | `pack-macos-llvm` |
 
 These are the same presets you use locally — see [INSTALL.md](../INSTALL.md).
 
-Runner selection per row is `vars.RUNNER_LINUX` / `vars.RUNNER_WINDOWS` with a GitHub-hosted fallback; macOS always runs on `macos-latest`. See [Self-hosted runners](#self-hosted-runners).
+The arm64 row builds **natively** on an aarch64 runner (no cross-compile / QEMU) so the `.deb`/`.rpm`/`.tgz` install on a Raspberry Pi and other arm64 hosts; CPack derives the package architecture from the target, so the packages are correctly labelled `arm64`/`aarch64`. The install-tree upload (consumed by `e2e-ui` and the Docker image) stays on the x64 `config-linux-gcc` row only.
+
+Runner selection per row is `vars.RUNNER_LINUX` / `vars.RUNNER_LINUX_ARM` / `vars.RUNNER_WINDOWS` with a GitHub-hosted fallback (the arm64 row falls back to `ubuntu-24.04-arm`); macOS always runs on `macos-latest`. See [Self-hosted runners](#self-hosted-runners).
 
 ### Test scope
 
@@ -208,7 +211,8 @@ Set these under **Settings > Variables > Actions**. Each value is a JSON array o
 
 | Variable | Type | Example | Applies to |
 |----------|------|---------|------------|
-| `RUNNER_LINUX` | JSON label array | `["self-hosted","linux","x64"]` | Linux rows of `_build.yml`, `e2e-ui`, `matter-bridge`, `docker-verify`, `docker-publish`, CodeQL, SonarCloud |
+| `RUNNER_LINUX` | JSON label array | `["self-hosted","linux","x64"]` | x64 Linux rows of `_build.yml`, `e2e-ui`, `matter-bridge`, `docker-verify`, `docker-publish`, CodeQL, SonarCloud |
+| `RUNNER_LINUX_ARM` | JSON label array | `["self-hosted","linux","arm64"]` | The arm64 Linux row of `_build.yml`. Falls back to the GitHub-hosted `ubuntu-24.04-arm` (free for public repos). |
 | `RUNNER_WINDOWS` | JSON label array | `["self-hosted","windows","x64"]` | Windows row of `_build.yml`, MSVC code analysis |
 
 ### Fallback

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -215,7 +215,7 @@ Set these under **Settings > Variables > Actions**. Each value is a JSON array o
 
 The pattern in the workflows is `${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}` (and the Windows equivalent). If the variable is unset, or the self-hosted runners go offline, jobs fall back to the GitHub-hosted runners automatically. To force the fallback, remove the repository variables.
 
-Self-hosted jobs also run extra steps the hosted jobs skip — they clean the workspace, point vcpkg at a persistent `~/.cache/vcpkg`, and (on Windows) load the MSVC environment with `ilammy/msvc-dev-cmd`.
+Self-hosted jobs also run extra steps the hosted jobs skip — they clean the workspace, point vcpkg at a persistent `~/.cache/vcpkg`, and (on Windows) load the MSVC environment with the local `./.github/actions/setup-msvc-env` composite action (pure PowerShell; sources `vcvars64.bat` and exports the env delta to `$GITHUB_ENV`).
 
 ### Provisioning
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -154,7 +154,8 @@ Each release includes:
 
 | Platform | Packages                     |
 |----------|------------------------------|
-| Linux    | `.tgz`, `.deb`, `.rpm`       |
+| Linux (amd64) | `.tgz`, `.deb`, `.rpm`  |
+| Linux (arm64) | `.tgz`, `.deb`, `.rpm`  |
 | Windows  | `.zip`, `.exe` (NSIS)        |
 | macOS    | `.tgz`, `.dmg`               |
 


### PR DESCRIPTION
Promote develop to main for the v0.6.0-beta.1 pre-release.

Headline: **native arm64 (Raspberry Pi) packages** — arm64 `.deb`/`.rpm`/`.tgz` now build on a `ubuntu-24.04-arm` runner alongside x86-64. Validated by the release dry-run (all four package legs green; arm64 deb installs and runs).