### PR TITLE
release: promote develop to main for v0.9.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.9.0-beta.2] - 2026-06-30
+
+A bug-fix release on top of 0.9.0-beta.1. One user-facing Home Assistant fix; the remainder is build, CI, and test-coverage hardening with no application behaviour change.
+
+### Fixed
+
+- **Home Assistant spa-mode, clean-mode, and second-pool-heater sensors now settle to a real on/off state.** The `Spa Mode`, `Clean Mode`, and `Pool Heater 2 (TEMP2)` binary sensors rendered their JSON-boolean source through a raw `value_template`, which Home Assistant's Jinja renders capitalised (`True`/`False`) — so it never matched the lowercase `payload_on`/`payload_off` and Home Assistant logged "No matching payload found" on every circulation/temperature publish, leaving the entities stuck. The templates now coerce to lowercase `true`/`false` (and map the not-reported case to `false`).
+
 ## [0.9.0-beta.1] - 2026-06-29
 
 A spa-control and dual-body feature release.

--- a/src/core/mqtt/ha_discovery.cpp
+++ b/src/core/mqtt/ha_discovery.cpp
@@ -316,7 +316,7 @@ namespace AqualinkAutomate::Mqtt
 			{"name", "Pool Heater 2 (TEMP2)"},
 			{"unique_id", UniqueId("pool_heater_2_enabled")},
 			{"state_topic", temperatures_topic},
-			{"value_template", "{{ value_json.pool_heater_2_enabled }}"},
+			{"value_template", "{{ 'true' if value_json.pool_heater_2_enabled else 'false' }}"},
 			{"payload_on", "true"},
 			{"payload_off", "false"}
 		};
@@ -385,7 +385,7 @@ namespace AqualinkAutomate::Mqtt
 			{"name", "Spa Mode"},
 			{"unique_id", UniqueId("spa_mode")},
 			{"state_topic", circulation_topic},
-			{"value_template", "{{ value_json.spa_mode }}"},
+			{"value_template", "{{ 'true' if value_json.spa_mode else 'false' }}"},
 			{"payload_on", "true"},
 			{"payload_off", "false"}
 		};
@@ -395,7 +395,7 @@ namespace AqualinkAutomate::Mqtt
 			{"name", "Clean Mode"},
 			{"unique_id", UniqueId("clean_mode")},
 			{"state_topic", circulation_topic},
-			{"value_template", "{{ value_json.clean_mode }}"},
+			{"value_template", "{{ 'true' if value_json.clean_mode else 'false' }}"},
 			{"payload_on", "true"},
 			{"payload_off", "false"}
 		};

--- a/src/core/mqtt/mqtt_integration.cpp
+++ b/src/core/mqtt/mqtt_integration.cpp
@@ -686,7 +686,7 @@ namespace AqualinkAutomate::Mqtt
 
 						auto action_str = ParsePayloadString(payload);
 
-						bool enable;
+						bool enable = false;
 						if (action_str == "ON")
 						{
 							enable = true;

--- a/src/jandy/devices/serial_adapter_device.cpp
+++ b/src/jandy/devices/serial_adapter_device.cpp
@@ -504,7 +504,7 @@ namespace AqualinkAutomate::Devices
 		}
 
 		// Map the heater's body of water to its RSSA heater command. Shared == the solar heater.
