### PR TITLE
ci: bump actions/cache to v6.1.0 in setup-vcpkg-cache composite action

### DIFF
--- a/.github/actions/setup-vcpkg-cache/action.yml
+++ b/.github/actions/setup-vcpkg-cache/action.yml
@@ -29,7 +29,7 @@ runs:
         echo "VCPKG_DOWNLOADS=$DOWNLOADS_DIR" >> "$GITHUB_ENV"
 
     - name: Cache vcpkg downloads
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/vcpkg/downloads
         key: vcpkg-downloads-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json') }}
@@ -45,7 +45,7 @@ runs:
     # disjoint archives and each gets its own cache. vcpkg names archives by ABI
     # hash, so multiple triplets would coexist safely in a single cache dir anyway.
     - name: Cache vcpkg binaries
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/vcpkg/archives
         key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-version.outputs.hash }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'cmake/vcpkg/triplets/**', 'cmake/vcpkg/overlays/**') }}


### PR DESCRIPTION
Aligns the composite action's two `actions/cache` pins (were @v5) with the v6.1.0 SHA already in `.github/workflows/_build.yml`. Dependabot's #24 missed this copy.