### PR TITLE
Promote develop to main: device-decode + certificate test coverage (Batches 6-9)

### DIFF
--- a/test/unit/certificates/test_certificate_generation.cpp
+++ b/test/unit/certificates/test_certificate_generation.cpp
@@ -10,6 +10,9 @@
 
 #include "application/application_defaults.h"
 #include "certificates/certificate_management.h"
+#include "exceptions/exception_certificate_notfound.h"
+#include "exceptions/exception_certificate_invalidformat.h"
+#include "options/options_web_options.h"
 
 namespace fs = std::filesystem;
 using namespace AqualinkAutomate;
@@ -105,6 +108,109 @@ BOOST_AUTO_TEST_CASE(EnsureSelfSignedMaterial_RefusesToGenerateForOperatorSpecif
 	Options::Web::SslCertificate operator_specified{ missing_dir / "their-cert.pem", missing_dir / "their-key.pem" };
 	const auto resolved = Certificates::EnsureSelfSignedMaterial(operator_specified);
 	BOOST_CHECK(!resolved.has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// LoadSslCertificates: resolve + load TLS material into an ssl::context, or
+// throw a typed certificate exception when the configured material is missing
+// or unloadable.
+//=============================================================================
+
+namespace
+{
+	Options::Web::WebSettings EnabledHttpsSettings(const fs::path& cert, const fs::path& key)
+	{
+		Options::Web::WebSettings cfg;   // https_server_is_enabled defaults true
+		cfg.ssl_certificate = Options::Web::SslCertificate{ cert, key };
+		return cfg;
+	}
+}
+
+BOOST_AUTO_TEST_SUITE(TestSuite_LoadSslCertificates)
+
+BOOST_AUTO_TEST_CASE(LoadSslCertificates_HttpsDisabled_IsNoOp)
+{
+	Options::Web::WebSettings cfg;
+	cfg.https_server_is_enabled = false;
+
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+
+	// Disabled HTTPS short-circuits before any certificate resolution.
+	BOOST_CHECK_NO_THROW(Certificates::LoadSslCertificates(cfg, ctx));
+}
+
+BOOST_AUTO_TEST_CASE(LoadSslCertificates_OperatorMissingMaterial_ThrowsNotFound)
+{
+	const fs::path dir = fs::temp_directory_path() / "aqualink_loadssl_missing";
+	std::error_code rm;
+	fs::remove_all(dir, rm);
+
+	// Non-default, non-existent paths: EnsureSelfSignedMaterial refuses to fabricate
+	// material for operator-specified paths, so loading must fail loudly.
+	auto cfg = EnabledHttpsSettings(dir / "cert.pem", dir / "key.pem");
+
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+	BOOST_CHECK_THROW(Certificates::LoadSslCertificates(cfg, ctx), Exceptions::Certificate_NotFound);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSslCertificates_ValidMaterial_LoadsSuccessfully)
+{
+	const fs::path dir = fs::temp_directory_path() / "aqualink_loadssl_valid";
+	std::error_code rm;
+	fs::remove_all(dir, rm);
+
+	const fs::path cert = dir / "cert.pem";
+	const fs::path key = dir / "key.pem";
+	BOOST_REQUIRE(Certificates::GenerateSelfSignedCertificate(cert, key));
+
+	auto cfg = EnabledHttpsSettings(cert, key);   // no ca_chain_certificate
+
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+	BOOST_CHECK_NO_THROW(Certificates::LoadSslCertificates(cfg, ctx));
+
+	fs::remove_all(dir, rm);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSslCertificates_InvalidPem_ThrowsInvalidFormat)
+{
+	const fs::path dir = fs::temp_directory_path() / "aqualink_loadssl_garbage";
+	std::error_code rm;
+	fs::remove_all(dir, rm);
+	fs::create_directories(dir, rm);
+
+	const fs::path cert = dir / "cert.pem";
+	const fs::path key = dir / "key.pem";
+	// Both files exist (so they are accepted as present) but are not valid PEM.
+	{ std::ofstream(cert, std::ios::binary) << "not a certificate"; }
+	{ std::ofstream(key, std::ios::binary) << "not a key"; }
+
+	auto cfg = EnabledHttpsSettings(cert, key);
+
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+	BOOST_CHECK_THROW(Certificates::LoadSslCertificates(cfg, ctx), Exceptions::Certificate_InvalidFormat);
+
+	fs::remove_all(dir, rm);
+}
+
+BOOST_AUTO_TEST_CASE(LoadSslCertificates_MissingCaChain_ThrowsNotFound)
+{
+	const fs::path dir = fs::temp_directory_path() / "aqualink_loadssl_cachain";
+	std::error_code rm;
+	fs::remove_all(dir, rm);
+
+	const fs::path cert = dir / "cert.pem";
+	const fs::path key = dir / "key.pem";
+	BOOST_REQUIRE(Certificates::GenerateSelfSignedCertificate(cert, key));
+
+	auto cfg = EnabledHttpsSettings(cert, key);
+	cfg.ca_chain_certificate = dir / "missing-ca-chain.pem";   // configured but absent
+
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+	BOOST_CHECK_THROW(Certificates::LoadSslCertificates(cfg, ctx), Exceptions::Certificate_NotFound);
+
+	fs::remove_all(dir, rm);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/devices/test_devices_iaq.cpp
+++ b/test/unit/devices/test_devices_iaq.cpp
@@ -12,12 +12,19 @@
 #include "jandy/devices/jandy_device_types.h"
 #include "jandy/messages/jandy_message_ids.h"
 
+#include "kernel/data_hub.h"
+#include "kernel/auxillary_devices/auxillary_device.h"
+#include "kernel/auxillary_traits/auxillary_traits_types.h"
+#include "kernel/body_of_water_ids.h"
+
 #include "support/unit_test_hublocatorinjector.h"
 #include "support/unit_test_mockreplayharness.h"
 #include "support/unit_test_protocolmessagebuilder.h"
 
 using namespace AqualinkAutomate;
 using namespace AqualinkAutomate::Devices;
+
+namespace IaqTraits = AqualinkAutomate::Kernel::AuxillaryTraitsTypes;
 
 namespace
 {
@@ -465,6 +472,236 @@ BOOST_AUTO_TEST_CASE(Heartbeat_AfterMainStatus_KeepsSystemStatusPage)
 		joined += '\n';
 	}
 	BOOST_CHECK(joined.find("System Status") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// =============================================================================
+// MainStatus -> DataHub state
+//
+// ProcessMainStatus does not just render the screen: it is the single authority
+// that fans the decoded MainStatus out into the DataHub (circulation mode + active
+// body, the three temperatures, the filter pump, and the Pool/Spa/Solar heaters).
+// The screen-rendering tests above never inspect that DataHub state, so these
+// drive the same proven MainStatus frame and assert the decoded model.
+// =============================================================================
+
+BOOST_AUTO_TEST_SUITE(IAQDevice_MainStatusDataHub_TestSuite)
+
+namespace
+{
+	void ReplayMainStatus(Test::MockReplayHarness& harness, const std::vector<uint8_t>& payload)
+	{
+		const uint8_t cmd_main_status = static_cast<uint8_t>(AqualinkAutomate::Messages::JandyMessageIds::IAQ_MainStatus);
+		harness.Replay(Test::MessageBuilder::CreateValidChecksummedMessage(IAQ_DEVICE_ID, cmd_main_status, payload));
+	}
+}
+
+BOOST_AUTO_TEST_CASE(MainStatus_PopulatesDataHubTemperatures)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	ReplayMainStatus(harness, MakeMainStatusPayload_CurrentFormat());
+
+	auto hub = harness.DataHub();
+	auto pool = hub->PoolTemp();
+	auto spa = hub->SpaTemp();
+	auto air = hub->AirTemp();
+
+	BOOST_REQUIRE(pool.has_value());
+	BOOST_REQUIRE(spa.has_value());
+	BOOST_REQUIRE(air.has_value());
+
+	// PoolTemp = pool_target (28C), SpaTemp = water_current (27C), AirTemp = air (24C).
+	BOOST_CHECK_CLOSE(pool.value().InCelsius().value(), 28.0, 0.01);
+	BOOST_CHECK_CLOSE(spa.value().InCelsius().value(), 27.0, 0.01);
+	BOOST_CHECK_CLOSE(air.value().InCelsius().value(), 24.0, 0.01);
+}
+
+BOOST_AUTO_TEST_CASE(MainStatus_PoolMode_SetsCirculationPool)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	// Default payload has spa_mode = 0x00 (Pool mode).
+	ReplayMainStatus(harness, MakeMainStatusPayload_CurrentFormat());
+
+	BOOST_CHECK(harness.DataHub()->CirculationMode == Kernel::CirculationModes::Pool);
+}
+
+BOOST_AUTO_TEST_CASE(MainStatus_SpaMode_SetsCirculationSpaAndAutoDetectsDualBody)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	auto payload = MakeMainStatusPayload_CurrentFormat();
+	payload[6] = 0x01;   // spa_mode ON (the byte after pump + pool_heat)
+	ReplayMainStatus(harness, payload);
+
+	auto hub = harness.DataHub();
+	BOOST_CHECK(hub->CirculationMode == Kernel::CirculationModes::Spa);
+	// Seeing spa mode on an otherwise-unconfigured IAQ infers a shared-equipment dual body.
+	BOOST_CHECK(hub->PoolConfiguration == Kernel::PoolConfigurations::DualBody_SharedEquipment);
+}
+
+BOOST_AUTO_TEST_CASE(MainStatus_CreatesFilterPump_TrackingPumpStatus)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	// First MainStatus: pump ON.
+	ReplayMainStatus(harness, MakeMainStatusPayload_CurrentFormat());
+
+	auto pumps = harness.DataHub()->FilterPumps();
+	BOOST_REQUIRE_EQUAL(pumps.size(), 1u);
+	auto status_on = pumps.front()->AuxillaryTraits.TryGet(IaqTraits::PumpStatusTrait{});
+	BOOST_REQUIRE(status_on.has_value());
+	BOOST_CHECK(status_on.value() == Kernel::PumpStatuses::Running);
+
+	// Second MainStatus: pump OFF -> the SAME pump flips status (no duplicate created).
+	auto payload_off = MakeMainStatusPayload_CurrentFormat();
+	payload_off[4] = 0x00;   // pump OFF
+	ReplayMainStatus(harness, payload_off);
+
+	auto pumps_after = harness.DataHub()->FilterPumps();
+	BOOST_REQUIRE_EQUAL(pumps_after.size(), 1u);
+	auto status_off = pumps_after.front()->AuxillaryTraits.TryGet(IaqTraits::PumpStatusTrait{});
+	BOOST_REQUIRE(status_off.has_value());
+	BOOST_CHECK(status_off.value() == Kernel::PumpStatuses::Off);
+}
+
+BOOST_AUTO_TEST_CASE(MainStatus_CreatesHeaters_WithDecodedStatus)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	// Payload: pool_heat = 0x01 (Heating), spa_heat = 0x00 (Off), solar = 0x00 (Off).
+	ReplayMainStatus(harness, MakeMainStatusPayload_CurrentFormat());
+
+	auto hub = harness.DataHub();
+
+	auto pool_heat = hub->Devices.FindByLabel("Pool Heat");
+	BOOST_REQUIRE_EQUAL(pool_heat.size(), 1u);
+	auto pool_status = pool_heat.front()->AuxillaryTraits.TryGet(IaqTraits::HeaterStatusTrait{});
+	BOOST_REQUIRE(pool_status.has_value());
+	BOOST_CHECK(pool_status.value() == Kernel::HeaterStatuses::Heating);
+
+	auto spa_heat = hub->Devices.FindByLabel("Spa Heat");
+	BOOST_REQUIRE_EQUAL(spa_heat.size(), 1u);
+	auto spa_status = spa_heat.front()->AuxillaryTraits.TryGet(IaqTraits::HeaterStatusTrait{});
+	BOOST_REQUIRE(spa_status.has_value());
+	BOOST_CHECK(spa_status.value() == Kernel::HeaterStatuses::Off);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// =============================================================================
+// AuxStatus -> DataHub auxillary devices
+//
+// ProcessAuxStatus decodes the IAQ AuxStatus (0x72) device list into the DataHub:
+// each entry creates/reconciles an auxillary device keyed by its stable aux id,
+// sets its on/off status, adopts the panel-provided label, and infers a body of
+// water from the label ("Spa"/"Pool"). The existing suite never exercises this.
+// Wire layout (see test_iaq_messages.cpp): num_devices, indices[], then per
+// device: status(1) type(1) pad(2) name_len(1) name[].
+// =============================================================================
+
+BOOST_AUTO_TEST_SUITE(IAQDevice_AuxStatusDataHub_TestSuite)
+
+namespace
+{
+	// Build one AuxStatus device entry (header + name) appended to `out`.
+	void AppendAuxDevice(std::vector<uint8_t>& out, bool is_on, uint8_t type, const std::string& name)
+	{
+		out.push_back(is_on ? 0x01 : 0x00);
+		out.push_back(type);
+		out.push_back(0x00);
+		out.push_back(0x00);
+		out.push_back(static_cast<uint8_t>(name.size()));
+		out.insert(out.end(), name.begin(), name.end());
+	}
+
+	void ReplayAuxStatus(Test::MockReplayHarness& harness, const std::vector<uint8_t>& payload)
+	{
+		const uint8_t cmd_aux = static_cast<uint8_t>(AqualinkAutomate::Messages::JandyMessageIds::IAQ_AuxStatus);
+		harness.Replay(Test::MessageBuilder::CreateValidChecksummedMessage(IAQ_DEVICE_ID, cmd_aux, payload));
+	}
+}
+
+BOOST_AUTO_TEST_CASE(AuxStatus_CreatesLabelledAuxWithPoolBody)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	// One device: aux index 5, ON, label "Pool Light".
+	std::vector<uint8_t> payload = { 0x01, 0x05 };
+	AppendAuxDevice(payload, /*is_on=*/true, /*type=*/0x00, "Pool Light");
+	ReplayAuxStatus(harness, payload);
+
+	auto matches = harness.DataHub()->Devices.FindByLabel("Pool Light");
+	BOOST_REQUIRE_EQUAL(matches.size(), 1u);
+	auto aux = matches.front();
+
+	auto status = aux->AuxillaryTraits.TryGet(IaqTraits::AuxillaryStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::AuxillaryStatuses::On);
+
+	// Label contains "Pool" -> body heuristic resolves to Pool.
+	auto body = aux->AuxillaryTraits.TryGet(IaqTraits::BodyOfWaterTrait{});
+	BOOST_REQUIRE(body.has_value());
+	BOOST_CHECK(body.value() == Kernel::BodyOfWaterIds::Pool);
+}
+
+BOOST_AUTO_TEST_CASE(AuxStatus_SpaLabel_ResolvesSpaBody)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	std::vector<uint8_t> payload = { 0x01, 0x05 };
+	AppendAuxDevice(payload, /*is_on=*/false, /*type=*/0x00, "Spa Jet");
+	ReplayAuxStatus(harness, payload);
+
+	auto matches = harness.DataHub()->Devices.FindByLabel("Spa Jet");
+	BOOST_REQUIRE_EQUAL(matches.size(), 1u);
+
+	auto body = matches.front()->AuxillaryTraits.TryGet(IaqTraits::BodyOfWaterTrait{});
+	BOOST_REQUIRE(body.has_value());
+	BOOST_CHECK(body.value() == Kernel::BodyOfWaterIds::Spa);
+
+	auto status = matches.front()->AuxillaryTraits.TryGet(IaqTraits::AuxillaryStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::AuxillaryStatuses::Off);
+}
+
+BOOST_AUTO_TEST_CASE(AuxStatus_SecondMessage_UpdatesStatusInPlace)
+{
+	Test::MockReplayHarness harness;
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(IAQ_DEVICE_ID));
+	IAQDevice device(device_id, harness.HubLocatorRef(), /*is_emulated=*/false);
+
+	// First: aux 5 ON.
+	std::vector<uint8_t> on = { 0x01, 0x05 };
+	AppendAuxDevice(on, /*is_on=*/true, /*type=*/0x00, "Pool Light");
+	ReplayAuxStatus(harness, on);
+
+	// Second: same aux 5 OFF -> reconciled by stable id, no duplicate.
+	std::vector<uint8_t> off = { 0x01, 0x05 };
+	AppendAuxDevice(off, /*is_on=*/false, /*type=*/0x00, "Pool Light");
+	ReplayAuxStatus(harness, off);
+
+	auto matches = harness.DataHub()->Devices.FindByLabel("Pool Light");
+	BOOST_REQUIRE_EQUAL(matches.size(), 1u);
+	auto status = matches.front()->AuxillaryTraits.TryGet(IaqTraits::AuxillaryStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::AuxillaryStatuses::Off);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/devices/test_devices_onetouch.cpp
+++ b/test/unit/devices/test_devices_onetouch.cpp
@@ -625,4 +625,118 @@ BOOST_AUTO_TEST_CASE(TestGoal_ChlorinatorBoost_ServicedAcrossFrames)
 	BOOST_CHECK(device.IsInNormalOperationForTest());
 }
 
