### PR TITLE
Release v0.7.0-beta.1

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -49,6 +49,9 @@ jobs:
             build_preset: build-linux-gcc
             test_preset: test-linux-gcc
             package_preset: pack-linux-gcc
+            # Release packages build in this glibc-2.36 container (Debian Bookworm /
+            # Raspberry Pi OS baseline) so they run on a stock Pi; CI builds on the host.
+            docker_platform: linux/amd64
           # Native arm64 build so the .deb/.rpm/.tgz install on a Raspberry Pi and
           # other aarch64 hosts. ubuntu-24.04-arm is a GitHub-hosted arm64 runner
           # (free for public repos); override RUNNER_LINUX_ARM to use a self-hosted
@@ -60,6 +63,7 @@ jobs:
             build_preset: build-linux-gcc-arm64
             test_preset: test-linux-gcc-arm64
             package_preset: pack-linux-gcc-arm64
+            docker_platform: linux/arm64
           - name: "Windows MSVC"
             runner: ${{ vars.RUNNER_WINDOWS || '["windows-latest"]' }}
             compiler: msvc
@@ -123,7 +127,12 @@ jobs:
         with:
           cache-key-prefix: ${{ matrix.name }}
 
+      # Host build path (CI on every platform + the Windows/macOS release builds).
+      # The Linux RELEASE build runs in a glibc-2.36 container instead (see the
+      # "Build, test & package (glibc-2.36 container)" step below), so these host
+      # steps skip for it.
       - name: Bootstrap vcpkg
+        if: ${{ !(inputs.do_package && runner.os == 'Linux') }}
         shell: bash
         run: |
           if [ -f "${{ github.workspace }}/deps/vcpkg/bootstrap-vcpkg.sh" ]; then
@@ -141,7 +150,7 @@ jobs:
       # them here too so the build also works on a not-yet-rebuilt image and on the
       # GitHub-hosted macOS runner. Windows builds libbacktrace without this path.
       - name: Install autotools for libbacktrace (Linux/macOS)
-        if: runner.os != 'Windows'
+        if: ${{ runner.os != 'Windows' && !(inputs.do_package && runner.os == 'Linux') }}
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
@@ -164,6 +173,7 @@ jobs:
       # emits a noisy "could not parse a v<...> tag" warning. 0.0.0-dev is exactly
       # the value that fallback would produce — just without the warning.
       - name: Configure
+        if: ${{ !(inputs.do_package && runner.os == 'Linux') }}
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.configure_preset }}
@@ -172,6 +182,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
 
       - name: Build
+        if: ${{ !(inputs.do_package && runner.os == 'Linux') }}
         uses: lukka/run-cmake@v10
         with:
           buildPreset: ${{ matrix.build_preset }}
@@ -179,7 +190,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
 
       - name: Show build errors on failure
-        if: failure()
+        if: ${{ failure() && !(inputs.do_package && runner.os == 'Linux') }}
         shell: bash
         run: |
           echo "::group::CMake build retry (verbose)"
@@ -187,11 +198,77 @@ jobs:
           echo "::endgroup::"
 
       - name: Test
+        if: ${{ !(inputs.do_package && runner.os == 'Linux') }}
         uses: lukka/run-cmake@v10
         with:
           testPreset: ${{ matrix.test_preset }}
         env:
           VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
