### PR TITLE
test(onetouch): cover setpoint/config page processors

### DIFF
--- a/test/unit/devices/test_devices_onetouch.cpp
+++ b/test/unit/devices/test_devices_onetouch.cpp
@@ -739,4 +739,89 @@ BOOST_AUTO_TEST_CASE(TestPageProcessor_TimeOut_SetsTimeOutMode)
 	BOOST_CHECK(data_hub->Mode == Kernel::EquipmentMode::TimeOut);
 }
 
+// =============================================================================
+// Configuration / setpoint page processors (decode a scraped menu page into the
+// DataHub model). Same CompleteScreen() mechanism as the Equipment Status tests.
+// =============================================================================
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_SetTemperature_ParsesHeatSetpoints)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "    Set Temp");          // detector
+	device.RenderScreenLineForTest(2, "Pool Heat   90`F");
+	device.RenderScreenLineForTest(3, "Spa Heat   102`F");
+	CompleteScreen(device);
+
+	auto pool = data_hub->PoolTempSetpoint();
+	auto spa = data_hub->SpaTempSetpoint();
+	BOOST_REQUIRE(pool.has_value());
+	BOOST_REQUIRE(spa.has_value());
+	BOOST_CHECK_CLOSE(pool.value().InFahrenheit().value(), 90.0, 0.5);
+	BOOST_CHECK_CLOSE(spa.value().InFahrenheit().value(), 102.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_SetAquapure_ScrapesChlorinatorSetpoints)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "  Set AQUAPURE");        // detector
+	device.RenderScreenLineForTest(3, "Set Pool to:  45%");
+	device.RenderScreenLineForTest(4, "Set Spa to:   50%");
+	CompleteScreen(device);
+
+	auto chlorinators = data_hub->Chlorinators();
+	BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+	auto pool_sp = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::ChlorinatorPoolSetpointTrait{});
+	auto spa_sp = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::ChlorinatorSpaSetpointTrait{});
+	BOOST_REQUIRE(pool_sp.has_value());
+	BOOST_REQUIRE(spa_sp.has_value());
+	BOOST_CHECK_EQUAL(static_cast<int>(pool_sp.value()), 45);
+	BOOST_CHECK_EQUAL(static_cast<int>(spa_sp.value()), 50);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_Version_PopulatesVersionsAndBodies)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(4, "B0029221");
+	device.RenderScreenLineForTest(5, "RS-8 Combo");
+	device.RenderScreenLineForTest(7, "REV T.0.1");           // detector "REV "
+	CompleteScreen(device);
+
+	BOOST_CHECK_EQUAL(data_hub->EquipmentVersions.Get("Model"), "B0029221");
+	BOOST_CHECK_EQUAL(data_hub->EquipmentVersions.Get("Type"), "RS-8 Combo");
+	BOOST_CHECK_EQUAL(data_hub->EquipmentVersions.Get("Revision"), "REV T.0.1");
+	// A decoded panel type resolves a pool configuration, which seeds the bodies.
+	BOOST_CHECK(data_hub->PoolConfiguration != Kernel::PoolConfigurations::Unknown);
+	BOOST_CHECK(!data_hub->Bodies().empty());
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_FreezeProtect_ParsesThreshold)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, " Freeze Protect");      // detector
+	device.RenderScreenLineForTest(3, "Temp        38`F");
+	CompleteScreen(device);
+
+	auto threshold = data_hub->FreezeProtectPoint();
+	BOOST_REQUIRE(threshold.has_value());
+	BOOST_CHECK_CLOSE(threshold.value().InFahrenheit().value(), 38.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_EquipmentOnOff_CreatesAuxDevices)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "Filter Pump  ***");     // detector "Filter Pump"
+	device.RenderScreenLineForTest(5, "Aux1         OFF");
+	device.RenderScreenLineForTest(6, "Aux2         OFF");
+	device.RenderScreenLineForTest(7, "Aux3          ON");
+	CompleteScreen(device);
+
+	// Each aux row is decoded into an auxillary device on the DataHub.
+	BOOST_CHECK_GE(data_hub->Auxillaries().size(), 3u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Batch 8 of the SonarCloud `new_coverage` work. Extends OneTouch page-processor coverage to the configuration/setpoint pages, using the `CompleteScreen()` mechanism introduced in #66. 5 new cases, no production code changed.

> **Stacked on [#66](https://github.com/iainchesworth/aqualink-automate/pull/66)** — it reuses the `CompleteScreen` helper and the same file, so this PR is based on `test/onetouch-processors`. Merge #66 first (or merge both together); GitHub will retarget this to `develop` once #66 lands.

## What's covered

- **`PageProcessor_SetTemperature`** → parses Pool/Spa heat setpoints by area label into `PoolTempSetpoint` / `SpaTempSetpoint` (90 °F / 102 °F).
- **`PageProcessor_SetAquapure`** → creates the `AquaPure` chlorinator and scrapes its configured Pool/Spa output setpoints (45% / 50%).
- **`PageProcessor_Version`** → records Model/Type/Revision, decodes the panel type into a pool configuration, and seeds the bodies of water.
- **`PageProcessor_FreezeProtect`** → parses the freeze-protect threshold (38 °F).
- **`PageProcessor_EquipmentOnOff`** → decodes each aux row into an auxillary device on the DataHub.

## Verification

Built locally (MSVC debug); full `testaqualink-automate` suite — **No errors detected** (exit 0). 5 new cases passing; OneTouch suite now at 48 cases.