-		SerialAdapter_SystemTemperatureCommands heater_cmd;
+		SerialAdapter_SystemTemperatureCommands heater_cmd{};
 		switch (heater_body)
 		{
 		case Kernel::BodyOfWaterIds::Pool:

--- a/test/unit/mqtt/test_mqtt_client.cpp
+++ b/test/unit/mqtt/test_mqtt_client.cpp
@@ -300,3 +300,274 @@ BOOST_AUTO_TEST_CASE(Test_Publish_QueueOverflow_DropsOldest)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// MqttClient last-will (LWT) tests
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_MqttClient_Will)
+
+BOOST_AUTO_TEST_CASE(Test_GetWill_DefaultsToEmpty)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	BOOST_CHECK(!client.GetWill().has_value());
+}
+
+BOOST_AUTO_TEST_CASE(Test_SetWill_StoresConfiguration)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	client.SetWill("status/availability", "offline", true);
+
+	const auto& will = client.GetWill();
+	BOOST_REQUIRE(will.has_value());
+	BOOST_CHECK_EQUAL(will->topic, "status/availability");
+	BOOST_CHECK_EQUAL(will->payload, "offline");
+	BOOST_CHECK_EQUAL(will->retain, true);
+}
+
+BOOST_AUTO_TEST_CASE(Test_SetWill_RetainDefaultsTrue)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	client.SetWill("status/availability", "offline");
+
+	const auto& will = client.GetWill();
+	BOOST_REQUIRE(will.has_value());
+	BOOST_CHECK_EQUAL(will->retain, true);
+}
+
+BOOST_AUTO_TEST_CASE(Test_SetWill_RetainCanBeDisabled)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	client.SetWill("status/availability", "offline", false);
+
+	const auto& will = client.GetWill();
+	BOOST_REQUIRE(will.has_value());
+	BOOST_CHECK_EQUAL(will->retain, false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// MqttClient client-id generation tests
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_MqttClient_GenerateClientId)
+
+BOOST_AUTO_TEST_CASE(Test_GenerateClientId_FormatContract)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	auto id = Test::MqttClientPacketTest::CallGenerateClientId(client);
+
+	// "aqualink-" (9 chars) + 8 random hex chars.
+	BOOST_REQUIRE_EQUAL(id.size(), 17u);
+	BOOST_CHECK(id.starts_with("aqualink-"));
+
+	const auto suffix = id.substr(9);
+	BOOST_CHECK_EQUAL(suffix.size(), 8u);
+	for (char c : suffix)
+	{
+		BOOST_CHECK_MESSAGE(std::string("0123456789abcdef").find(c) != std::string::npos,
+			std::string("client-id suffix must be lowercase hex, saw: ") + c);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(Test_GenerateClientId_ProducesDistinctValues)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	auto id1 = Test::MqttClientPacketTest::CallGenerateClientId(client);
+	auto id2 = Test::MqttClientPacketTest::CallGenerateClientId(client);
+
+	BOOST_CHECK_NE(id1, id2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// MqttClient reconnect-backoff tests (exponential growth, cap, saturation,
+// jitter bounds). delay_pre_jitter = base * 2^min(attempts, 10), capped at max;
+// jitter is added uniformly from [0, delay_pre_jitter / 4].
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_MqttClient_ReconnectDelay)
+
+namespace
+{
+	Options::Mqtt::MqttSettings MakeBackoffSettings(std::chrono::seconds initial, std::chrono::seconds max)
+	{
+		auto settings = Test::MakeMqttSettings();
+		settings.reconnect_delay_initial = initial;
+		settings.reconnect_delay_max = max;
+		return settings;
+	}
+}
+
+BOOST_AUTO_TEST_CASE(Test_ReconnectDelay_FirstAttemptIsBaseDelay)
+{
+	boost::asio::io_context ioc;
+	// base = 4s, attempts = 0 -> pre-jitter = 4, jitter in [0, 1].
+	Mqtt::MqttClient client(ioc, MakeBackoffSettings(std::chrono::seconds(4), std::chrono::seconds(3600)));
+	Test::MqttClientPacketTest::SetReconnectAttempts(client, 0);
+
+	auto delay = Test::MqttClientPacketTest::CallCalculateReconnectDelay(client).count();
+	BOOST_CHECK_GE(delay, 4);
+	BOOST_CHECK_LE(delay, 5);
+}
+
+BOOST_AUTO_TEST_CASE(Test_ReconnectDelay_GrowsExponentially)
+{
+	boost::asio::io_context ioc;
+	// base = 4s: attempt n -> pre-jitter = 4 * 2^n, jitter in [0, (4*2^n)/4].
+	Mqtt::MqttClient client(ioc, MakeBackoffSettings(std::chrono::seconds(4), std::chrono::seconds(100000)));
+
+	for (std::uint16_t n = 0; n <= 4; ++n)
+	{
+		Test::MqttClientPacketTest::SetReconnectAttempts(client, n);
+		const std::int64_t pre_jitter = static_cast<std::int64_t>(4) << n;
+		auto delay = Test::MqttClientPacketTest::CallCalculateReconnectDelay(client).count();
+		BOOST_CHECK_GE(delay, pre_jitter);
+		BOOST_CHECK_LE(delay, pre_jitter + pre_jitter / 4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE(Test_ReconnectDelay_CappedAtMaxDelay)
+{
+	boost::asio::io_context ioc;
+	// base = 10s, max = 20s. attempt 5 -> pre-jitter = 10 * 32 = 320, capped to 20,
+	// jitter in [0, 5] -> result in [20, 25].
+	Mqtt::MqttClient client(ioc, MakeBackoffSettings(std::chrono::seconds(10), std::chrono::seconds(20)));
+	Test::MqttClientPacketTest::SetReconnectAttempts(client, 5);
+
+	auto delay = Test::MqttClientPacketTest::CallCalculateReconnectDelay(client).count();
+	BOOST_CHECK_GE(delay, 20);
+	BOOST_CHECK_LE(delay, 25);
+}
+
+BOOST_AUTO_TEST_CASE(Test_ReconnectDelay_SaturatesAtTenShifts)
+{
+	boost::asio::io_context ioc;
+	// base = 1s, huge cap. The shift is clamped at min(attempts, 10), so attempt 10,
+	// 11 and 50 all share pre-jitter = 1 * 2^10 = 1024 and jitter in [0, 256].
+	Mqtt::MqttClient client(ioc, MakeBackoffSettings(std::chrono::seconds(1), std::chrono::seconds(1000000)));
+
+	const std::int64_t pre_jitter = static_cast<std::int64_t>(1) << 10; // 1024
+
+	for (std::uint16_t n : { std::uint16_t{ 10 }, std::uint16_t{ 11 }, std::uint16_t{ 50 } })
+	{
+		Test::MqttClientPacketTest::SetReconnectAttempts(client, n);
+		auto delay = Test::MqttClientPacketTest::CallCalculateReconnectDelay(client).count();
+		BOOST_CHECK_GE(delay, pre_jitter);
+		BOOST_CHECK_LE(delay, pre_jitter + pre_jitter / 4);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// MqttClient subscribe / poll guard tests (synchronous early-return paths)
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_MqttClient_Guards)
+
+BOOST_AUTO_TEST_CASE(Test_Subscribe_WhenNotConnected_IsHarmless)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	auto client = std::make_shared<Mqtt::MqttClient>(ioc, settings);
+
+	// Not connected: Subscribe() must log a warning and return without touching
+	// the endpoint (which is not started) — i.e. no throw, no state change.
+	BOOST_REQUIRE(!client->IsConnected());
+	BOOST_CHECK_NO_THROW(client->Subscribe("some/topic", 1));
+	BOOST_CHECK(!client->IsConnected());
+}
+
+BOOST_AUTO_TEST_CASE(Test_Poll_WhenNotRunning_IsHarmless)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	auto client = std::make_shared<Mqtt::MqttClient>(ioc, settings);
+
+	// Not running: Poll() takes the early-return branch before any flush work.
+	BOOST_REQUIRE(!client->IsRunning());
+	BOOST_CHECK_NO_THROW(client->Poll());
+}
+
+BOOST_AUTO_TEST_CASE(Test_Poll_WhenConnected_FlushesWithoutThrowing)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	auto client = std::make_shared<Mqtt::MqttClient>(ioc, settings);
+
+	// Force the connected/running state so Poll() runs the flush path
+	// (FlushIfConnected) rather than the early-return guard.
+	Test::MqttClientPacketTest::ForceConnectedState(*client);
+	client->Publish("topic/a", "payload_a");
+
+	BOOST_REQUIRE(client->IsRunning());
+	BOOST_CHECK_NO_THROW(client->Poll());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// MqttClient diagnostics-accessor tests (initial values)
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_MqttClient_Diagnostics)
+
+BOOST_AUTO_TEST_CASE(Test_Diagnostics_InitialCounters)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	Mqtt::MqttClient client(ioc, settings);
+
+	BOOST_CHECK_EQUAL(client.PublishQueueDepth(), 0u);
+	BOOST_CHECK_EQUAL(client.ReconnectAttempts(), 0u);
+	BOOST_CHECK_EQUAL(client.PublishedCount(), 0u);
+	BOOST_CHECK_EQUAL(client.DroppedCount(), 0u);
+	BOOST_CHECK(client.LastError().empty());
+}
+
+BOOST_AUTO_TEST_CASE(Test_Diagnostics_SettingsAccessorReflectsConfig)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	settings.broker_host = "broker.example";
+	settings.broker_port = 8883;
+	Mqtt::MqttClient client(ioc, settings);
+
+	BOOST_CHECK_EQUAL(client.Settings().broker_host, "broker.example");
+	BOOST_CHECK_EQUAL(client.Settings().broker_port, 8883);
+}
+
+BOOST_AUTO_TEST_CASE(Test_Diagnostics_PublishQueueDepthTracksPublishes)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeClientTestSettings();
+	auto client = std::make_shared<Mqtt::MqttClient>(ioc, settings);
+
+	BOOST_CHECK_EQUAL(client->PublishQueueDepth(), 0u);
+	client->Publish("topic/a", "a");
+	client->Publish("topic/b", "b");
+	BOOST_CHECK_EQUAL(client->PublishQueueDepth(), 2u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mqtt/test_mqtt_ha_discovery.cpp
+++ b/test/unit/mqtt/test_mqtt_ha_discovery.cpp
@@ -436,6 +436,120 @@ BOOST_AUTO_TEST_CASE(Test_PublishDiscoveryConfigs_BinarySensorsHavePayloadOnOff)
 	}
 }
 