+
+      # Persist the glibc-2.36 container's vcpkg binary cache. On self-hosted runners
+      # $HOME/.cache survives across runs already; this restores it for the
+      # GitHub-hosted arm64 runner. Keyed separately from the host (Ubuntu-25.04)
+      # cache so the two glibc baselines never share archives.
+      - name: Cache vcpkg (glibc-2.36 container)
+        if: ${{ inputs.do_package && runner.os == 'Linux' && !contains(matrix.runner, 'self-hosted') }}
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/vcpkg-bookworm
+          key: vcpkg-bookworm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json', 'cmake/vcpkg/triplets/**') }}
+          restore-keys: |
+            vcpkg-bookworm-${{ runner.os }}-${{ runner.arch }}-
+
+      # ---------------------------------------------------------------------------
+      # Linux RELEASE build — inside a glibc-2.36 container (Debian Bookworm /
+      # Raspberry Pi OS baseline) so the .deb/.rpm/.tgz run on a stock Pi and every
+      # newer distro. Native per-arch (linux/amd64 on the x64 runner, linux/arm64 on
+      # the arm runner — no QEMU). The job stays on the host, so the deb smoke test
+      # below still has Docker. The bundled gcc-15 libstdc++/libgcc (see
+      # cmake/CPackConfig.cmake) make the older-glibc base safe for the C++23 code.
+      # ---------------------------------------------------------------------------
+      - name: Build, test & package (glibc-2.36 container)
+        if: ${{ inputs.do_package && runner.os == 'Linux' }}
+        shell: bash
+        env:
+          VERSION_OVERRIDE: ${{ inputs.version_tag || '0.0.0-dev' }}
+          CONFIGURE_PRESET: ${{ matrix.configure_preset }}
+          BUILD_PRESET: ${{ matrix.build_preset }}
+          TEST_PRESET: ${{ matrix.test_preset }}
+          PACKAGE_PRESET: ${{ matrix.package_preset }}
+          # The x64 leg also produces the install tree the Docker image consumes.
+          PACK_INSTALLTREE: ${{ inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc' }}
+        run: |
+          mkdir -p "$HOME/.cache/vcpkg-bookworm"
+          docker run --rm --platform ${{ matrix.docker_platform }} \
+            -v "${{ github.workspace }}":/work -w /work \
+            -v "$HOME/.cache/vcpkg-bookworm":/vcpkgcache \
+            -e VERSION_OVERRIDE -e CONFIGURE_PRESET -e BUILD_PRESET -e TEST_PRESET \
+            -e PACKAGE_PRESET -e PACK_INSTALLTREE \
+            gcc:15-bookworm bash -eu -c '
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -qq
+              apt-get install -y -qq --no-install-recommends \
+                ninja-build git ca-certificates curl zip unzip tar make \
+                autoconf autoconf-archive automake libtool pkg-config python3 \
+                binutils file rpm fakeroot >/dev/null
+              ARCH=$(uname -m)
+              curl -fsSL "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-linux-${ARCH}.tar.gz" | tar xz -C /opt
+              export PATH="/opt/cmake-3.31.6-linux-${ARCH}/bin:$PATH"
+              # Restore exec bits on the maintainer scripts (lost on a Windows checkout).
+              chmod +x packaging/deb/postinst packaging/deb/prerm packaging/deb/postrm packaging/rpm/*.sh packaging/tarball/*.sh
+              git config --global --add safe.directory /work
+              git config --global --add safe.directory /work/deps/vcpkg
+              export VCPKG_DEFAULT_BINARY_CACHE=/vcpkgcache
+              ./deps/vcpkg/bootstrap-vcpkg.sh -disableMetrics >/dev/null
+              cmake --preset "$CONFIGURE_PRESET" -DDERIVED_VERSION_OVERRIDE="$VERSION_OVERRIDE"
+              cmake --build --preset "$BUILD_PRESET"
+              ctest --preset "$TEST_PRESET"
+              if [ "$PACK_INSTALLTREE" = "true" ]; then
+                cmake --install "build/$CONFIGURE_PRESET" --prefix "install/$CONFIGURE_PRESET"
+                tar czf installtree-linux-gcc.tar.gz -C "install/$CONFIGURE_PRESET" .
+              fi
+              cpack --preset "$PACKAGE_PRESET"
+            '
 
       # ---------------------------------------------------------------------------
       # Linux install tree (consumed by e2e-ui and the assembled Docker image so
@@ -203,8 +280,10 @@ jobs:
       # ---------------------------------------------------------------------------
       # x64 only: the install tree feeds the (x64) Docker image + e2e-ui, and the
       # artifact name is fixed, so the arm64 Linux entry must NOT also upload it.
+      # CI builds the tree here on the host; the RELEASE tree is produced inside the
+      # glibc-2.36 container step above (so the Docker image runs on a stock Pi too).
       - name: Install + pack the Linux install tree
-        if: inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc'
+        if: inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc' && !inputs.do_package
         shell: bash
         run: |
           cmake --install build/config-linux-gcc --prefix "${{ github.workspace }}/install/config-linux-gcc"
@@ -226,21 +305,28 @@ jobs:
       # ---------------------------------------------------------------------------
       # Packaging (release path only — inputs.do_package)
       # ---------------------------------------------------------------------------
+      # Windows/macOS package on the host; Linux packages are built by the
+      # glibc-2.36 container step above (cpack runs inside it).
       - name: Package
-        if: inputs.do_package
+        if: inputs.do_package && runner.os != 'Linux'
         run: cpack --preset=${{ matrix.package_preset }}
 
-      # Install/extract the freshly built package on a clean target and run the
-      # binary. This catches missing runtime dependencies (the exact failure mode of
-      # an unbundled dynamic build) BEFORE the package is published.
+      # Install the freshly built .deb on a CLEAN debian:bookworm (the Raspberry Pi
+      # OS baseline: glibc 2.36, gcc-12 system libstdc++) and run it. This is the
+      # guard that the packages still run on a stock Pi — it catches both a missing
+      # runtime dependency AND a regression to a too-new glibc/libstdc++ baseline
+      # (which an ubuntu:25.04 test would silently pass). Runs natively per arch.
       - name: Smoke test — install package & run (Linux)
         if: inputs.do_package && runner.os == 'Linux'
         run: |
-          docker run --rm -v "$PWD/packages:/pkg:ro" ubuntu:25.04 bash -c '
+          docker run --rm --platform ${{ matrix.docker_platform }} \
+            -v "$PWD/packages:/pkg:ro" debian:bookworm bash -c '
             set -e
             apt-get update -qq
             apt-get install -y -qq /pkg/*.deb
-            aqualink-automate --version'
+            aqualink-automate --version
+            test -f /etc/aqualink-automate/aqualink-automate.conf
+            getent passwd aqualink >/dev/null'
 
       - name: Smoke test — extract ZIP & run (Windows)
         if: inputs.do_package && runner.os == 'Windows'

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -52,6 +52,9 @@ jobs:
             # Release packages build in this glibc-2.36 container (Debian Bookworm /
             # Raspberry Pi OS baseline) so they run on a stock Pi; CI builds on the host.
             docker_platform: linux/amd64
+            # Install-tree artifact name (consumed by e2e-ui + the multi-arch Docker
+            # image). The x64 name is unsuffixed for back-compat with the e2e-ui job.
+            installtree_name: installtree-linux-gcc
           # Native arm64 build so the .deb/.rpm/.tgz install on a Raspberry Pi and
           # other aarch64 hosts. ubuntu-24.04-arm is a GitHub-hosted arm64 runner
           # (free for public repos); override RUNNER_LINUX_ARM to use a self-hosted
@@ -64,6 +67,7 @@ jobs:
             test_preset: test-linux-gcc-arm64
             package_preset: pack-linux-gcc-arm64
             docker_platform: linux/arm64
+            installtree_name: installtree-linux-gcc-arm64
           - name: "Windows MSVC"
             runner: ${{ vars.RUNNER_WINDOWS || '["windows-latest"]' }}
             compiler: msvc
@@ -235,15 +239,17 @@ jobs:
           BUILD_PRESET: ${{ matrix.build_preset }}
           TEST_PRESET: ${{ matrix.test_preset }}
           PACKAGE_PRESET: ${{ matrix.package_preset }}
-          # The x64 leg also produces the install tree the Docker image consumes.
-          PACK_INSTALLTREE: ${{ inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc' }}
+          # Both Linux legs produce a per-arch install tree the multi-arch Docker
+          # image consumes (and e2e-ui consumes the x64 one).
+          PACK_INSTALLTREE: ${{ inputs.upload_installtree }}
+          INSTALLTREE_NAME: ${{ matrix.installtree_name }}
         run: |
           mkdir -p "$HOME/.cache/vcpkg-bookworm"
           docker run --rm --platform ${{ matrix.docker_platform }} \
             -v "${{ github.workspace }}":/work -w /work \
             -v "$HOME/.cache/vcpkg-bookworm":/vcpkgcache \
             -e VERSION_OVERRIDE -e CONFIGURE_PRESET -e BUILD_PRESET -e TEST_PRESET \
-            -e PACKAGE_PRESET -e PACK_INSTALLTREE \
+            -e PACKAGE_PRESET -e PACK_INSTALLTREE -e INSTALLTREE_NAME \
             gcc:15-bookworm bash -eu -c '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update -qq
@@ -265,7 +271,7 @@ jobs:
               ctest --preset "$TEST_PRESET"
               if [ "$PACK_INSTALLTREE" = "true" ]; then
                 cmake --install "build/$CONFIGURE_PRESET" --prefix "install/$CONFIGURE_PRESET"
-                tar czf installtree-linux-gcc.tar.gz -C "install/$CONFIGURE_PRESET" .
+                tar czf "${INSTALLTREE_NAME}.tar.gz" -C "install/$CONFIGURE_PRESET" .
               fi
               cpack --preset "$PACKAGE_PRESET"
             '
@@ -293,13 +299,15 @@ jobs:
           tar czf "${{ github.workspace }}/installtree-linux-gcc.tar.gz" \
             -C "${{ github.workspace }}/install/config-linux-gcc" .
 
+      # CI uploads only the x64 tree (for e2e-ui); a release uploads both Linux legs'
+      # trees (x64 + arm64) for the multi-arch Docker image. Per-arch artifact name.
       - name: Upload Linux install tree
-        if: inputs.upload_installtree && matrix.configure_preset == 'config-linux-gcc'
+        if: inputs.upload_installtree && runner.os == 'Linux' && (inputs.do_package || matrix.configure_preset == 'config-linux-gcc')
         uses: actions/upload-artifact@v6
         with:
-          name: installtree-linux-gcc
+          name: ${{ matrix.installtree_name }}
           if-no-files-found: error
-          path: installtree-linux-gcc.tar.gz
+          path: ${{ matrix.installtree_name }}.tar.gz
           retention-days: 3
 
       # ---------------------------------------------------------------------------

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -1,0 +1,126 @@
+# Publish GPG-signed APT + DNF package repositories to GitHub Pages.
+#
+# Fires when a GitHub Release is published (by release.yml). It pulls the release's
+# .deb/.rpm assets, (re)builds a reprepro apt repo + a createrepo_c dnf repo, signs
+# them with the project GPG key, and publishes everything to the `gh-pages` branch
+# so users can `apt install` / `dnf install` and get `apt upgrade` updates.
+#
+# REQUIRED ONE-TIME SETUP (see docs/releasing.md > Package repositories):
+#   1. Generate a signing key and add the ASCII-armored PRIVATE key as the repo
+#      secret REPO_GPG_PRIVATE_KEY (and, if it has one, REPO_GPG_PASSPHRASE).
+#   2. Enable GitHub Pages for the repository, serving from the `gh-pages` branch.
+# Until the secret is present this workflow no-ops (the build job is skipped), so it
+# is safe to merge before the key exists.
+name: Publish package repos
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)publish into the repos (e.g. v0.7.0-beta.1)"
+        required: true
+        type: string
+
+concurrency:
+  group: publish-repos
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # push to gh-pages
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # The secrets context is not usable in a job-level if, so surface the key's
+    # presence as an env value and gate the steps' work on it (same pattern as
+    # docker-publish's Docker Hub login).
+    env:
+      HAVE_GPG_KEY: ${{ secrets.REPO_GPG_PRIVATE_KEY != '' && 'true' || 'false' }}
+      TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+    steps:
+      - name: Skip if no signing key configured
+        if: env.HAVE_GPG_KEY != 'true'
+        run: echo "::warning::REPO_GPG_PRIVATE_KEY is not set — skipping repo publish. See docs/releasing.md."
+
+      - name: Checkout (work tree)
+        if: env.HAVE_GPG_KEY == 'true'
+        uses: actions/checkout@v5
+
+      - name: Checkout gh-pages (existing repo state)
+        if: env.HAVE_GPG_KEY == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          path: pages
+        continue-on-error: true   # first run: branch doesn't exist yet
+
+      - name: Install repo tooling
+        if: env.HAVE_GPG_KEY == 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq reprepro createrepo-c gnupg
+
+      - name: Import signing key
+        if: env.HAVE_GPG_KEY == 'true'
+        id: gpg
+        env:
+          GPG_KEY: ${{ secrets.REPO_GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_KEY" | gpg --batch --import
+          KEYID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          echo "keyid=$KEYID" >> "$GITHUB_OUTPUT"
+          gpg --armor --export "$KEYID" > public-key.asc
+          echo "Imported signing key $KEYID"
+
+      - name: Download release assets (.deb / .rpm)
+        if: env.HAVE_GPG_KEY == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p assets
+          gh release download "$TAG" -R "${{ github.repository }}" -p '*.deb' -p '*.rpm' -D assets
+          echo "Downloaded:"; ls -1 assets
+
+      - name: Build APT + DNF repositories
+        if: env.HAVE_GPG_KEY == 'true'
+        env:
+          KEYID: ${{ steps.gpg.outputs.keyid }}
+        run: |
+          set -euo pipefail
+          OUT=pages
+          mkdir -p "$OUT/apt/conf" "$OUT/rpm"
+
+          # ---- APT (reprepro) -------------------------------------------------
+          cat > "$OUT/apt/conf/distributions" <<EOF
+          Origin: Aqualink Automate
+          Label: Aqualink Automate
+          Codename: stable
+          Architectures: amd64 arm64
+          Components: main
+          Description: Aqualink Automate APT repository
+          SignWith: $KEYID
+          EOF
+          for deb in assets/*.deb; do
+            reprepro -b "$OUT/apt" --keepunreferencedfiles includedeb stable "$deb"
+          done
+
+          # ---- DNF/YUM (createrepo_c, signed repomd) --------------------------
+          cp assets/*.rpm "$OUT/rpm"/
+          createrepo_c --update "$OUT/rpm"
+          gpg --batch --yes --detach-sign --armor "$OUT/rpm/repodata/repomd.xml"
+
+          # ---- Shared: public key, install scripts, landing page --------------
+          cp public-key.asc "$OUT/key.gpg"
+          cp cicd/repo/install-apt.sh "$OUT/install-apt.sh"
+          cp cicd/repo/install-dnf.sh "$OUT/install-dnf.sh"
+          cp cicd/repo/index.html "$OUT/index.html"
+          echo "Repos built into $OUT:"; find "$OUT" -maxdepth 2 -type d
+
+      - name: Publish to GitHub Pages
+        if: env.HAVE_GPG_KEY == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: pages
+          keep_files: true   # preserve prior packages already in the repo
+          commit_message: "repo: publish ${{ env.TAG }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,10 @@ jobs:
         with:
           submodules: recursive
 
+      # QEMU lets buildx assemble the linux/arm64 image on the x64 runner. The
+      # runtime-assembled stage only unpacks a prebuilt tarball (no compilation), so
+      # the emulated work is trivial.
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
 
       # The Dockerfile's base images (ubuntu:25.04, node:22-bookworm-slim) are
@@ -198,25 +202,28 @@ jobs:
             # so before this `edge` existed a prerelease had no floating tag at all.
             type=raw,value=edge,enable=${{ needs.resolve-version.outputs.is_prerelease == 'true' }}
 
-      # Stage the prebuilt Linux install tree (built + version-stamped by
-      # build-packages on the Ubuntu-25.04 runner) into the build context so the
-      # runtime-assembled stage copies it straight in — NO vcpkg/source recompile.
-      - name: Download Linux install tree
+      # Stage the prebuilt per-arch install trees (built + version-stamped by
+      # build-packages in the glibc-2.36 container) into the build context so the
+      # runtime-assembled stage copies each straight in — NO vcpkg/source recompile.
+      - name: Download Linux install trees (amd64 + arm64)
         uses: actions/download-artifact@v4
         with:
-          name: installtree-linux-gcc
-          path: docker/context
+          pattern: installtree-linux-gcc*
+          path: docker/context-dl
+          merge-multiple: true
 
-      - name: Verify staged install tree
+      - name: Stage + verify per-arch install trees
         run: |
-          TARBALL=docker/context/installtree-linux-gcc.tar.gz
-          if [ ! -f "$TARBALL" ]; then
-            echo "::error::Staged install-tree tarball missing ($TARBALL) — cannot assemble the image."
-            exit 1
-          fi
-          tar tzf "$TARBALL" ./bin/aqualink-automate >/dev/null \
-            || { echo "::error::install-tree tarball does not contain ./bin/aqualink-automate"; exit 1; }
-          echo "Staged install tree OK ($(du -h "$TARBALL" | cut -f1))."
+          mkdir -p docker/context
+          mv docker/context-dl/installtree-linux-gcc.tar.gz       docker/context/installtree-linux-gcc-amd64.tar.gz
+          mv docker/context-dl/installtree-linux-gcc-arm64.tar.gz docker/context/installtree-linux-gcc-arm64.tar.gz
+          for a in amd64 arm64; do
+            T="docker/context/installtree-linux-gcc-$a.tar.gz"
+            [ -f "$T" ] || { echo "::error::Staged install-tree tarball missing ($T)."; exit 1; }
+            tar tzf "$T" ./bin/aqualink-automate >/dev/null \
+              || { echo "::error::$T does not contain ./bin/aqualink-automate"; exit 1; }
+            echo "Staged $a install tree OK ($(du -h "$T" | cut -f1))."
+          done
 
       # Assemble + push via buildx, wrapped in a bounded retry so a transient Docker
       # Hub CDN blob timeout pulling a base image doesn't fail the release. The image
@@ -237,7 +244,7 @@ jobs:
           retry_wait_seconds: 30
           retry_on: error
           command: |
-            cmd=(docker buildx build --target runtime-assembled --push)
+            cmd=(docker buildx build --target runtime-assembled --platform linux/amd64,linux/arm64 --push)
             while IFS= read -r tag;   do [ -n "$tag" ]   && cmd+=(--tag   "$tag");   done <<< "${IMAGE_TAGS}"
             while IFS= read -r label; do [ -n "$label" ] && cmd+=(--label "$label"); done <<< "${IMAGE_LABELS}"
             cmd+=(.)
@@ -252,16 +259,25 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE="ghcr.io/${{ github.repository }}:${{ needs.resolve-version.outputs.version }}"
-          echo "Pulling published image: $IMAGE"
+          echo "Manifest platforms:"
+          PLATFORMS="$(docker buildx imagetools inspect "$IMAGE" --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}} {{end}}')"
+          echo "  $PLATFORMS"
+          for want in linux/amd64 linux/arm64; do
+            echo "$PLATFORMS" | grep -qw "$want" \
+              || { echo "::error::Published image is missing the $want platform"; exit 1; }
+          done
+          echo "Pulling + running (native amd64):"
           docker pull "$IMAGE"
-          echo "Running --version on the pulled image:"
           OUTPUT="$(docker run --rm "$IMAGE" --version)"
           echo "$OUTPUT"
           if ! echo "$OUTPUT" | grep -qF "${{ needs.resolve-version.outputs.version }}"; then
             echo "::error::Published image did not report version ${{ needs.resolve-version.outputs.version }}"
             exit 1
           fi
-          echo "Published Docker image verified: pullable, runs, and reports ${{ needs.resolve-version.outputs.version }}."
+          echo "Running --version on the arm64 variant (QEMU):"
+          docker run --rm --platform linux/arm64 "$IMAGE" --version | grep -qF "${{ needs.resolve-version.outputs.version }}" \
+            && echo "arm64 variant OK" || { echo "::error::arm64 image did not run/report version"; exit 1; }
+          echo "Published multi-arch Docker image verified (amd64 + arm64)."
 
   github-release:
     name: GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.6.0-beta.1] - 2026-06-19
+
+### Added
+
+- **Native arm64 (Raspberry Pi) packages.** `.deb`, `.rpm`, and `.tar.gz` are now built for 64-bit ARM (aarch64) alongside the existing x86-64 builds, so Aqualink-Automate installs on a Raspberry Pi (3 / 4 / 5 and Zero 2 running a 64-bit OS) and other arm64 Linux hosts. The arm64 binaries are built natively on an `ubuntu-24.04-arm` runner — not cross-compiled or emulated — run the full test suite before packaging, and the `.deb` carries the correct `Architecture: arm64`. Pick the package matching your machine (`dpkg --print-architecture` / `uname -m`). The Docker image remains `linux/amd64` only.
+
+### Fixed
+
+- **Matter commissioning QR code now renders.** The diagnostics page's Matter pairing QR (added in 0.4.0-beta.1) did not draw; it now displays correctly, so the bridge can be paired by scanning rather than entering the manual pairing code.
+
 ## [0.5.0-beta.1] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.7.0-beta.1] - 2026-06-20
+
+### Added
+
+- **Runs on stock Raspberry Pi OS / Debian Bookworm.** The Linux `.deb`/`.rpm`/`.tgz` are now built on a glibc-2.36 base and bundle the gcc-15 C++ runtime, so they install and run on Raspberry Pi OS Bookworm (and every newer distro) on both `amd64` and `arm64`. Previously they required a too-new glibc/libstdc++ and would not even load on a stock Pi.
+- **Installs as a `systemd` service.** The `.deb`/`.rpm` create an `aqualink` service account (in `dialout` for serial access), install a default config at `/etc/aqualink-automate/aqualink-automate.conf`, and a hardened `systemd` unit (enabled on boot; start it once your serial port is set). The `.tgz` ships an `install.sh` that does the same.
+- **APT and DNF package repositories.** Install and stay updated with your package manager from a signed repository — `curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-apt.sh | sh` then `sudo apt install aqualink-automate` (and a `dnf` equivalent). See [INSTALL.md](INSTALL.md).
+- **Multi-arch Docker image.** The GHCR image is now `linux/amd64` + `linux/arm64`, so a Raspberry Pi pulls the arm64 variant from the same tag.
+- **Raspberry Pi guide** ([docs/raspberry-pi.md](docs/raspberry-pi.md)): install, RS-485 hardware (USB adapter vs GPIO UART), udev stable device naming, the service, and troubleshooting.
+
 ## [0.6.0-beta.1] - 2026-06-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -265,11 +265,17 @@ COPY --from=ci /src/install/config-linux-gcc/ .
 
 FROM runtime-base AS runtime-assembled
 
+# Multi-arch: buildx builds this stage once per --platform, setting TARGETARCH
+# (amd64 / arm64). Each install tree is built in the glibc-2.36 container for its
+# arch (release.yml docker-publish stages both under docker/context/ as
+# installtree-linux-gcc-<arch>.tar.gz); pick the matching one. The runtime base
+# (ubuntu:25.04, glibc 2.41) is newer than the package floor, so the tree runs.
+ARG TARGETARCH
 # The install tree arrives as a tarball (lossless symlinks + exec bits through the
 # CI artifact round-trip) and is unpacked here INSIDE the image, so it is correct
 # regardless of the host/runner filesystem (e.g. a Windows box cannot represent the
 # versioned-.so symlinks the binary loads by SONAME).
-COPY docker/context/installtree-linux-gcc.tar.gz /tmp/installtree.tar.gz
+COPY docker/context/installtree-linux-gcc-${TARGETARCH}.tar.gz /tmp/installtree.tar.gz
 RUN tar xzf /tmp/installtree.tar.gz -C /opt/aqualink-automate && rm /tmp/installtree.tar.gz
 # No USER directive: starts as root; the entrypoint applies PUID/PGID then drops
 # privileges via gosu (set PUID=0 to stay root). See docker-entrypoint.sh.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,9 +17,29 @@ This is the single authoritative guide for getting Aqualink Automate onto a mach
 - [Development container](#development-container)
 - [Docker](#docker)
 
+## Linux: APT / DNF repository (recommended)
+
+On Debian / Ubuntu / **Raspberry Pi OS** (`amd64` or `arm64`), add the signed APT
+repository — you then get `apt upgrade` updates and a managed `systemd` service:
+
+```bash
+curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-apt.sh | sh
+```
+
+On Fedora / RHEL / openSUSE:
+
+```bash
+curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-dnf.sh | sh
+```
+
+After installing, set your serial port in `/etc/aqualink-automate/aqualink-automate.conf`
+and `sudo systemctl start aqualink-automate`. See the [Raspberry Pi guide](docs/raspberry-pi.md).
+There is also a [Docker image](#docker) (multi-arch: `linux/amd64` + `linux/arm64`).
+
 ## Pre-built binaries
 
-Download the package for your platform from the [GitHub Releases](https://github.com/iainchesworth/aqualink-automate/releases) page.
+Prefer the repository above on Linux; otherwise download the package for your platform
+from the [GitHub Releases](https://github.com/iainchesworth/aqualink-automate/releases) page.
 
 | Platform | Package types | Notes |
 |----------|---------------|-------|

--- a/cicd/repo/index.html
+++ b/cicd/repo/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Aqualink Automate — package repositories</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 16px/1.6 system-ui, sans-serif; max-width: 46rem; margin: 3rem auto; padding: 0 1rem; }
+  h1 { margin-bottom: 0; }
+  p.lead { color: gray; margin-top: .25rem; }
+  pre { background: rgba(127,127,127,.12); padding: .9rem 1rem; border-radius: 8px; overflow-x: auto; }
+  code { font-family: ui-monospace, monospace; }
+  h2 { margin-top: 2rem; }
+  a { color: #2b7; }
+</style>
+</head>
+<body>
+  <h1>Aqualink Automate</h1>
+  <p class="lead">APT &amp; DNF package repositories — install and stay up to date with your system package manager.</p>
+
+  <h2>Debian / Ubuntu / Raspberry Pi OS (APT)</h2>
+  <pre><code>curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-apt.sh | sh</code></pre>
+  <p>Then <code>sudo apt upgrade</code> keeps it current. Builds for <code>amd64</code> and <code>arm64</code> (Raspberry Pi).</p>
+
+  <h2>Fedora / RHEL / openSUSE (DNF/YUM)</h2>
+  <pre><code>curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-dnf.sh | sh</code></pre>
+
+  <h2>After installing</h2>
+  <pre><code>sudoedit /etc/aqualink-automate/aqualink-automate.conf   # set serial-port = ...
+sudo systemctl start aqualink-automate
+journalctl -u aqualink-automate -f</code></pre>
+
+  <p>
+    Signing key: <a href="key.gpg">key.gpg</a> ·
+    <a href="https://github.com/iainchesworth/aqualink-automate">Project &amp; docs</a> ·
+    <a href="https://github.com/iainchesworth/aqualink-automate/blob/main/docs/raspberry-pi.md">Raspberry Pi guide</a>
+  </p>
+</body>
+</html>

--- a/cicd/repo/install-apt.sh
+++ b/cicd/repo/install-apt.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Add the Aqualink Automate APT repository and install (Debian / Ubuntu / Raspberry
+# Pi OS). After this, `sudo apt upgrade` keeps it up to date.
+#
+#   curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-apt.sh | sh
+set -e
+
+BASE="https://iainchesworth.github.io/aqualink-automate"
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+
+command -v curl >/dev/null 2>&1 || { echo "Please install curl first." >&2; exit 1; }
+
+$SUDO install -d -m 0755 /etc/apt/keyrings
+curl -fsSL "$BASE/key.gpg" | $SUDO gpg --dearmor -o /etc/apt/keyrings/aqualink-automate.gpg
+echo "deb [signed-by=/etc/apt/keyrings/aqualink-automate.gpg] $BASE/apt stable main" \
+  | $SUDO tee /etc/apt/sources.list.d/aqualink-automate.list >/dev/null
+
+$SUDO apt-get update
+$SUDO apt-get install -y aqualink-automate
+
+echo
+echo "Installed. Next: set your serial port in /etc/aqualink-automate/aqualink-automate.conf"
+echo "then: sudo systemctl start aqualink-automate"

--- a/cicd/repo/install-dnf.sh
+++ b/cicd/repo/install-dnf.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Add the Aqualink Automate DNF/YUM repository and install (Fedora / RHEL / openSUSE).
+# After this, `sudo dnf upgrade` keeps it up to date.
+#
+#   curl -fsSL https://iainchesworth.github.io/aqualink-automate/install-dnf.sh | sh
+set -e
+
+BASE="https://iainchesworth.github.io/aqualink-automate"
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+
+PM="dnf"; command -v dnf >/dev/null 2>&1 || PM="yum"
+
+$SUDO rpm --import "$BASE/key.gpg"
+$SUDO tee /etc/yum.repos.d/aqualink-automate.repo >/dev/null <<EOF
+[aqualink-automate]
+name=Aqualink Automate
+baseurl=$BASE/rpm
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=$BASE/key.gpg
+EOF
+
+$SUDO "$PM" install -y aqualink-automate
+
+echo
+echo "Installed. Next: set your serial port in /etc/aqualink-automate/aqualink-automate.conf"
+echo "then: sudo systemctl start aqualink-automate"

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -104,18 +104,95 @@ elseif("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
             PATTERN "pkgconfig" EXCLUDE
             PATTERN "cmake" EXCLUDE)
 
+    # Bundle the C++ runtime (libstdc++ / libgcc) alongside the vcpkg libraries.
+    # The project is built with a newer gcc than stable distros ship (e.g. gcc-15
+    # vs gcc-12 on Debian Bookworm / Raspberry Pi OS), so the binary AND the
+    # vcpkg .so files require a newer GLIBCXX/CXXABI than the target system has —
+    # without this they fail to load with "version `GLIBCXX_3.4.3x' not found".
+    # These libs are NOT under vcpkg_installed; locate the compiler's own copies
+    # and drop them into the same private dir, where the executable's $ORIGIN
+    # RPATH (and each vcpkg .so's own $ORIGIN RPATH) resolves them. (glibc itself
+    # cannot be bundled — that is handled by building on an old-glibc base.)
+    foreach(_aq_runtime_lib libstdc++.so.6 libgcc_s.so.1)
+        execute_process(
+            COMMAND "${CMAKE_CXX_COMPILER}" "-print-file-name=${_aq_runtime_lib}"
+            OUTPUT_VARIABLE _aq_runtime_lib_path
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        get_filename_component(_aq_runtime_lib_path "${_aq_runtime_lib_path}" REALPATH)
+        if(EXISTS "${_aq_runtime_lib_path}")
+            # RENAME to the SONAME so the loader finds it by the name the binary needs.
+            install(FILES "${_aq_runtime_lib_path}"
+                DESTINATION ${AQ_PRIVATE_LIBDIR}
+                COMPONENT Runtime
+                RENAME ${_aq_runtime_lib})
+        else()
+            message(WARNING "Could not locate ${_aq_runtime_lib} to bundle (got '${_aq_runtime_lib_path}')")
+        endif()
+    endforeach()
+
     # System installation packages for unix systems
     set(CPACK_GENERATOR "TGZ;DEB;RPM" CACHE STRING "Package targets")
 
-    # The dependency libraries are bundled privately, so dpkg-shlibdeps must NOT
-    # try to resolve them against system packages (it would fail / mis-declare).
-    # Declare only the genuine system runtime dependencies explicitly.
+    # The dependency libraries — including the C++ runtime above — are bundled
+    # privately, so dpkg-shlibdeps must NOT try to resolve them against system
+    # packages. The ONLY genuine system runtime dependency is glibc. The version
+    # floor matches the build base: the release packages are built on a glibc-2.36
+    # base (Debian Bookworm / Raspberry Pi OS) so they run there and on every newer
+    # distro; keep this in lockstep with the package build environment.
     set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libstdc++6, libgcc-s1")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.36), systemd")
     set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
     # RPM's automatic dependency scanner sees the bundled .so as both provided
     # (by the private lib dir) and required (by the binary), so it self-resolves.
     set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
+
+    # -----------------------------------------------------------------------
+    # System integration — systemd service, /etc config, service account.
+    # (See packaging/README.md.) Installed for every Linux generator; the .deb/
+    # .rpm control scripts create the 'aqualink' account + enable the unit, and
+    # the relocatable .tgz ships packaging/tarball/install.sh which does the same.
+    # -----------------------------------------------------------------------
+    set(AQ_PACKAGING_DIR "${CMAKE_SOURCE_DIR}/packaging")
+
+    # systemd vendor unit -> /usr/lib/systemd/system; sysusers declaration ->
+    # /usr/lib/sysusers.d (both relative to the /usr package prefix).
+    install(FILES "${AQ_PACKAGING_DIR}/systemd/aqualink-automate.service"
+        DESTINATION lib/systemd/system COMPONENT Runtime)
+    install(FILES "${AQ_PACKAGING_DIR}/sysusers.d/aqualink-automate.conf"
+        DESTINATION lib/sysusers.d COMPONENT Runtime)
+
+    # Default config -> /etc (ABSOLUTE: /etc is outside the /usr prefix). Marked
+    # as a conffile (deb, via the control file) / %config(noreplace) (rpm, below)
+    # so admin edits survive upgrades.
+    install(FILES "${AQ_PACKAGING_DIR}/config/aqualink-automate.conf"
+        DESTINATION /etc/aqualink-automate COMPONENT Runtime)
+
+    # RS-485 udev naming template, alongside the example configs.
+    install(FILES "${AQ_PACKAGING_DIR}/udev/60-aqualink-automate.rules.example"
+        DESTINATION ${AQ_EXAMPLES_DESTINATION} COMPONENT ExampleConfigs)
+
+    # Ship the packaging sources inside the archive so the relocatable .tgz's
+    # install.sh can place them (deb/rpm ignore these — they use the copies above
+    # plus their control scripts), and the .tgz installer/uninstaller at the root.
+    install(DIRECTORY
+        "${AQ_PACKAGING_DIR}/systemd" "${AQ_PACKAGING_DIR}/config" "${AQ_PACKAGING_DIR}/sysusers.d"
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/aqualink-automate/packaging COMPONENT Runtime)
+    install(PROGRAMS
+        "${AQ_PACKAGING_DIR}/tarball/install.sh" "${AQ_PACKAGING_DIR}/tarball/uninstall.sh"
+        DESTINATION . COMPONENT Runtime)
+
+    # .deb maintainer scripts (create account, enable unit) + conffiles list.
+    set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+        "${AQ_PACKAGING_DIR}/deb/postinst"
+        "${AQ_PACKAGING_DIR}/deb/prerm"
+        "${AQ_PACKAGING_DIR}/deb/postrm"
+        "${AQ_PACKAGING_DIR}/deb/conffiles")
+
+    # .rpm scriptlets + protect the config on upgrade + systemd runtime dep.
+    set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${AQ_PACKAGING_DIR}/rpm/post.sh")
+    set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${AQ_PACKAGING_DIR}/rpm/preun.sh")
+    set(CPACK_RPM_USER_FILELIST "%config(noreplace) /etc/aqualink-automate/aqualink-automate.conf")
+    set(CPACK_RPM_PACKAGE_REQUIRES "systemd")
 
  else()
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -1,0 +1,112 @@
+# Running on a Raspberry Pi
+
+Aqualink Automate runs well on a Raspberry Pi sitting next to your pool equipment,
+wired to the AquaLink RS-485 bus. This page is the Pi-specific quick start; for the
+full option reference see [configuration.md](configuration.md), and for non-Pi hosts
+see [hardware-server-automation.md](hardware-server-automation.md).
+
+## Which Pi
+
+| Model | Notes |
+|-------|-------|
+| **Pi 5 / Pi 4** | Plenty of headroom; also fine for the Docker image with the Matter bridge. |
+| **Pi 3 / Zero 2 W** | Ample for the app + web UI. The Zero 2 W (512 MB RAM) is the lowest-cost always-on option. |
+
+Use the **64-bit (arm64) Raspberry Pi OS** (Bookworm or newer). The `.deb`/`.rpm`/`.tgz`
+are built for `arm64` (and `amd64`); 32-bit Raspberry Pi OS is not currently supported.
+
+## Install
+
+Download the `arm64` `.deb` from the [latest release](https://github.com/iainchesworth/aqualink-automate/releases)
+and install it — the package brings its own runtime libraries, so it works on a stock
+Raspberry Pi OS with no extra dependencies:
+
+```bash
+sudo apt install ./aqualink-automate_*_arm64.deb
+```
+
+This installs the binary, a `systemd` service, the `aqualink` service account (added to
+the `dialout` group for serial access), and a default config at
+`/etc/aqualink-automate/aqualink-automate.conf`. The service is **enabled on boot but not
+started yet** — it needs your serial port first (below).
+
+## Connect the RS-485 bus
+
+You need an RS-485 transceiver between the Pi and the AquaLink bus. Two common ways:
+
+### A. USB-RS485 adapter (easiest)
+
+Plug in a USB-RS485 adapter (FTDI, CH340, or CP2102 based). It appears as `/dev/ttyUSB0`:
+
+```bash
+ls -l /dev/serial/by-id/      # confirm it's detected
+```
+
+Because `/dev/ttyUSB0` can renumber across reboots/replugs, pin a stable name. Copy the
+shipped udev template and uncomment the line for your adapter:
+
+```bash
+sudo cp /usr/share/doc/aqualink-automate/examples/60-aqualink-automate.rules.example \
+        /etc/udev/rules.d/60-aqualink-automate.rules
+sudoedit /etc/udev/rules.d/60-aqualink-automate.rules     # uncomment your adapter
+sudo udevadm control --reload-rules && sudo udevadm trigger
+ls -l /dev/aqualink-rs485                                 # -> your adapter
+```
+
+### B. GPIO UART + RS-485 HAT (no USB port used)
+
+If you use a MAX485/transceiver HAT on the 40-pin header, enable the **PL011** UART and
+free it from the serial login console:
+
+```bash
+sudo raspi-config        # Interface Options -> Serial Port:
+                         #   login shell over serial?  NO
+                         #   serial hardware enabled?  YES
+```
+
+For full-rate PL011 on `/dev/ttyAMA0` (rather than the lower-quality mini-UART), add to
+`/boot/firmware/config.txt`:
+
+```
+enable_uart=1
+dtoverlay=disable-bt        # frees PL011 (/dev/ttyAMA0) on Pi 3/4/Zero 2 W
+```
+
+Reboot, then use `serial-port = /dev/ttyAMA0`.
+
+## Configure and start
+
+Set your serial device in the config, then start the service:
+
+```bash
+sudoedit /etc/aqualink-automate/aqualink-automate.conf
+#   serial-port = /dev/aqualink-rs485      (or /dev/ttyUSB0, or /dev/ttyAMA0)
+
+sudo systemctl start aqualink-automate
+sudo systemctl status aqualink-automate
+journalctl -u aqualink-automate -f         # live logs
+```
+
+The web UI is at `http://<pi-address>:9000`. To use port 80 instead, set
+`http-port = 80` in the config (the service is granted `CAP_NET_BIND_SERVICE`, so it
+does not need to run as root). If you expose the UI to your LAN, consider setting
+`api-auth-token`.
+
+## Updating / uninstalling
+
+```bash
+sudo apt install ./aqualink-automate_<newer>_arm64.deb   # upgrade (config is preserved)
+sudo systemctl status aqualink-automate                   # restarts automatically on upgrade
+
+sudo apt remove aqualink-automate                         # remove (keeps /etc config)
+sudo apt purge  aqualink-automate                         # remove config + state too
+```
+
+## Troubleshooting
+
+- **`status` shows the serial port can't be opened** — check the device path, that the
+  adapter is plugged in, and that the `aqualink` user is in `dialout`
+  (`id aqualink`). After adding a udev rule, re-run `udevadm trigger`.
+- **UI not reachable from another machine** — the default binds `0.0.0.0`; check the
+  Pi's firewall and that you used the Pi's LAN address and port (`9000` by default).
+- **Logs** — everything goes to the journal: `journalctl -u aqualink-automate -e`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -177,6 +177,32 @@ Additionally:
 
 These packages are produced by CPack via the matching `pack-*` presets. `pack-*` presets exist only for the **Release** configure presets (those with no `-debug`/`-coverage` suffix), so swap the `config-` prefix for `pack-` only on a Release preset — for example `config-linux-gcc` → `pack-linux-gcc`. See [INSTALL.md](../INSTALL.md) for the local pack-* preset workflow.
 
+The Docker image is **multi-arch** (`linux/amd64` + `linux/arm64`) — a single tag serves both, so a Raspberry Pi pulls the arm64 variant automatically.
+
+## Package repositories (APT + DNF)
+
+`.github/workflows/publish-repos.yml` publishes GPG-signed **APT** (reprepro) and
+**DNF** (createrepo_c) repositories to the `gh-pages` branch when a release is
+published, so users can `apt install` / `dnf install` and get `apt upgrade` updates
+(see [INSTALL.md](../INSTALL.md)). It **no-ops until configured**, so it is safe to
+merge first. One-time setup:
+
+1. **Generate a signing key** (no passphrase keeps CI simplest):
+   ```bash
+   gpg --batch --quick-generate-key "Aqualink Automate <you@example.com>" rsa4096 sign never
+   gpg --armor --export-secret-keys "Aqualink Automate" > aqualink-repo-private.asc
+   ```
+2. **Add the secret** `REPO_GPG_PRIVATE_KEY` (Settings → Secrets → Actions) with the
+   contents of `aqualink-repo-private.asc`. If the key has a passphrase, also add
+   `REPO_GPG_PASSPHRASE`. Then delete the local private-key file.
+3. **Enable GitHub Pages** (Settings → Pages) serving from the `gh-pages` branch
+   (the first publish creates it). The repo base URL is
+   `https://<owner>.github.io/aqualink-automate/`.
+
+To (re)publish an existing release into the repos, run the workflow manually with its
+tag (`workflow_dispatch`). The publish job preserves previously-published packages
+(`keep_files: true`), so the repo accumulates the full version history.
+
 ## Troubleshooting
 
 ### Version shows `0.0.0-dev` in CI

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,30 @@
+# Linux packaging — system integration files
+
+These files turn the `.deb` / `.rpm` / `.tar.gz` from "a binary in `/usr/bin`" into a
+managed **systemd service** with a service account, `/etc` config, and serial-port
+access. They are wired into CPack in [`cmake/CPackConfig.cmake`](../cmake/CPackConfig.cmake)
+(Linux branch).
+
+| File | Installed to (deb/rpm) | Purpose |
+|------|------------------------|---------|
+| `systemd/aqualink-automate.service` | `/usr/lib/systemd/system/` | `Type=simple` unit; runs as `aqualink`, reads `/etc/.../aqualink-automate.conf`, logs to journald, hardened, `dialout` for serial. |
+| `config/aqualink-automate.conf` | `/etc/aqualink-automate/` (conffile / `%config(noreplace)`) | Default config. Listens on `0.0.0.0:9000`, HTTPS off; serial port is left for the admin to set. |
+| `sysusers.d/aqualink-automate.conf` | `/usr/lib/sysusers.d/` | Declares the `aqualink` system user + `dialout` membership. |
+| `udev/60-aqualink-automate.rules.example` | `…/share/doc/aqualink-automate/examples/` | Template for a stable `/dev/aqualink-rs485` symlink (admin copies + edits). |
+| `deb/{postinst,prerm,postrm,conffiles}` | deb control archive | Create the account, enable the unit; never auto-start on a *fresh* install (the service needs a serial port first). |
+| `rpm/{post.sh,preun.sh}` | rpm scriptlets | Same behaviour for the `.rpm`. |
+| `tarball/{install,uninstall}.sh` | `…/share/aqualink-automate/packaging/tarball/` (+ `install.sh` at the tarball root) | The relocatable `.tar.gz` has no maintainer scripts, so these do the same job by hand (install to `/opt/aqualink-automate`, template the unit's `ExecStart`). |
+
+## First-run behaviour (deb/rpm)
+
+A fresh install creates the service and **enables it on boot** but does **not start it**,
+because the service is useless (and would `Restart=on-failure` loop) until a serial port
+is configured. The postinst prints the two next steps:
+
+```
+sudo nano /etc/aqualink-automate/aqualink-automate.conf   # set serial-port = /dev/ttyUSB0
+sudo systemctl start aqualink-automate
+journalctl -u aqualink-automate -f
+```
+
+An *upgrade* restarts the service only if it was already running.

--- a/packaging/config/aqualink-automate.conf
+++ b/packaging/config/aqualink-automate.conf
@@ -1,0 +1,51 @@
+# Aqualink Automate - configuration
+#
+# Flat INI: "<option-long-name> = <value>", one per line; '#' starts a comment.
+# This is the file the systemd service reads (ExecStart ... --config <this file>).
+# Full reference of every option:  /usr/share/doc/aqualink-automate/examples/config-full.conf
+# Online docs:                     https://github.com/iainchesworth/aqualink-automate/blob/main/docs/configuration.md
+#
+# After editing:  sudo systemctl restart aqualink-automate
+# Live logs:      journalctl -u aqualink-automate -f
+
+# --- RS-485 connection -------------------------------------------------------
+# REQUIRED for live data. Pick ONE of the following and uncomment it.
+#
+# 1) Local USB-RS485 adapter (most common). List adapters with:
+#       ls -l /dev/serial/by-id/
+#serial-port = /dev/ttyUSB0
+#baudrate = 9600
+#
+# 2) A stable name via the optional udev rule (see the udev example shipped in
+#    /usr/share/doc/aqualink-automate/examples/), so it is not /dev/ttyUSB<n>:
+#serial-port = /dev/aqualink-rs485
+#
+# 3) A remote RFC2217 serial bridge (no local device needed):
+#remote-serial-port = 192.168.1.50:8899
+#rfc2217 = true
+
+# --- Pool controller emulation ----------------------------------------------
+jandy-device-type = onetouch
+jandy-device-id = 0x41
+
+# --- Web interface -----------------------------------------------------------
+# Listen on all interfaces so the UI is reachable from your LAN; use 127.0.0.1
+# to restrict it to this host only. The service runs unprivileged on port 9000.
+# You may set http-port = 80 - the service is granted CAP_NET_BIND_SERVICE.
+address = 0.0.0.0
+http-port = 9000
+disable-https = true
+# Require a token for API / WebSocket access (recommended if exposed to the LAN):
+#api-auth-token = change-me
+
+# --- MQTT / Home Assistant (optional) ---------------------------------------
+#mqtt = true
+#mqtt-host = 192.168.1.100
+#mqtt-port = 1883
+#home-assistant = true
+
+# --- Logging (optional) ------------------------------------------------------
+# More global detail:
+#debug = true
+# Per-channel, e.g.:
+#loglevel-serial = debug

--- a/packaging/deb/conffiles
+++ b/packaging/deb/conffiles
@@ -1,0 +1,1 @@
+/etc/aqualink-automate/aqualink-automate.conf

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Aqualink Automate - Debian postinst
+set -e
+
+SERVICE=aqualink-automate.service
+USER=aqualink
+GROUP=aqualink
+STATE_DIR=/var/lib/aqualink-automate
+SYSUSERS=/usr/lib/sysusers.d/aqualink-automate.conf
+
+create_account() {
+    # Prefer systemd-sysusers (declarative); fall back to useradd/groupadd.
+    if command -v systemd-sysusers >/dev/null 2>&1 && [ -f "$SYSUSERS" ]; then
+        systemd-sysusers "$SYSUSERS" >/dev/null 2>&1 || true
+    fi
+    if ! getent group "$GROUP" >/dev/null 2>&1; then
+        groupadd --system "$GROUP" >/dev/null 2>&1 || true
+    fi
+    if ! getent passwd "$USER" >/dev/null 2>&1; then
+        useradd --system --gid "$GROUP" --no-create-home --home-dir "$STATE_DIR" \
+                --shell /usr/sbin/nologin --comment "Aqualink Automate" "$USER" >/dev/null 2>&1 || true
+    fi
+    # Serial-port access.
+    if getent group dialout >/dev/null 2>&1; then
+        usermod --append --groups dialout "$USER" >/dev/null 2>&1 || true
+    fi
+    mkdir -p "$STATE_DIR"
+    chown "$USER":"$GROUP" "$STATE_DIR" 2>/dev/null || true
+}
+
+case "$1" in
+    configure)
+        create_account
+
+        # Pick up the (optional) RS-485 naming rule if the admin installed one.
+        if command -v udevadm >/dev/null 2>&1; then
+            udevadm control --reload-rules >/dev/null 2>&1 || true
+        fi
+
+        if [ -d /run/systemd/system ]; then
+            systemctl daemon-reload >/dev/null 2>&1 || true
+            systemctl enable "$SERVICE" >/dev/null 2>&1 || true
+            if [ -n "$2" ]; then
+                # Upgrade: restart only if it was already running.
+                if systemctl is-active --quiet "$SERVICE"; then
+                    systemctl restart "$SERVICE" >/dev/null 2>&1 || true
+                fi
+            else
+                # Fresh install: do NOT auto-start - the service needs a serial
+                # port configured first (it would otherwise restart-loop).
+                echo "Aqualink Automate is installed and will start on boot."
+                echo "  1. Set your RS-485 device in /etc/aqualink-automate/aqualink-automate.conf"
+                echo "     (serial-port = ...), then:"
+                echo "  2. sudo systemctl start aqualink-automate"
+                echo "  Web UI: http://<this-host>:9000   Logs: journalctl -u aqualink-automate -f"
+            fi
+        fi
+        ;;
+esac
+
+exit 0

--- a/packaging/deb/postrm
+++ b/packaging/deb/postrm
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Aqualink Automate - Debian postrm
+set -e
+
+case "$1" in
+    remove)
+        if [ -d /run/systemd/system ]; then
+            systemctl daemon-reload >/dev/null 2>&1 || true
+        fi
+        ;;
+    purge)
+        # Remove configuration and runtime state. The service account is left in
+        # place (removing system users on purge is discouraged and risks orphaned
+        # file ownership elsewhere).
+        rm -rf /etc/aqualink-automate /var/lib/aqualink-automate
+        if [ -d /run/systemd/system ]; then
+            systemctl daemon-reload >/dev/null 2>&1 || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Aqualink Automate - Debian prerm
+set -e
+
+SERVICE=aqualink-automate.service
+
+case "$1" in
+    remove|deconfigure)
+        if [ -d /run/systemd/system ]; then
+            systemctl stop "$SERVICE" >/dev/null 2>&1 || true
+            systemctl disable "$SERVICE" >/dev/null 2>&1 || true
+        fi
+        ;;
+esac
+
+exit 0

--- a/packaging/rpm/post.sh
+++ b/packaging/rpm/post.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Aqualink Automate - RPM %post  ($1 = 1 on first install, >=2 on upgrade)
+set -e
+
+SERVICE=aqualink-automate.service
+USER=aqualink
+GROUP=aqualink
+STATE_DIR=/var/lib/aqualink-automate
+SYSUSERS=/usr/lib/sysusers.d/aqualink-automate.conf
+
+if command -v systemd-sysusers >/dev/null 2>&1 && [ -f "$SYSUSERS" ]; then
+    systemd-sysusers "$SYSUSERS" >/dev/null 2>&1 || true
+fi
+if ! getent group "$GROUP" >/dev/null 2>&1; then
+    groupadd --system "$GROUP" >/dev/null 2>&1 || true
+fi
+if ! getent passwd "$USER" >/dev/null 2>&1; then
+    useradd --system --gid "$GROUP" --no-create-home --home-dir "$STATE_DIR" \
+            --shell /sbin/nologin --comment "Aqualink Automate" "$USER" >/dev/null 2>&1 || true
+fi
+if getent group dialout >/dev/null 2>&1; then
+    usermod --append --groups dialout "$USER" >/dev/null 2>&1 || true
+fi
+mkdir -p "$STATE_DIR"
+chown "$USER":"$GROUP" "$STATE_DIR" 2>/dev/null || true
+
+if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload-rules >/dev/null 2>&1 || true
+fi
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || true
+    systemctl enable "$SERVICE" >/dev/null 2>&1 || true
+    if [ "$1" -ge 2 ]; then
+        # Upgrade: restart only if already running.
+        if systemctl is-active --quiet "$SERVICE"; then
+            systemctl restart "$SERVICE" >/dev/null 2>&1 || true
+        fi
+    else
+        echo "Aqualink Automate is installed and will start on boot."
+        echo "  1. Set your RS-485 device in /etc/aqualink-automate/aqualink-automate.conf"
+        echo "  2. sudo systemctl start aqualink-automate"
+        echo "  Web UI: http://<this-host>:9000   Logs: journalctl -u aqualink-automate -f"
+    fi
+fi
+
+exit 0

--- a/packaging/rpm/preun.sh
+++ b/packaging/rpm/preun.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Aqualink Automate - RPM %preun  ($1 = 0 on final erase, >=1 on upgrade)
+set -e
+
+SERVICE=aqualink-automate.service
+
+if [ "$1" -eq 0 ]; then
+    # Final removal (not an upgrade): stop + disable.
+    if [ -d /run/systemd/system ]; then
+        systemctl stop "$SERVICE" >/dev/null 2>&1 || true
+        systemctl disable "$SERVICE" >/dev/null 2>&1 || true
+    fi
+fi
+
+exit 0

--- a/packaging/systemd/aqualink-automate.service
+++ b/packaging/systemd/aqualink-automate.service
@@ -1,0 +1,55 @@
+[Unit]
+Description=Aqualink Automate - Jandy/Zodiac AquaLink RS pool controller bridge
+Documentation=https://github.com/iainchesworth/aqualink-automate
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Dedicated unprivileged service account (created by the package). It is a member
+# of 'dialout' so it can open the RS-485 serial device.
+User=aqualink
+Group=aqualink
+SupplementaryGroups=dialout
+
+ExecStart=/usr/bin/aqualink-automate --config /etc/aqualink-automate/aqualink-automate.conf
+
+# The app handles SIGTERM/SIGINT with a clean, ordered shutdown.
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=30s
+KillSignal=SIGTERM
+
+# Logs are written to stderr -> the journal (journalctl -u aqualink-automate).
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=aqualink-automate
+
+# Persistent state (history DB, equipment-cache snapshots) lives under
+# /var/lib/aqualink-automate, created and owned by the service account.
+StateDirectory=aqualink-automate
+WorkingDirectory=/var/lib/aqualink-automate
+
+# Let the unprivileged account bind a privileged port if the user sets
+# http-port/https-port < 1024 (the packaged default is the unprivileged 9000).
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# --- Hardening -------------------------------------------------------------
+# The app only needs to read /etc + /usr, write its StateDirectory, talk to the
+# network, and open the serial device (granted via the 'dialout' group; /dev is
+# left intact, so PrivateDevices is NOT enabled).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectKernelLogs=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictNamespaces=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/sysusers.d/aqualink-automate.conf
+++ b/packaging/sysusers.d/aqualink-automate.conf
@@ -1,0 +1,6 @@
+# systemd-sysusers declaration for the Aqualink Automate service account.
+# Applied by the package's install scriptlet (and natively by systemd-sysusers).
+#Type Name      ID  GECOS                Home directory               Shell
+u     aqualink  -   "Aqualink Automate"  /var/lib/aqualink-automate   /usr/sbin/nologin
+# Serial-port access.
+m     aqualink  dialout

--- a/packaging/tarball/install.sh
+++ b/packaging/tarball/install.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Install Aqualink Automate (systemd service + /etc config) from an extracted
+# tarball. The .deb/.rpm do this for you - this script is for the .tar.gz.
+#
+# Usage (from the extracted tarball root, as root):
+#       sudo ./install.sh            # installs to /opt/aqualink-automate
+#       sudo AQ_PREFIX=/srv/aqua ./install.sh
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PKG="$HERE/share/aqualink-automate/packaging"
+DEST="${AQ_PREFIX:-/opt/aqualink-automate}"
+USER=aqualink
+GROUP=aqualink
+STATE_DIR=/var/lib/aqualink-automate
+
+[ "$(id -u)" -eq 0 ] || { echo "Please run as root (sudo)." >&2; exit 1; }
+[ -x "$HERE/bin/aqualink-automate" ] || { echo "Run this from the extracted tarball root (bin/aqualink-automate not found)." >&2; exit 1; }
+[ -d "$PKG" ] || { echo "Packaging files not found at $PKG." >&2; exit 1; }
+
+echo "Installing application tree to $DEST ..."
+mkdir -p "$DEST"
+cp -a "$HERE"/. "$DEST"/
+rm -f "$DEST/install.sh" "$DEST/uninstall.sh"
+
+echo "Creating service account '$USER' ..."
+if command -v systemd-sysusers >/dev/null 2>&1 && [ -f "$PKG/sysusers.d/aqualink-automate.conf" ]; then
+    install -m 0644 "$PKG/sysusers.d/aqualink-automate.conf" /usr/lib/sysusers.d/aqualink-automate.conf
+    systemd-sysusers /usr/lib/sysusers.d/aqualink-automate.conf >/dev/null 2>&1 || true
+fi
+getent group "$GROUP" >/dev/null 2>&1 || groupadd --system "$GROUP" >/dev/null 2>&1 || true
+getent passwd "$USER" >/dev/null 2>&1 || useradd --system --gid "$GROUP" --no-create-home \
+    --home-dir "$STATE_DIR" --shell /usr/sbin/nologin --comment "Aqualink Automate" "$USER" >/dev/null 2>&1 || true
+getent group dialout >/dev/null 2>&1 && usermod --append --groups dialout "$USER" >/dev/null 2>&1 || true
+mkdir -p "$STATE_DIR" && chown "$USER":"$GROUP" "$STATE_DIR" 2>/dev/null || true
+
+echo "Installing /etc/aqualink-automate/aqualink-automate.conf ..."
+mkdir -p /etc/aqualink-automate
+if [ -f /etc/aqualink-automate/aqualink-automate.conf ]; then
+    echo "  (keeping your existing config)"
+else
+    install -m 0640 "$PKG/config/aqualink-automate.conf" /etc/aqualink-automate/aqualink-automate.conf
+    chgrp "$GROUP" /etc/aqualink-automate/aqualink-automate.conf 2>/dev/null || true
+fi
+
+echo "Installing systemd unit (ExecStart -> $DEST/bin) ..."
+sed "s|/usr/bin/aqualink-automate|$DEST/bin/aqualink-automate|" \
+    "$PKG/systemd/aqualink-automate.service" > /etc/systemd/system/aqualink-automate.service
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload
+    systemctl enable aqualink-automate.service >/dev/null 2>&1 || true
+fi
+
+cat <<EOF
+
+Aqualink Automate installed to $DEST.
+  1. Edit /etc/aqualink-automate/aqualink-automate.conf  (set serial-port = ...)
+  2. sudo systemctl start aqualink-automate
+  Web UI: http://<this-host>:9000   Logs: journalctl -u aqualink-automate -f
+  Uninstall: sudo $DEST/share/aqualink-automate/packaging/tarball/uninstall.sh
+EOF

--- a/packaging/tarball/uninstall.sh
+++ b/packaging/tarball/uninstall.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Uninstall an Aqualink Automate tarball install (the reverse of install.sh).
+# Usage:  sudo ./uninstall.sh            # keeps /etc config + state
+#         sudo AQ_PURGE=1 ./uninstall.sh # also removes config + state
+set -e
+
+DEST="${AQ_PREFIX:-/opt/aqualink-automate}"
+
+[ "$(id -u)" -eq 0 ] || { echo "Please run as root (sudo)." >&2; exit 1; }
+
+if [ -d /run/systemd/system ]; then
+    systemctl stop aqualink-automate.service >/dev/null 2>&1 || true
+    systemctl disable aqualink-automate.service >/dev/null 2>&1 || true
+fi
+rm -f /etc/systemd/system/aqualink-automate.service
+[ -d /run/systemd/system ] && systemctl daemon-reload >/dev/null 2>&1 || true
+
+rm -rf "$DEST"
+
+if [ "${AQ_PURGE:-0}" = "1" ]; then
+    rm -rf /etc/aqualink-automate /var/lib/aqualink-automate
+    echo "Removed application, config, and state. The 'aqualink' service account was left in place."
+else
+    echo "Removed application + service unit. Kept /etc/aqualink-automate and /var/lib/aqualink-automate."
+    echo "Run with AQ_PURGE=1 to remove those too."
+fi

--- a/packaging/udev/60-aqualink-automate.rules.example
+++ b/packaging/udev/60-aqualink-automate.rules.example
@@ -1,0 +1,26 @@
+# Stable device name for your RS-485 adapter (EXAMPLE / template).
+#
+# A USB-RS485 adapter enumerates as /dev/ttyUSB0, /dev/ttyUSB1, ... and the number
+# can change across reboots or replugs. This rule pins it to a fixed name,
+# /dev/aqualink-rs485, so the config never has to change.
+#
+# 1. Find your adapter's identifiers:
+#       udevadm info -a -n /dev/ttyUSB0 | grep -E 'idVendor|idProduct|serial'
+# 2. Copy this file to /etc/udev/rules.d/60-aqualink-automate.rules, uncomment the
+#    line that matches your adapter (or add your own idVendor/idProduct/serial).
+# 3. Reload:
+#       sudo udevadm control --reload-rules && sudo udevadm trigger
+# 4. Set in /etc/aqualink-automate/aqualink-automate.conf:
+#       serial-port = /dev/aqualink-rs485
+#
+# FTDI FT232 (very common):
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="aqualink-rs485", GROUP="dialout", MODE="0660"
+#
+# WCH CH340/CH341:
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", SYMLINK+="aqualink-rs485", GROUP="dialout", MODE="0660"
+#
+# Silicon Labs CP2102:
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="aqualink-rs485", GROUP="dialout", MODE="0660"
+#
+# Pin a SPECIFIC adapter by serial number (when you have several of the same model):
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{serial}=="A12345BC", SYMLINK+="aqualink-rs485", GROUP="dialout", MODE="0660"


### PR DESCRIPTION
Promote develop to main for the v0.7.0-beta.1 pre-release.

**Raspberry Pi (and x64) Linux, done properly:**
- Linux `.deb`/`.rpm`/`.tgz` now build on a glibc-2.36 base + bundle the gcc-15 C++ runtime, so they run on **stock Raspberry Pi OS / Debian Bookworm** (amd64 + arm64) — the previous packages required a too-new glibc and would not load on a Pi.
- Install as a **systemd service** (service account, `/etc` config, `dialout`, hardened unit).
- **Multi-arch Docker** image (`linux/amd64` + `linux/arm64`).
- Signed **APT + DNF repositories** (`apt install` / `dnf install`) published to GitHub Pages.
- Raspberry Pi documentation.

Validated: full release dry-run green on all platforms; deb runs on clean `debian:bookworm`; both Docker arch images build + run.