### PR TITLE
ci: target Dependabot at develop and group updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,50 @@
 # Dependabot keeps third-party dependencies current and, crucially, advances the
 # SHA-pinned GitHub Actions (see the `uses: <owner>/<repo>@<40-char-sha> # vX.Y.Z`
-# pins across .github/workflows/**) so the pins do not silently rot — each bump
-# arrives as a reviewable PR that updates both the SHA and the version comment.
+# pins across .github/workflows/**) so the pins do not silently rot.
+#
+# PRs target the `develop` integration branch (not the default `main`) so updates
+# flow through the normal develop -> main release path, and each ecosystem's bumps
+# are collapsed into a single grouped weekly PR rather than one PR per dependency.
 version: 2
 updates:
   # GitHub Actions used by the workflows + composite actions under .github/.
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # npm — repo root (Playwright e2e harness: package.json / package-lock.json).
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
+    groups:
+      npm-root:
+        patterns:
+          - "*"
 
   # npm — the Matter bridge sidecar (matter-bridge/package.json).
   - package-ecosystem: "npm"
     directory: "/matter-bridge"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
+    groups:
+      matter-bridge:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot reads this config from the default branch (`main`), so its PRs were landing on `main` instead of the `develop` integration branch, and each dependency arrived as its own PR (8 open at once for the last GitHub Actions batch).

This change:
- adds `target-branch: develop` to all three ecosystems (github-actions, npm root, npm matter-bridge) so future PRs target develop and flow through the normal develop -> main release path;
- groups each ecosystem's bumps into a single weekly PR instead of one-per-dependency.

Note: required checks (Linux GCC / Docker / Matter Bridge) are currently red on `main` and `develop` for unrelated reasons; this PR touches only `.github/dependabot.yml`.