### PR TITLE
ci(coverage): exclude throw/unreachable branches from gcovr reports

### DIFF
--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -341,6 +341,7 @@ jobs:
         gcovr --sonarqube "${{ github.workspace }}/coverage-e2e.xml" \
           -r "${{ github.workspace }}" \
           --gcov-ignore-parse-errors=negative_hits.warn \
+          --exclude-throw-branches --exclude-unreachable-branches \
           -e "${{ github.workspace }}/deps" \
           -e "${{ github.workspace }}/build/config-linux-gcc-coverage/vcpkg_installed" \
           -e "${{ github.workspace }}/test" \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -256,7 +256,10 @@ setup_target_for_coverage_opencppcoverage(
 
 elseif(USE_SONARQUBE)
 
-set(GCOVR_ADDITIONAL_ARGS "--gcov-ignore-parse-errors=negative_hits.warn")
+# NOTE: this is consumed as a CMake list (each element becomes one VERBATIM
+# argument to gcovr). Keep each flag a SEPARATE list element — collapsing them
+# into one space-joined string makes gcovr see a single malformed argument.
+set(GCOVR_ADDITIONAL_ARGS "--gcov-ignore-parse-errors=negative_hits.warn" "--exclude-throw-branches" "--exclude-unreachable-branches")
 
 setup_target_for_coverage_gcovr_xml(
 	NAME coverage-testaqualink-automate


### PR DESCRIPTION
## Why

SonarCloud's `new_coverage` quality gate (80% on new code) combines line **and** branch (condition) coverage. On the recent dashboard-gap PR, `new_line_coverage` was strong (86.5%) but `new_branch_coverage` was only 46.4%, dragging combined `new_coverage` to ~56% and failing the gate.

The branch numbers are dominated by **noise**, not real untested logic: gcov counts the implicit C++ exception edge of every potentially-throwing call (`std::format`, `nlohmann::json` ops, allocations) as a branch whose "throw" side is never taken in tests. Smoking gun — `src/core/mqtt/ha_discovery.cpp` reported **272 uncovered conditions from only 148 added lines**, almost all unthrown exception edges.

## What

Add `--exclude-throw-branches` and `--exclude-unreachable-branches` to **both** gcovr invocations so the unit report and the e2e report stay consistent:

- `test/CMakeLists.txt` — appended to `GCOVR_ADDITIONAL_ARGS` (flows into the SonarQube gcovr command in `cmake/tools/coverage/CodeCoverage.cmake`). The `else()` HTML path is untouched (the var is set only in the `USE_SONARQUBE` branch).
- `.github/workflows/automated-codescanning.yml` — added to the `CodeScanning_E2ECoverage` job's `gcovr --sonarqube` command.

Both flags are standard gcovr (>= 4.2) options that exclude compiler-generated exception/unreachable branches so coverage reflects real decision logic.

## Effect

Branch coverage on the SonarQube report should rise substantially (the throw-edge noise is removed), lifting combined `new_coverage`. Part 2 (separate PR) adds tests for the remaining *real* uncovered branches.