+// =============================================================================
+// Equipment Status page processing (StatusProcessor_* fan-out)
+//
+// Rendering the EQUIPMENT STATUS page and completing it with a Status frame runs
+// PageProcessor_EquipmentStatus, which dispatches every non-empty line through
+// the nine StatusProcessor_* matchers. Each decodes its row into the DataHub.
+// =============================================================================
+
+namespace
+{
+	// Complete the rendered screen so ProcessScreenUpdates() runs the matching page
+	// processor (the render seam leaves the screen in Updating mode; the page
+	// processors only fire on the UpdateComplete transition, exactly as a real
+	// Status frame would drive it). Screen mode + ProcessScreenUpdates are public.
+	void CompleteScreen(OneTouchDevice& device)
+	{
+		device.ScreenMode(Capabilities::ScreenModes::UpdateComplete);
+		device.ProcessScreenUpdates();
+	}
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_FilterPump_CreatesRunningPump)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(2, "Filter Pump");
+	CompleteScreen(device);
+
+	auto pumps = data_hub->FilterPumps();
+	BOOST_REQUIRE_EQUAL(pumps.size(), 1u);
+	auto status = pumps.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::PumpStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::PumpStatuses::Running);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_PoolHeat_EnaParsesEnabled)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(3, "Pool Heat ENA");   // "ENA" suffix -> Enabled
+	CompleteScreen(device);
+
+	auto heaters = data_hub->Devices.FindByLabel("Pool Heat");
+	BOOST_REQUIRE_EQUAL(heaters.size(), 1u);
+	auto status = heaters.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::HeaterStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::HeaterStatuses::Enabled);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_SpaHeat_NoSuffixParsesHeating)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(4, "Spa Heat");   // no "ENA" -> actively Heating
+	CompleteScreen(device);
+
+	auto heaters = data_hub->Devices.FindByLabel("Spa Heat");
+	BOOST_REQUIRE_EQUAL(heaters.size(), 1u);
+	auto status = heaters.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::HeaterStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::HeaterStatuses::Heating);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_AquaPure_CreatesChlorinatorWithDutyCycle)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(6, "AquaPure  50%");   // right-justified value (multiple spaces)
+	CompleteScreen(device);
+
+	auto chlorinators = data_hub->Devices.FindByLabel("AquaPure");
+	BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+	auto duty = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::DutyCycleTrait{});
+	BOOST_REQUIRE(duty.has_value());
+	BOOST_CHECK_EQUAL(static_cast<int>(duty.value()), 50);
+}
+
+BOOST_AUTO_TEST_CASE(TestStatusProcessor_SaltLevel_ParsesPpm)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "EQUIPMENT STATUS");
+	device.RenderScreenLineForTest(7, "Salt  3000  ppm");
+	CompleteScreen(device);
+
+	BOOST_CHECK_CLOSE(data_hub->SaltLevel().value(), 3000.0, 0.01);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_Service_SetsServiceMode)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	// The Service page is detected by line 3 "Service Mode".
+	device.RenderScreenLineForTest(3, "Service Mode");
+	CompleteScreen(device);
+
+	BOOST_CHECK(data_hub->Mode == Kernel::EquipmentMode::Service);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_TimeOut_SetsTimeOutMode)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	// The TimeOut page is detected by line 3 "Timeout Mode".
+	device.RenderScreenLineForTest(3, "Timeout Mode");
+	CompleteScreen(device);
+
+	BOOST_CHECK(data_hub->Mode == Kernel::EquipmentMode::TimeOut);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/devices/test_devices_onetouch.cpp
+++ b/test/unit/devices/test_devices_onetouch.cpp
@@ -739,4 +739,89 @@ BOOST_AUTO_TEST_CASE(TestPageProcessor_TimeOut_SetsTimeOutMode)
 	BOOST_CHECK(data_hub->Mode == Kernel::EquipmentMode::TimeOut);
 }
 
