### PR TITLE
ci(codeql): refresh main baseline + fix self-hosted root-owned workspace

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -83,15 +83,27 @@ jobs:
             package_preset: pack-macos-llvm
 
     steps:
+      # BEFORE checkout: a prior RELEASE built inside a root gcc container (the
+      # glibc-2.36 packaging step below) can leave root-owned files in this shared
+      # self-hosted workspace that actions/checkout's git-clean cannot delete
+      # ("permission denied, rmdir build/..."), failing the job before it starts.
+      # Reset ownership to the runner user via a throwaway ROOT container -- NOT host
+      # sudo -- then drop the stale build trees. The chown-on-exit trap in that
+      # packaging step is what stops new root-owned files appearing; this is the
+      # belt-and-braces recovery for any that predate it.
+      - name: Clean workspace (self-hosted)
+        if: contains(matrix.runner, 'self-hosted')
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ] && [ -n "$(find . ! -uid "$(id -u)" -print -quit 2>/dev/null)" ]; then
+            docker run --rm -v "${{ github.workspace }}":/w -w /w alpine:3 chown -R "$(id -u):$(id -g)" /w
+          fi
+          rm -rf build install
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive
           fetch-depth: ${{ inputs.fetch_depth }}
-
-      - name: Clean workspace (self-hosted)
-        if: contains(matrix.runner, 'self-hosted')
-        shell: bash
-        run: rm -rf build/
 
       - uses: ./.github/actions/setup-cpp-toolchain
         if: ${{ !contains(matrix.runner, 'self-hosted') }}
@@ -275,7 +287,15 @@ jobs:
             -v "$HOME/.cache/vcpkg-bookworm":/vcpkgcache \
             -e VERSION_OVERRIDE -e CONFIGURE_PRESET -e BUILD_PRESET -e TEST_PRESET \
             -e PACKAGE_PRESET -e PACK_INSTALLTREE -e INSTALLTREE_NAME \
+            -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
             gcc:15-bookworm bash -eu -c '
+              # This container runs as root (needed for apt-get and writing /opt), so
+              # every file it creates under the bind-mounted /work is root-owned on the
+              # host. On a persistent self-hosted runner that poisons the shared
+              # workspace -- the next jobs (CodeQL, CI) cannot delete build/ and their
+              # checkout fails. Chown the tree back to the invoking host user on exit,
+              # via a trap so it runs even if configure/build/test/package fails.
+              trap "chown -R $HOST_UID:$HOST_GID /work 2>/dev/null || true" EXIT
               export DEBIAN_FRONTEND=noninteractive
               apt-get update -qq
               apt-get install -y -qq --no-install-recommends \

--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -1,17 +1,32 @@
 name: Automated Code Scanning
 
 on:
-  # Code scanning is SLOW (full per-platform builds), so only scan code where it
-  # is genuinely NEW:
+  # Code scanning is SLOW (full per-platform builds), so only scan code where it is
+  # genuinely NEW or where the result must be RECORDED against a branch:
   #   * pull_request into develop -> feature work entering the integration branch
   #   * pull_request into main    -> code arriving on the release branch, EXCEPT a
   #       develop->main promotion (skipped per-job below: that code was already
   #       scanned when it entered develop, so re-scanning the promotion is pure
   #       duplication and was the long redundant run we removed)
-  #   * schedule -> weekly baseline of the default branch (Security tab)
+  #   * push to main -> REQUIRED to keep the default-branch security baseline (the
+  #       Security tab / CodeQL "tool status") current. A pull_request run uploads
+  #       SARIF against the throwaway refs/pull/N/merge ref, which NEVER updates
+  #       main's baseline -- only an analysis whose ref is refs/heads/main does. So
+  #       no amount of per-PR scanning refreshes the Security tab; without this push
+  #       trigger the baseline depended solely on the weekly schedule below, and a
+  #       single failed/skipped cron silently froze it for weeks. Fires only on
+  #       merges to main (one scan per promotion), not the old per-feature-push
+  #       re-scanning we removed.
+  #   * schedule -> weekly safety-net baseline of the default branch
   #   * workflow_dispatch -> on demand
-  # The former `push: [main, feature/**, bug/**]` triggers re-scanned the
-  # post-merge main commit and every WIP feature push, all already covered above.
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - 'LICENSE'
   pull_request:
     branches: [ "develop", "main" ]
     # Docs-only changes touch no compiled code, so there is nothing new to scan.
@@ -64,13 +79,22 @@ jobs:
         language: [ 'c-cpp' ]
 
     steps:
+    # BEFORE checkout so a dirty tree cannot fail actions/checkout's git-clean. A
+    # prior RELEASE built inside a root gcc container (_build.yml) can leave
+    # root-owned files the unprivileged runner cannot delete; reset ownership via a
+    # throwaway ROOT container -- NOT host sudo -- then drop the stale build trees.
+    - name: Clean workspace (self-hosted)
+      if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ] && [ -n "$(find . ! -uid "$(id -u)" -print -quit 2>/dev/null)" ]; then
+          docker run --rm -v "${{ github.workspace }}":/w -w /w alpine:3 chown -R "$(id -u):$(id -g)" /w
+        fi
+        rm -rf build install
+
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         submodules: recursive
-
-    - name: Clean workspace (self-hosted)
-      if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
-      run: rm -rf build/
 
     - uses: ./.github/actions/setup-cpp-toolchain
       if: ${{ !contains(vars.RUNNER_LINUX || '', 'self-hosted') }}
@@ -174,13 +198,22 @@ jobs:
       contents: read
 
     steps:
