### PR TITLE
docs: add support links (issues + discussions) to docs home

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,3 +57,8 @@ Two RS-485 protocols are supported and auto-detected from the wire traffic:
 **Jandy/Zodiac (Fluidra) Aqualink RS** and **Pentair**. The
 [GitHub repository](https://github.com/iainchesworth/aqualink-automate) has the
 full source, issue tracker, and changelog.
+
+## Questions and support
+
+- **Bugs and feature requests** — open an [issue](https://github.com/iainchesworth/aqualink-automate/issues).
+- **Questions, ideas, and help** — start a [GitHub Discussion](https://github.com/iainchesworth/aqualink-automate/discussions).


### PR DESCRIPTION
Docs-only change: adds a 'Questions and support' section to the docs landing page pointing to GitHub Issues and the newly-enabled Discussions.

Doubles as the first real-world validation of the docs-only CI path from #39/#43 — expect the build matrix, E2E, Matter, and Docker jobs to be **skipped**, code scanning to not run, and **CI Status** to pass on the skip.