### PR TITLE
test(onetouch): cover Equipment Status processors and mode pages

### DIFF
--- a/test/unit/devices/test_devices_onetouch.cpp
+++ b/test/unit/devices/test_devices_onetouch.cpp
@@ -625,4 +625,118 @@ BOOST_AUTO_TEST_CASE(TestGoal_ChlorinatorBoost_ServicedAcrossFrames)
 	BOOST_CHECK(device.IsInNormalOperationForTest());
 }
 
+// =============================================================================
+// Equipment Status page processing (StatusProcessor_* fan-out)
+//
+// Rendering the EQUIPMENT STATUS page and completing it with a Status frame runs
+// PageProcessor_EquipmentStatus, which dispatches every non-empty line through
+// the nine StatusProcessor_* matchers. Each decodes its row into the DataHub.
+// =============================================================================
+
+namespace
+{
+	// Complete the rendered screen so ProcessScreenUpdates() runs the matching page
+	// processor (the render seam leaves the screen in Updating mode; the page
+	// processors only fire on the UpdateComplete transition, exactly as a real
+	// Status frame would drive it). Screen mode + ProcessScreenUpdates are public.
+	void CompleteScreen(OneTouchDevice& device)
+	{
+		device.ScreenMode(Capabilities::ScreenModes::UpdateComplete);
+		device.ProcessScreenUpdates();
+	}
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_FilterPump_CreatesRunningPump)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(2, "Filter Pump");
+	CompleteScreen(device);
+
+	auto pumps = data_hub->FilterPumps();
+	BOOST_REQUIRE_EQUAL(pumps.size(), 1u);
+	auto status = pumps.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::PumpStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::PumpStatuses::Running);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_PoolHeat_EnaParsesEnabled)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(3, "Pool Heat ENA");   // "ENA" suffix -> Enabled
+	CompleteScreen(device);
+
+	auto heaters = data_hub->Devices.FindByLabel("Pool Heat");
+	BOOST_REQUIRE_EQUAL(heaters.size(), 1u);
+	auto status = heaters.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::HeaterStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::HeaterStatuses::Enabled);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_SpaHeat_NoSuffixParsesHeating)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(4, "Spa Heat");   // no "ENA" -> actively Heating
+	CompleteScreen(device);
+
+	auto heaters = data_hub->Devices.FindByLabel("Spa Heat");
+	BOOST_REQUIRE_EQUAL(heaters.size(), 1u);
+	auto status = heaters.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::HeaterStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::HeaterStatuses::Heating);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_AquaPure_CreatesChlorinatorWithDutyCycle)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(6, "AquaPure  50%");   // right-justified value (multiple spaces)
+	CompleteScreen(device);
+
+	auto chlorinators = data_hub->Devices.FindByLabel("AquaPure");
+	BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+	auto duty = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::DutyCycleTrait{});
+	BOOST_REQUIRE(duty.has_value());
+	BOOST_CHECK_EQUAL(static_cast<int>(duty.value()), 50);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_SaltLevel_ParsesPpm)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(7, "Salt  3000  ppm");
+	CompleteScreen(device);
+
+	BOOST_CHECK_CLOSE(data_hub->SaltLevel().value(), 3000.0, 0.01);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_Service_SetsServiceMode)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	// The Service page is detected by line 3 "Service Mode".
+	device.RenderScreenLineForTest(3, "Service Mode");
+	CompleteScreen(device);
+
+	BOOST_CHECK(data_hub->Mode == Kernel::EquipmentMode::Service);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_TimeOut_SetsTimeOutMode)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	// The TimeOut page is detected by line 3 "Timeout Mode".
+	device.RenderScreenLineForTest(3, "Timeout Mode");
+	CompleteScreen(device);
+
+	BOOST_CHECK(data_hub->Mode == Kernel::EquipmentMode::TimeOut);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Batch 7 of the SonarCloud `new_coverage` work. Covers the OneTouch page/status processors (`onetouch_statusprocessors.cpp` + `onetouch_pageprocessors.cpp`), which decode a rendered screen into the DataHub but were never asserted by any test. 7 new cases, no production code changed.

## Mechanism

Render the relevant screen lines via the existing `RenderScreenLineForTest` seam, then complete the screen with `ScreenMode(UpdateComplete)` + `ProcessScreenUpdates()` — the **public** path a real Status frame drives — which runs the matching `PageProcessor_*` and asserts the decoded model. (Established empirically that `DeliverStatusFrameForTest` alone does *not* complete the screen, so the explicit completion is required.)

## What's covered

**`PageProcessor_EquipmentStatus` fan-out (StatusProcessor_*):**
- `FilterPump` → creates the filter pump, marks it `Running`.
- `PoolHeat` → `"Pool Heat ENA"` parses as `Enabled`.
- `SpaHeat` → bare `"Spa Heat"` parses as actively `Heating`.
- `AquaPurePercentage` → creates the `AquaPure` chlorinator, sets duty cycle from the right-justified `"AquaPure  50%"`.
- `SaltLevelPPM` → `"Salt  3000  ppm"` parses into the salt level.

**Mode pages:**
- `PageProcessor_Service` → `EquipmentMode::Service`.
- `PageProcessor_TimeOut` → `EquipmentMode::TimeOut`.

## Verification

Built locally (MSVC debug); full `testaqualink-automate` suite — **No errors detected** (exit 0). 7 new cases passing; OneTouch suite grows to 43 cases.