### PR TITLE
test(hub,navigator): cover MQTT message routing and item-navigation edge cases

### DIFF
--- a/test/unit/mqtt/test_mqtt_hub.cpp
+++ b/test/unit/mqtt/test_mqtt_hub.cpp
@@ -478,3 +478,93 @@ BOOST_AUTO_TEST_CASE(Test_PerBodyTemperatures_PublishedWithFreshnessShape)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// Inbound message routing (HandleMessage -> ProcessCommand). The hub subscribes
+// to the client's OnMessageReceived in its constructor, so firing that signal
+// drives the real parse + dispatch without a broker.
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_MqttHub_MessageRouting)
+
+BOOST_AUTO_TEST_CASE(Test_HandleMessage_ValidJson_RoutedToHandler)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeHubTestSettings();
+	Mqtt::MqttHub hub(ioc, settings);
+	hub.Start();   // wires the client OnMessageReceived -> HandleMessage connection
+
+	std::optional<nlohmann::json> captured;
+	hub.RegisterCommand("ctrl", [&](const std::string&, const nlohmann::json& p) { captured = p; });
+
+	hub.GetMqttClient()->OnMessageReceived(hub.CommandTopic("ctrl"), R"({"v":42})");
+
+	BOOST_REQUIRE(captured.has_value());
+	BOOST_CHECK_EQUAL(captured->value("v", 0), 42);
+}
+
+BOOST_AUTO_TEST_CASE(Test_HandleMessage_InvalidJson_FallsBackToRaw)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeHubTestSettings();
+	Mqtt::MqttHub hub(ioc, settings);
+	hub.Start();
+
+	std::optional<nlohmann::json> captured;
+	hub.RegisterCommand("ctrl", [&](const std::string&, const nlohmann::json& p) { captured = p; });
+
+	// Unparseable payload: the handler still runs, with the raw text wrapped as {"raw": ...}.
+	hub.GetMqttClient()->OnMessageReceived(hub.CommandTopic("ctrl"), "{ not valid json");
+
+	BOOST_REQUIRE(captured.has_value());
+	BOOST_REQUIRE(captured->contains("raw"));
+	BOOST_CHECK_EQUAL(captured->at("raw").get<std::string>(), "{ not valid json");
+}
+
+BOOST_AUTO_TEST_CASE(Test_HandleMessage_EmptyPayload_RoutedWithEmptyJson)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeHubTestSettings();
+	Mqtt::MqttHub hub(ioc, settings);
+	hub.Start();
+
+	bool called = false;
+	std::optional<nlohmann::json> captured;
+	hub.RegisterCommand("ctrl", [&](const std::string&, const nlohmann::json& p) { called = true; captured = p; });
+
+	// Empty payload bypasses JSON parsing entirely; the handler still fires with a null json.
+	hub.GetMqttClient()->OnMessageReceived(hub.CommandTopic("ctrl"), "");
+
+	BOOST_CHECK(called);
+	BOOST_REQUIRE(captured.has_value());
+	BOOST_CHECK(captured->is_null());
+}
+
+BOOST_AUTO_TEST_CASE(Test_HandleMessage_NonCommandTopic_Ignored)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeHubTestSettings();
+	Mqtt::MqttHub hub(ioc, settings);
+	hub.Start();
+
+	bool called = false;
+	hub.RegisterCommand("ctrl", [&](const std::string&, const nlohmann::json&) { called = true; });
+
+	// A status topic is not a command topic, so HandleMessage drops it before dispatch.
+	hub.GetMqttClient()->OnMessageReceived(hub.StatusTopic("ctrl"), R"({"v":1})");
+
+	BOOST_CHECK(!called);
+}
+
+BOOST_AUTO_TEST_CASE(Test_HandleMessage_UnknownCommand_IsHarmless)
+{
+	boost::asio::io_context ioc;
+	auto settings = MakeHubTestSettings();
+	Mqtt::MqttHub hub(ioc, settings);
+	hub.Start();
+
+	// No handler registered for "ghost": ProcessCommand logs and returns without throwing.
+	BOOST_CHECK_NO_THROW(hub.GetMqttClient()->OnMessageReceived(hub.CommandTopic("ghost"), R"({"v":1})"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/navigation/test_navigation_navigator_edgecases.cpp
+++ b/test/unit/navigation/test_navigation_navigator_edgecases.cpp
@@ -764,4 +764,95 @@ BOOST_AUTO_TEST_CASE(TestSetAquapure_PositionsCursorOnPoolRow_WithoutSelect)
 	BOOST_CHECK_EQUAL(static_cast<int>(nav.GetCursorLine()), 3);
 }
 
+// =============================================================================
+// Initial state and target tracking
+// =============================================================================
+
+// A freshly-constructed Navigator is idle, unsynced and not complete - none of the
+// navigation getters report a destination before StartSync()/NavigateTo().
+BOOST_AUTO_TEST_CASE(TestInitialState_FreshNavigatorIsIdleAndUnsynced)
+{
+	auto model = BuildTestModel();
+	Navigator nav(model);
+
+	BOOST_CHECK_EQUAL(static_cast<int>(nav.GetState()), static_cast<int>(Navigator::State::Idle));
+	BOOST_CHECK(!nav.IsSynced());
+	BOOST_CHECK(!nav.IsComplete());
+	BOOST_CHECK(!nav.IsSuccess());
+	BOOST_CHECK(nav.GetCurrentPage() == PageId::Unknown);
+}
+
+// NavigateTo records the requested destination and enters the Navigating state.
+BOOST_AUTO_TEST_CASE(TestNavigateTo_RecordsTargetAndEntersNavigating)
+{
+	auto model = BuildTestModel();
+	Navigator nav(model);
+
+	nav.StartSync();
+	auto system_content = MakePage({{0, "Equipment ON/OFF"}});
+	for (uint32_t i = 0; i < Navigator::SYNC_REQUIRED_CONSISTENT_COUNT; ++i)
+	{
+		nav.OnPageUpdate(system_content, 0);
+	}
+	BOOST_REQUIRE(nav.IsSynced());
+
+	nav.NavigateTo(PageId::MenuHelp);
+
+	BOOST_CHECK(nav.GetTargetPage() == PageId::MenuHelp);
+	BOOST_CHECK_EQUAL(static_cast<int>(nav.GetState()), static_cast<int>(Navigator::State::Navigating));
+	BOOST_CHECK(!nav.IsComplete());
+}
+
+// =============================================================================
+// NavigateToItem with an EMPTY label: the fixed target line is used directly
+// (no on-screen label search), so the cursor is walked to that line.
+// =============================================================================
+
+// Cursor below the fixed target line -> the Navigator walks it down (no label lookup).
+BOOST_AUTO_TEST_CASE(TestNavigateToItem_EmptyLabel_WalksToFixedLine)
+{
+	auto model = BuildTestModel();
+	Navigator nav(model);
+
+	auto equip = MakePage({{0, "Equipment ON/OFF"}, {1, "Filter Pump"}});
+	nav.StartSync();
+	for (uint32_t i = 0; i < Navigator::SYNC_REQUIRED_CONSISTENT_COUNT; ++i)
+	{
+		nav.OnPageUpdate(equip, 0);
+	}
+	BOOST_REQUIRE(nav.IsSynced());
+	BOOST_REQUIRE(nav.GetCurrentPage() == PageId::EquipmentOnOff);
+
+	// Empty label -> use the fixed line 5; cursor at 0 -> walk down toward it.
+	nav.NavigateToItem(PageId::EquipmentOnOff, 5, "", PageId::Unknown);
+
+	auto cmd = nav.OnPageUpdate(equip, 0);
+	BOOST_REQUIRE(cmd.has_value());
+	BOOST_CHECK_EQUAL(static_cast<int>(cmd.value()), static_cast<int>(NavKeyCommand::LineDown));
+}
+
+// Cursor already on the fixed target line with no select target -> complete in place
+// (no Select; the device drives whatever editor the row hosts).
+BOOST_AUTO_TEST_CASE(TestNavigateToItem_EmptyLabel_AtLine_CompletesWithoutSelect)
+{
+	auto model = BuildTestModel();
+	Navigator nav(model);
+
+	auto equip = MakePage({{0, "Equipment ON/OFF"}, {1, "Filter Pump"}});
+	nav.StartSync();
+	for (uint32_t i = 0; i < Navigator::SYNC_REQUIRED_CONSISTENT_COUNT; ++i)
+	{
+		nav.OnPageUpdate(equip, 5);
+	}
+	BOOST_REQUIRE(nav.IsSynced());
+
+	nav.NavigateToItem(PageId::EquipmentOnOff, 5, "", PageId::Unknown);
+
+	auto cmd = nav.OnPageUpdate(equip, 5);
+	BOOST_CHECK(!cmd.has_value());
+	BOOST_CHECK(nav.IsComplete());
+	BOOST_CHECK(nav.IsSuccess());
+	BOOST_CHECK_EQUAL(static_cast<int>(nav.GetCursorLine()), 5);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Batch 5 of the SonarCloud `new_coverage` work. 9 new cases across two files, all via public/seam APIs, no production code changed.

## mqtt_hub.cpp — inbound message routing

Drives the real `HandleMessage` → `ProcessCommand` path through the client's `OnMessageReceived` signal (wired in `Start()`):
- Valid JSON reaches the registered handler **parsed**.
- An unparseable payload falls back to `{"raw": <text>}`.
- An empty payload routes a null json (handler still fires).
- A non-command topic is dropped before dispatch.
- An unknown command is harmless (logged, no throw).

## navigator.cpp — initial state + empty-label item navigation

- A freshly-constructed `Navigator` is `Idle` / unsynced / not complete.
- `NavigateTo` records the target page and enters `Navigating`.
- `NavigateToItem` with an **empty label** uses the fixed target line directly (no on-screen label search): walks the cursor down toward it, and completes **in place without a Select** when already positioned with no select target.

## Verification

Built locally (MSVC debug); full `testaqualink-automate` suite — **No errors detected** (exit 0). 9 new cases passing; the navigator suite grows to 24 cases (80 assertions). (One iteration was needed on the hub tests once I confirmed the `OnMessageReceived`→`HandleMessage` connection is established in `Start()`, not the constructor.)