+// =============================================================================
+// Configuration / setpoint page processors (decode a scraped menu page into the
+// DataHub model). Same CompleteScreen() mechanism as the Equipment Status tests.
+// =============================================================================
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_SetTemperature_ParsesHeatSetpoints)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "    Set Temp");          // detector
+	device.RenderScreenLineForTest(2, "Pool Heat   90`F");
+	device.RenderScreenLineForTest(3, "Spa Heat   102`F");
+	CompleteScreen(device);
+
+	auto pool = data_hub->PoolTempSetpoint();
+	auto spa = data_hub->SpaTempSetpoint();
+	BOOST_REQUIRE(pool.has_value());
+	BOOST_REQUIRE(spa.has_value());
+	BOOST_CHECK_CLOSE(pool.value().InFahrenheit().value(), 90.0, 0.5);
+	BOOST_CHECK_CLOSE(spa.value().InFahrenheit().value(), 102.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_SetAquapure_ScrapesChlorinatorSetpoints)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "  Set AQUAPURE");        // detector
+	device.RenderScreenLineForTest(3, "Set Pool to:  45%");
+	device.RenderScreenLineForTest(4, "Set Spa to:   50%");
+	CompleteScreen(device);
+
+	auto chlorinators = data_hub->Chlorinators();
+	BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+	auto pool_sp = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::ChlorinatorPoolSetpointTrait{});
+	auto spa_sp = chlorinators.front()->AuxillaryTraits.TryGet(Kernel::AuxillaryTraitsTypes::ChlorinatorSpaSetpointTrait{});
+	BOOST_REQUIRE(pool_sp.has_value());
+	BOOST_REQUIRE(spa_sp.has_value());
+	BOOST_CHECK_EQUAL(static_cast<int>(pool_sp.value()), 45);
+	BOOST_CHECK_EQUAL(static_cast<int>(spa_sp.value()), 50);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_Version_PopulatesVersionsAndBodies)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(4, "B0029221");
+	device.RenderScreenLineForTest(5, "RS-8 Combo");
+	device.RenderScreenLineForTest(7, "REV T.0.1");           // detector "REV "
+	CompleteScreen(device);
+
+	BOOST_CHECK_EQUAL(data_hub->EquipmentVersions.Get("Model"), "B0029221");
+	BOOST_CHECK_EQUAL(data_hub->EquipmentVersions.Get("Type"), "RS-8 Combo");
+	BOOST_CHECK_EQUAL(data_hub->EquipmentVersions.Get("Revision"), "REV T.0.1");
+	// A decoded panel type resolves a pool configuration, which seeds the bodies.
+	BOOST_CHECK(data_hub->PoolConfiguration != Kernel::PoolConfigurations::Unknown);
+	BOOST_CHECK(!data_hub->Bodies().empty());
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_FreezeProtect_ParsesThreshold)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, " Freeze Protect");      // detector
+	device.RenderScreenLineForTest(3, "Temp        38`F");
+	CompleteScreen(device);
+
+	auto threshold = data_hub->FreezeProtectPoint();
+	BOOST_REQUIRE(threshold.has_value());
+	BOOST_CHECK_CLOSE(threshold.value().InFahrenheit().value(), 38.0, 0.5);
+}
+
+BOOST_AUTO_TEST_CASE(TestPageProcessor_EquipmentOnOff_CreatesAuxDevices)
+{
+	FaultableOneTouchDevice device(device_type, *this, true);
+
+	device.RenderScreenLineForTest(0, "Filter Pump  ***");     // detector "Filter Pump"
+	device.RenderScreenLineForTest(5, "Aux1         OFF");
+	device.RenderScreenLineForTest(6, "Aux2         OFF");
+	device.RenderScreenLineForTest(7, "Aux3          ON");
+	CompleteScreen(device);
+
+	// Each aux row is decoded into an auxillary device on the DataHub.
+	BOOST_CHECK_GE(data_hub->Auxillaries().size(), 3u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Promotes `develop` to `main` to refresh the SonarCloud `main` analysis with the latest `new_coverage` test batches. No production code changes — all four merged PRs are test-only.

Carries:
- **#65** — iaq MainStatus + AuxStatus DataHub decoding
- **#66** — onetouch Equipment Status processors + mode pages
- **#67** — onetouch setpoint/config page processors
- **#68** — certificate `LoadSslCertificates` resolution paths

## Why

SonarCloud only analyzes the `main` branch; these test batches have landed on `develop` but the gate metric (`new_coverage`) only refreshes after a `main` scan. Promoting triggers that rescan so we can measure the actual coverage movement from Batches 6-9.

## Verification

Each PR merged via its own green CI (Branch Name + CI Status required checks). This is a promotion of already-reviewed, already-green commits.