### PR TITLE
test(services): cover history + equipment-cache lifecycle and guards

### DIFF
--- a/test/unit/equipment_cache/test_equipment_cache_service.cpp
+++ b/test/unit/equipment_cache/test_equipment_cache_service.cpp
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <system_error>
@@ -183,6 +184,146 @@ BOOST_AUTO_TEST_CASE(FileRoundTrip_SaveThenLoad)
 
 	std::filesystem::remove(path, ec);
 	std::filesystem::remove(path + ".tmp", ec);
+}
+
+//=============================================================================
+// Load / SaveNow guards (missing file, malformed JSON, no configured path).
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(Load_FileDoesNotExist_IsNoOp)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	settings.equipment_cache_file = (std::filesystem::temp_directory_path() / "aqualink_eqcache_absent.json").string();
+	std::error_code ec;
+	std::filesystem::remove(settings.equipment_cache_file, ec);   // ensure absent
+
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	BOOST_CHECK_NO_THROW(service.Load());
+	BOOST_CHECK(Find<Kernel::DataHub>()->Devices.FindByTrait(Traits::AuxillaryTypeTrait{}).empty());
+}
+
+BOOST_AUTO_TEST_CASE(Load_MalformedJson_IsCaughtAndIgnored)
+{
+	boost::asio::io_context io;
+	const auto path = (std::filesystem::temp_directory_path() / "aqualink_eqcache_bad.json").string();
+	{
+		std::ofstream out(path, std::ios::binary | std::ios::trunc);
+		out << "{ this is not valid json";
+	}
+
+	Options::Equipment::EquipmentSettings settings;
+	settings.equipment_cache_file = path;
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	// The parse exception is caught and logged; Load must not propagate it.
+	BOOST_CHECK_NO_THROW(service.Load());
+	BOOST_CHECK(Find<Kernel::DataHub>()->Devices.FindByTrait(Traits::AuxillaryTypeTrait{}).empty());
+
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+}
+
+BOOST_AUTO_TEST_CASE(SaveNow_NoConfiguredFile_IsNoOp)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;   // no equipment_cache_file
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	Find<Kernel::DataHub>()->Devices.Add(MakeDevice("Filter Pump", Traits::AuxillaryTypes::Pump));
+
+	BOOST_CHECK_NO_THROW(service.SaveNow());
+}
+
+//=============================================================================
+// ApplySnapshot config adoption: the cached pool-config / system-board is only
+// adopted while the live value is still Unknown (live discovery always wins).
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(ApplySnapshot_AdoptsPoolConfig_WhenUnknown)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	auto hub = Find<Kernel::DataHub>();
+	BOOST_REQUIRE(hub->PoolConfiguration == Kernel::PoolConfigurations::Unknown);
+
+	nlohmann::json snapshot;
+	snapshot["pool_configuration"] = "SingleBody";
+	service.ApplySnapshot(snapshot);
+
+	BOOST_CHECK(hub->PoolConfiguration == Kernel::PoolConfigurations::SingleBody);
+}
+
+BOOST_AUTO_TEST_CASE(ApplySnapshot_IgnoresPoolConfig_WhenAlreadyKnown)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	auto hub = Find<Kernel::DataHub>();
+	hub->ApplyPoolConfiguration(Kernel::PoolConfigurations::DualBody_SharedEquipment, Kernel::ConfigurationSource::Auto);
+
+	nlohmann::json snapshot;
+	snapshot["pool_configuration"] = "SingleBody";
+	service.ApplySnapshot(snapshot);
+
+	// Live discovery already set it, so the cached value must NOT override.
+	BOOST_CHECK(hub->PoolConfiguration == Kernel::PoolConfigurations::DualBody_SharedEquipment);
+}
+
+BOOST_AUTO_TEST_CASE(ApplySnapshot_AdoptsSystemBoard_WhenUnknown)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	auto hub = Find<Kernel::DataHub>();
+	BOOST_REQUIRE(hub->SystemBoard == Kernel::SystemBoards::Unknown);
+
+	nlohmann::json snapshot;
+	snapshot["system_board"] = "RS8_Only";
+	service.ApplySnapshot(snapshot);
+
+	BOOST_CHECK(hub->SystemBoard == Kernel::SystemBoards::RS8_Only);
+}
+
+BOOST_AUTO_TEST_CASE(ApplySnapshot_MalformedDeviceId_RestoresWithFreshIdAndTraits)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	auto hub = Find<Kernel::DataHub>();
+
+	// A malformed "id" must not abort the restore: the device is recreated with a fresh
+	// id (deduped by label instead) and its other traits are still applied.
+	nlohmann::json snapshot;
+	snapshot["devices"] = nlohmann::json::array({
+		{ { "id", "not-a-uuid" }, { "label", "Spa Jet" }, { "type", "Auxillary" }, { "body_of_water", "Spa" } }
+	});
+	service.ApplySnapshot(snapshot);
+
+	auto restored = hub->Devices.FindByLabel("Spa Jet");
+	BOOST_REQUIRE_EQUAL(restored.size(), 1u);
+	BOOST_REQUIRE(restored.front()->AuxillaryTraits.Has(Traits::BodyOfWaterTrait{}));
+	BOOST_CHECK(*(restored.front()->AuxillaryTraits[Traits::BodyOfWaterTrait{}]) == Kernel::BodyOfWaterIds::Spa);
+}
+
+BOOST_AUTO_TEST_CASE(Snapshot_FreshHub_HasUnknownConfigAndNoDevices)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	const auto snapshot = service.Snapshot();
+
+	BOOST_CHECK_EQUAL(snapshot["pool_configuration"], "Unknown");
+	BOOST_CHECK_EQUAL(snapshot["system_board"], "Unknown");
+	BOOST_REQUIRE(snapshot.contains("devices"));
+	BOOST_CHECK(snapshot["devices"].empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/history/test_history_service.cpp
+++ b/test/unit/history/test_history_service.cpp
@@ -278,4 +278,84 @@ BOOST_AUTO_TEST_CASE(RecordDeviceState_FoldsLegacyLabelKeyedSeries)
 	BOOST_CHECK_EQUAL(series.front().count, 3);   // 2 legacy + 1 new, merged
 }
 
