### PR TITLE
fix(build): initialize variables to satisfy clang-tidy gate

### DIFF
--- a/src/core/mqtt/mqtt_integration.cpp
+++ b/src/core/mqtt/mqtt_integration.cpp
@@ -686,7 +686,7 @@ namespace AqualinkAutomate::Mqtt
 
 						auto action_str = ParsePayloadString(payload);
 
-						bool enable;
+						bool enable = false;
 						if (action_str == "ON")
 						{
 							enable = true;

--- a/src/jandy/devices/serial_adapter_device.cpp
+++ b/src/jandy/devices/serial_adapter_device.cpp
@@ -504,7 +504,7 @@ namespace AqualinkAutomate::Devices
 		}
 
 		// Map the heater's body of water to its RSSA heater command. Shared == the solar heater.
-		SerialAdapter_SystemTemperatureCommands heater_cmd;
+		SerialAdapter_SystemTemperatureCommands heater_cmd{};
 		switch (heater_body)
 		{
 		case Kernel::BodyOfWaterIds::Pool:


### PR DESCRIPTION
## Summary

The `config-windows-msvc-debug` preset runs clang-tidy with `WarningsAsErrors` enabled (the static-analysis gate). Two `cppcoreguidelines-init-variables` violations on `develop` currently fail the build (`ninja: build stopped`), so the documented local debug build cannot compile.

This initializes both locals:

- [`src/core/mqtt/mqtt_integration.cpp`](src/core/mqtt/mqtt_integration.cpp) — `bool enable;` → `bool enable = false;` (assigned in an ON/OFF if-else whose else branch returns)
- [`src/jandy/devices/serial_adapter_device.cpp`](src/jandy/devices/serial_adapter_device.cpp) — `SerialAdapter_SystemTemperatureCommands heater_cmd;` → value-initialized `{}` (assigned in a switch whose default returns)

## Behaviour

Neither is a runtime bug — both vars are always assigned before use because the fall-through branches return early. Pure clang-tidy hygiene, no behavioural change, so no new tests.

## Verification

Built the `testaqualink-automate` target under the `config-windows-msvc-debug` preset in a VS Dev Shell. Build completes (exit 0), compiling past both TUs and linking the test executable — the static-analysis gate now passes.