### PR TITLE
ci: stop push/PR double-runs (push on main+develop only; per-branch concurrency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,23 @@
 name: CI
 
 on:
+  # Only the long-lived branches build on push; feature branches build via their
+  # pull_request (a WIP push to a branch without a PR runs nothing, and a push to
+  # a branch WITH a PR is covered by the PR run). This removes the per-WIP-push
+  # full-matrix runs and the push+PR double-run on every feature branch.
   push:
-    branches: ["main", "develop", "feat/**", "fix/**", "docs/**", "ci/**", "test/**", "refactor/**", "chore/**", "build/**", "perf/**"]
+    branches: ["main", "develop"]
   pull_request:
     branches: ["develop", "main"]
 
+# Group by the source branch across BOTH event types (head_ref is set for PRs,
+# ref_name for pushes), so a branch can only have one CI run in flight. This
+# collapses the push run and the pull_request run of the same commit into one
+# lane — notably on a develop->main promotion, where the develop push and the
+# PR both target commit on `develop` and would otherwise run two Windows MSVC
+# builds at once on the single self-hosted runner and collide.
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Stops the redundant push+PR double-runs that, on the single self-hosted Windows runner, caused two `Build & Test / Windows MSVC` builds to collide (seen during the #41 develop→main promotion, where the same commit fired a `push` run and a `pull_request` run).

## Changes (`ci.yml` only)

- **`push:` now only `[main, develop]`** (was every `<type>/**` branch). Feature branches build via their PR: a WIP push to a branch with no PR runs nothing; a push to a branch with a PR is covered by the PR run. Removes per-WIP-push full-matrix runs and the feature-branch double-run.
- **Concurrency grouped by source branch across both events** — `${{ github.workflow }}-${{ github.head_ref || github.ref_name }}` (was `ci-<pr-number>||<ref>`, which keyed push and PR into different lanes). Now a branch has one CI lane, so the develop-push and develop→main-PR runs of the same commit collapse into one instead of fighting over the runner.

## Notes

- This branch's own `ci.yml` already has the narrowed `push:` list, so pushing it triggers **no** push run — only the PR run — which is the fix demonstrating itself.
- No change to the docs-only gate or the `CI Status` aggregator from #39.