+    # BEFORE checkout so a dirty tree cannot fail actions/checkout's git-clean. A
+    # prior RELEASE built inside a root gcc container (_build.yml) can leave
+    # root-owned files the unprivileged runner cannot delete; reset ownership via a
+    # throwaway ROOT container -- NOT host sudo -- then drop the stale build trees.
+    - name: Clean workspace (self-hosted)
+      if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ] && [ -n "$(find . ! -uid "$(id -u)" -print -quit 2>/dev/null)" ]; then
+          docker run --rm -v "${{ github.workspace }}":/w -w /w alpine:3 chown -R "$(id -u):$(id -g)" /w
+        fi
+        rm -rf build install
+
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         submodules: recursive
-
-    - name: Clean workspace (self-hosted)
-      if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
-      run: rm -rf build/
 
     - uses: ./.github/actions/setup-cpp-toolchain
       if: ${{ !contains(vars.RUNNER_LINUX || '', 'self-hosted') }}
@@ -349,14 +382,23 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
 
     steps:
+    # BEFORE checkout so a dirty tree cannot fail actions/checkout's git-clean. A
+    # prior RELEASE built inside a root gcc container (_build.yml) can leave
+    # root-owned files the unprivileged runner cannot delete; reset ownership via a
+    # throwaway ROOT container -- NOT host sudo -- then drop the stale build trees.
+    - name: Clean workspace (self-hosted)
+      if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ] && [ -n "$(find . ! -uid "$(id -u)" -print -quit 2>/dev/null)" ]; then
+          docker run --rm -v "${{ github.workspace }}":/w -w /w alpine:3 chown -R "$(id -u):$(id -g)" /w
+        fi
+        rm -rf build install
+
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         submodules: recursive
-
-    - name: Clean workspace (self-hosted)
-      if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
-      run: rm -rf build/
 
     - uses: ./.github/actions/setup-cpp-toolchain
       if: ${{ !contains(vars.RUNNER_LINUX || '', 'self-hosted') }}
@@ -455,14 +497,21 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        submodules: recursive
-
+    # BEFORE checkout so a dirty tree cannot fail actions/checkout. (The
+    # root-owned-file recovery only applies to Linux self-hosted runners; on Windows
+    # the plain rm suffices, so the guarded branch is a no-op here.)
     - name: Clean workspace (self-hosted)
       if: contains(vars.RUNNER_WINDOWS || '', 'self-hosted')
       shell: bash
-      run: rm -rf build/
+      run: |
+        if [ "$RUNNER_OS" = "Linux" ] && [ -n "$(find . ! -uid "$(id -u)" -print -quit 2>/dev/null)" ]; then
+          docker run --rm -v "${{ github.workspace }}":/w -w /w alpine:3 chown -R "$(id -u):$(id -g)" /w
+        fi
+        rm -rf build install
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        submodules: recursive
 
     - uses: ./.github/actions/setup-cpp-toolchain
       if: ${{ !contains(vars.RUNNER_WINDOWS || '', 'self-hosted') }}


### PR DESCRIPTION
## Why

The CodeQL **Security tab / tool status** for `main` shows *failing* with a last
successful scan in **April**, despite every PR and branch being scanned. Two
independent problems:

1. **Per-PR scanning never refreshes main's baseline.** The Security-tab baseline
   is keyed to the default branch (`refs/heads/main`). PR runs upload SARIF
   against the throwaway `refs/pull/N/merge` ref, which *never* updates main — so
   no amount of PR scanning moves the status page. The only thing that did was the
   weekly `schedule`, and the `push:[main]` trigger had been removed for dedupe.

2. **The weekly cron then broke.** It failed at `actions/checkout` with
   `EACCES: permission denied, rmdir build/config-linux-gcc` on the self-hosted
   Linux runner. The glibc-2.36 packaging step in `_build.yml` runs a
   `gcc:15-bookworm` container **as root** over the bind-mounted workspace,
   leaving root-owned `build/`/`install/` the unprivileged runner can't delete.
   The existing `Clean workspace: rm -rf build/` ran *after* checkout, so it could
   never recover.

So the baseline froze in April and went red when the June cron failed.

## What changed

**Security baseline**
- Re-add `push: [main]` (docs paths-ignored) to `automated-codescanning.yml` so
  main's CodeQL baseline refreshes on every promotion merge, decoupled from the
  flaky weekly cron. The `develop`→`main` promotion PR still skips per-job; the
  post-merge push scans main once.

**Root-owned workspace (durable, no host sudo)**
- `_build.yml` packaging container: pass `HOST_UID/HOST_GID` and
  `trap "chown -R … /work" EXIT` so files it creates are chowned back to the
  runner user even if build/test/package fails — new root-owned files never persist.
- All self-hosted `Clean workspace` steps (`_build.yml` + the four codescanning
  jobs) move **before** checkout and self-heal: detect any foreign-owned file and
  `chown` it back via a throwaway **root container** (not host sudo), then remove
  `build/`/`install/`. This also clears any pre-existing leftovers automatically.

## Sweep

Confirmed `_build.yml`'s packaging container is the **only** step that writes the
workspace as root. The smoke-test container mounts `packages:ro`; the other
`docker run`/buildx steps have no rw workspace mount.

## How it goes green

`push:[main]` and the self-heal only take effect on `main` once merged + promoted
(scheduled/push runs use main's copy of the workflow). This PR's own codescanning
run exercises the new self-healing clean on `develop`; after promotion the
post-merge push scans `main`, uploads against `refs/heads/main`, and the Security
tab clears.