+// Regression: a binary_sensor whose value_template is a raw {{ value_json.x }}
+// passthrough renders a JSON boolean source as Python-capitalised "True"/"False",
+// which never matches the lowercase payload_on/payload_off ("true"/"false"). HA then
+// logs "No matching payload found" on every publish and the entity never settles.
+// The fix is to coerce inside the template ({{ 'true' if value_json.x else 'false' }}).
+//
+// This test (a) pins the three previously-broken bool sensors to the coercion form, and
+// (b) walks EVERY generated binary_sensor so any future entity that reintroduces the
+// raw-passthrough + lowercase-payload combo fails loudly here.
+BOOST_AUTO_TEST_CASE(Test_PublishDiscoveryConfigs_BooleanBinarySensorsCoerceLowercase)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeTestSettings();
+	auto client = std::make_shared<Mqtt::MqttClient>(ioc, settings);
+	Mqtt::HomeAssistantDiscovery ha(client, settings);
+
+	// A combo system so the spa/clean circulation sensors and both bodies are emitted.
+	auto data_hub = std::make_shared<Kernel::DataHub>();
+	data_hub->ApplyPoolConfiguration(Kernel::PoolConfigurations::DualBody_SharedEquipment, Kernel::ConfigurationSource::UserSpecified);
+	ha.ConnectDataHub(data_hub);
+
+	ha.PublishDiscoveryConfigs();
+
+	auto& queue = Test::MqttClientPacketTest::GetPublishQueue(*client);
+	BOOST_REQUIRE_EQUAL(queue.size(), 1);
+	auto payload = nlohmann::json::parse(queue[0].payload);
+	BOOST_REQUIRE(payload.contains("cmps"));
+	auto& cmps = payload["cmps"];
+
+	// A "raw passthrough" template emits the JSON value verbatim - no conditional, no
+	// filter, no explicit lowercase literal - so a bool source stringifies to "True"/"False".
+	auto is_raw_passthrough = [](const std::string& tmpl)
+	{
+		return tmpl.find("value_json") != std::string::npos
+			&& tmpl.find(" if ") == std::string::npos
+			&& tmpl.find('|') == std::string::npos
+			&& tmpl.find("'true'") == std::string::npos
+			&& tmpl.find("'false'") == std::string::npos;
+	};
+
+	// Documented exception: the alert binary_sensors read the AlertMonitor's consolidated
+	// document, which already publishes the STRING "true"/"false" (AlertMonitor::BuildStateJson),
+	// so a raw passthrough is correct there. They must NOT be "fixed" with the truthiness
+	// coercion - {{ 'true' if value_json.x else 'false' }} would render the string "false" as
+	// truthy and report a cleared alert as raised. Any other raw-passthrough bool sensor is a bug.
+	auto is_string_sourced_exception = [](const std::string& key)
+	{
+		return key.rfind("alert_", 0) == 0;
+	};
+
+	std::size_t bool_sensor_count = 0;
+	for (auto& [key, cmp] : cmps.items())
+	{
+		if (!cmp.contains("p") || cmp["p"] != "binary_sensor")
+		{
+			continue;
+		}
+
+		BOOST_REQUIRE_MESSAGE(cmp.contains("payload_on") && cmp.contains("payload_off"),
+			"binary_sensor missing payload_on/off: " + key);
+
+		const auto payload_on = cmp["payload_on"].get<std::string>();
+		const auto payload_off = cmp["payload_off"].get<std::string>();
+
+		// We only police the lowercase-boolean payload convention here.
+		if (!(payload_on == "true" && payload_off == "false"))
+		{
+			continue;
+		}
+
+		BOOST_REQUIRE_MESSAGE(cmp.contains("value_template"),
+			"bool binary_sensor missing value_template: " + key);
+		const auto tmpl = cmp["value_template"].get<std::string>();
+
+		if (is_string_sourced_exception(key))
+		{
+			continue;
+		}
+
+		++bool_sensor_count;
+
+		// The combo we are guarding against: a raw passthrough whose output would be
+		// "True"/"False" for a JSON-bool source.
+		BOOST_CHECK_MESSAGE(!is_raw_passthrough(tmpl),
+			"binary_sensor '" + key + "' uses a raw {{ value_json.x }} passthrough with lowercase "
+			"payload_on/off; a JSON-bool source renders 'True'/'False' and never matches. Coerce in "
+			"the template: {{ 'true' if value_json.x else 'false' }} (value_template was: " + tmpl + ")");
+
+		// And, positively, the template must emit literals that match the declared payloads.
+		BOOST_CHECK_MESSAGE(tmpl.find("'" + payload_on + "'") != std::string::npos,
+			"binary_sensor '" + key + "' value_template does not emit payload_on literal '" + payload_on + "': " + tmpl);
+		BOOST_CHECK_MESSAGE(tmpl.find("'" + payload_off + "'") != std::string::npos,
+			"binary_sensor '" + key + "' value_template does not emit payload_off literal '" + payload_off + "': " + tmpl);
+	}
+
+	// Sanity: the walk actually exercised the policed sensors (3 circulation/setpoint bool
+	// sensors + 3 temperature "stale" companions on a combo system), not zero.
+	BOOST_CHECK_GE(bool_sensor_count, 6u);
+
+	// Pin the three previously-broken sensors to the exact coercion form.
+	for (const auto* key : { "spa_mode", "clean_mode", "pool_heater_2_enabled" })
+	{
+		BOOST_REQUIRE_MESSAGE(cmps.contains(key), std::string("missing bool binary_sensor: ") + key);
+		auto& cmp = cmps[key];
+		BOOST_CHECK_EQUAL(cmp["p"], "binary_sensor");
+		BOOST_CHECK_EQUAL(cmp["payload_on"], "true");
+		BOOST_CHECK_EQUAL(cmp["payload_off"], "false");
+
+		const auto tmpl = cmp["value_template"].get<std::string>();
+		const std::string expected = std::string("{{ 'true' if value_json.") + key + " else 'false' }}";
+		BOOST_CHECK_EQUAL(tmpl, expected);
+	}
+}
+
 BOOST_AUTO_TEST_CASE(Test_PublishDiscoveryConfigs_SwitchEntitiesHaveCommandTopic)
 {
 	boost::asio::io_context ioc;

--- a/test/unit/support/unit_test_mqtt_support.h
+++ b/test/unit/support/unit_test_mqtt_support.h
@@ -35,6 +35,27 @@ public:
 		client.m_State = Mqtt::MqttClient::State::Connected;
 		client.m_Running = true;
 	}