+//=============================================================================
+// Lifecycle / maintenance guards (Flush, PurgeOld, Stop, Heartbeat, disabled).
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(Flush_EmptyBuffer_IsNoOp)
+{
+	boost::asio::io_context io;
+	History::HistoryService service(io, *this, MemorySettings());
+	service.Start();
+
+	// Nothing buffered: Flush takes the empty-buffer early return and leaves the DB empty.
+	BOOST_CHECK_NO_THROW(service.Flush());
+	BOOST_CHECK(service.ListSeries().empty());
+}
+
+BOOST_AUTO_TEST_CASE(PurgeOld_RetentionZero_KeepsAllSamples)
+{
+	boost::asio::io_context io;
+	History::HistoryService service(io, *this, MemorySettings());
+	std::int64_t now = 1'000'000;
+	service.SetClock([&now] { return now; });
+	service.Start();
+
+	// Retention 0 disables purging entirely (keep-forever), so PurgeOld is a no-op.
+	Find<Kernel::PreferencesHub>()->HistoryRetentionDays = 0;
+
+	service.RecordNumeric("temp/pool", "C", 20.0, /*is_heartbeat=*/true);
+	now += 5;
+	service.RecordNumeric("temp/pool", "C", 21.0, /*is_heartbeat=*/true);
+	service.Flush();
+
+	service.PurgeOld();
+
+	auto series = service.ListSeries();
+	BOOST_REQUIRE_EQUAL(series.size(), 1u);
+	BOOST_CHECK_EQUAL(series.front().count, 2);   // nothing purged
+}
+
+BOOST_AUTO_TEST_CASE(Stop_AfterStart_FlushesCleanly)
+{
+	boost::asio::io_context io;
+	History::HistoryService service(io, *this, MemorySettings());
+	std::int64_t now = 10;
+	service.SetClock([&now] { return now; });
+	service.Start();
+
+	service.RecordNumeric("temp/pool", "C", 20.0, /*is_heartbeat=*/true);
+
+	// Stop flushes the outstanding buffer and tears down timers without throwing.
+	BOOST_CHECK_NO_THROW(service.Stop());
+}
+
+BOOST_AUTO_TEST_CASE(Heartbeat_OnEmptyDataHub_RecordsNothing)
+{
+	boost::asio::io_context io;
+	History::HistoryService service(io, *this, MemorySettings());
+	std::int64_t now = 1'000;
+	service.SetClock([&now] { return now; });
+	service.Start();
+
+	// With no temps/chemistry/chlorinator on the DataHub, SampleCurrentState takes every
+	// "absent value" branch and records nothing.
+	BOOST_CHECK_NO_THROW(service.Heartbeat());
+	BOOST_CHECK(service.ListSeries().empty());
+}
+
+BOOST_AUTO_TEST_CASE(Start_EmptyDbPath_StaysDisabled)
+{
+	boost::asio::io_context io;
+	auto settings = MemorySettings();
+	settings.db_path = "";   // disabled: no database is opened
+	History::HistoryService service(io, *this, settings);
+
+	BOOST_CHECK_NO_THROW(service.Start());
+
+	// A disabled service silently drops samples and reports no series.
+	BOOST_CHECK_NO_THROW(service.RecordNumeric("temp/pool", "C", 20.0, /*is_heartbeat=*/true));
+	BOOST_CHECK(service.ListSeries().empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Batch 4 of the SonarCloud `new_coverage` work — tractable persistence-service extensions across two existing suites. 13 new cases, all via public APIs, no production code changed.

## history_service.cpp

Exercises the maintenance/lifecycle guards previously uncovered:
- `Flush()` empty-buffer early return (no-op, DB stays empty).
- `PurgeOld()` with retention 0 → keep-all (early return; samples survive).
- `Stop()` after `Start()` → clean flush + timer teardown.
- `Heartbeat()` over an empty DataHub → drives `SampleCurrentState`'s absent-value branches (records nothing).
- Disabled service (empty `db_path`) silently drops samples and reports no series.

## equipment_cache_service.cpp

- `Load()` guards: missing file (early return) and malformed JSON (parse exception caught, not propagated).
- `SaveNow()` with no configured file → no-op.
- `ApplySnapshot()` config adoption: cached `pool_configuration` / `system_board` adopted **only while the live value is Unknown** (and ignored once live discovery has set it).
- `ApplySnapshot()` malformed device `id` → falls back to a fresh id while still applying the remaining traits (`body_of_water`).
- `Snapshot()` on a fresh hub → `Unknown` config, no devices.

## Verification

Built locally (MSVC debug); full `testaqualink-automate` suite — **No errors detected** (exit 0). 13 new cases (80 assertions across the two suites) all passing.