+
+	/// Invoke the private client-id generator directly so its format contract
+	/// ("aqualink-" + 8 hex chars) can be asserted without going through the ctor.
+	static std::string CallGenerateClientId(const Mqtt::MqttClient& client)
+	{
+		return client.GenerateClientId();
+	}
+
+	/// Invoke the private exponential-backoff calculator directly. Combine with
+	/// SetReconnectAttempts() to exercise the growth / cap / saturation branches.
+	static std::chrono::seconds CallCalculateReconnectDelay(const Mqtt::MqttClient& client)
+	{
+		return client.CalculateReconnectDelay();
+	}
+
+	/// Seed the reconnect-attempt counter so CalculateReconnectDelay()'s backoff
+	/// can be driven deterministically across attempt counts.
+	static void SetReconnectAttempts(Mqtt::MqttClient& client, std::uint16_t attempts)
+	{
+		client.m_ReconnectAttempts = attempts;
+	}
 };
 
 //=============================================================================


### PR DESCRIPTION
Promotes `develop` to `main` to cut **v0.9.0-beta.2** — a bug-fix release on top of `v0.9.0-beta.1`.

## What's included since v0.9.0-beta.1

### Fixed (user-facing)
- **Home Assistant spa-mode / clean-mode / second-pool-heater sensors now settle to on/off.** `Spa Mode`, `Clean Mode`, and `Pool Heater 2 (TEMP2)` binary sensors rendered a JSON boolean through a raw `value_template`, which HA's Jinja renders capitalised (`True`/`False`) — never matching the lowercase `payload_on`/`payload_off`. The templates now coerce to lowercase `true`/`false`.

### Build / CI / test hardening (no behaviour change)
- `fix(build)`: initialize variables to satisfy the clang-tidy gate.
- `ci(coverage)`: exclude throw/unreachable branches from gcovr reports.
- `test(mqtt)`: cover `MqttClient` synchronous helpers.
- `test(options)`: end-to-end Matter options processor coverage.

## Release
- Suggested tag: **`v0.9.0-beta.2`** (patch bump within the beta line — validated via `scripts/next-version.sh`).
- CHANGELOG.md `[0.9.0-beta.2]` section added.
- Tag will be pushed on `main` after this merges (Release workflow trigger).
