### PR TITLE
test(certificates): cover the read-only-install cert fallback path

### DIFF
--- a/src/core/certificates/certificate_management.cpp
+++ b/src/core/certificates/certificate_management.cpp
@@ -186,6 +186,42 @@ namespace AqualinkAutomate::Certificates
 		return true;
 	}
 
+	namespace Detail
+	{
+
+		std::optional<Options::Web::SslCertificate> GenerateOrReuseInDirectories(const std::vector<fs::path>& candidate_dirs)
+		{
+			std::error_code ec;
+
+			for (const auto& dir : candidate_dirs)
+			{
+				if (!DirectoryIsWritable(dir))
+				{
+					continue;
+				}
+
+				const fs::path cert_out = dir / "cert.pem";
+				const fs::path key_out = dir / "key.pem";
+
+				// Reuse an already-generated pair in a fallback directory across restarts.
+				if (fs::exists(cert_out, ec) && fs::exists(key_out, ec))
+				{
+					LogInfo(Channel::Certificates, std::format("Reusing previously-generated self-signed certificate at {}", cert_out.string()));
+					return Options::Web::SslCertificate{ cert_out, key_out };
+				}
+
+				if (GenerateSelfSignedCertificate(cert_out, key_out))
+				{
+					return Options::Web::SslCertificate{ cert_out, key_out };
+				}
+			}
+
+			return std::nullopt;
+		}
+
+	}
+	// namespace Detail
+
 	std::optional<Options::Web::SslCertificate> EnsureSelfSignedMaterial(const Options::Web::SslCertificate& configured)
 	{
 		std::error_code ec;
@@ -215,30 +251,7 @@ namespace AqualinkAutomate::Certificates
 		std::error_code tmp_ec;
 		candidate_dirs.push_back(fs::temp_directory_path(tmp_ec) / "aqualink-automate" / "ssl");
 
-		for (const auto& dir : candidate_dirs)
-		{
-			if (!DirectoryIsWritable(dir))
-			{
-				continue;
-			}
-
-			const fs::path cert_out = dir / "cert.pem";
-			const fs::path key_out = dir / "key.pem";
-
-			// Reuse an already-generated pair in a fallback directory across restarts.
-			if (fs::exists(cert_out, ec) && fs::exists(key_out, ec))
-			{
-				LogInfo(Channel::Certificates, std::format("Reusing previously-generated self-signed certificate at {}", cert_out.string()));
-				return Options::Web::SslCertificate{ cert_out, key_out };
-			}
-
-			if (GenerateSelfSignedCertificate(cert_out, key_out))
-			{
-				return Options::Web::SslCertificate{ cert_out, key_out };
-			}
-		}
-
-		return std::nullopt;
+		return Detail::GenerateOrReuseInDirectories(candidate_dirs);
 	}
 
 	void LoadSslCertificates(const AqualinkAutomate::Options::Web::WebSettings& cfg, boost::asio::ssl::context& ctx)

--- a/src/core/certificates/certificate_management.h
+++ b/src/core/certificates/certificate_management.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <optional>
+#include <vector>
 
 #include <boost/asio/ssl/context.hpp>
 
@@ -28,6 +29,24 @@ namespace AqualinkAutomate::Certificates
 	// falling back to a writable runtime directory when that is read-only. Returns
 	// the cert+key paths actually in use, or std::nullopt if none could be produced.
 	std::optional<AqualinkAutomate::Options::Web::SslCertificate> EnsureSelfSignedMaterial(const AqualinkAutomate::Options::Web::SslCertificate& configured);
+
+	namespace Detail
+	{
+
+		// Walk 'candidate_dirs' in order and, in the FIRST directory that can be
+		// created and written to, either reuse an existing cert.pem/key.pem pair or
+		// generate a fresh self-signed pair there. Returns the cert+key paths in use,
+		// or std::nullopt if no candidate directory was usable.
+		//
+		// This is the read-only-install fallback that backs EnsureSelfSignedMaterial;
+		// it is exposed here (rather than kept in the .cpp's unnamed namespace) so the
+		// security-critical generate/reuse/skip-unwritable path can be unit-tested
+		// with controlled directories, without depending on the built-in default cert
+		// paths being writable.
+		std::optional<AqualinkAutomate::Options::Web::SslCertificate> GenerateOrReuseInDirectories(const std::vector<std::filesystem::path>& candidate_dirs);
+
+	}
+	// namespace Detail
 
 }
 // namespace AqualinkAutomate::Certificates

--- a/test/unit/certificates/test_certificate_generation.cpp
+++ b/test/unit/certificates/test_certificate_generation.cpp
@@ -107,4 +107,135 @@ BOOST_AUTO_TEST_CASE(EnsureSelfSignedMaterial_RefusesToGenerateForOperatorSpecif
 	BOOST_CHECK(!resolved.has_value());
 }
 
+//=============================================================================
+// Read-only-install fallback (Detail::GenerateOrReuseInDirectories).
+//
+// This is the security-critical branch that backs EnsureSelfSignedMaterial when
+// the built-in default cert/key paths are not writable (the common packaged
+// case): it walks candidate directories in order and, in the first writable
+// one, reuses or freshly generates a per-install self-signed pair. Testing the
+// helper directly lets us drive that path with controlled directories instead
+// of depending on the real (install-tree) default paths being writable.
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(Fallback_GeneratesFreshPairInFirstWritableDirectory)
+{
+	const fs::path base = fs::temp_directory_path() / "aqualink_certgen_fallback_gen";
+	std::error_code rm;
+	fs::remove_all(base, rm);
+
+	const fs::path secure_dir = base / "ssl";
+
+	const auto resolved = Certificates::Detail::GenerateOrReuseInDirectories({ secure_dir });
+	BOOST_REQUIRE(resolved.has_value());
+
+	// Material must land in the chosen secure directory under the fixed names.
+	BOOST_CHECK(resolved->certificate == secure_dir / "cert.pem");
+	BOOST_CHECK(resolved->private_key == secure_dir / "key.pem");
+	BOOST_REQUIRE(fs::exists(resolved->certificate));
+	BOOST_REQUIRE(fs::exists(resolved->private_key));
+
+	// The freshly generated material must be loadable by the TLS stack.
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+	boost::system::error_code ec;
+	ctx.use_certificate_file(resolved->certificate.string(), boost::asio::ssl::context::pem, ec);
+	BOOST_CHECK_MESSAGE(!ec, "generated certificate did not load: " << ec.message());
+	ctx.use_private_key_file(resolved->private_key.string(), boost::asio::ssl::context::pem, ec);
+	BOOST_CHECK_MESSAGE(!ec, "generated private key did not load: " << ec.message());
+
+#ifndef _WIN32
+	// The private key must be owner-only (0600) on disk.
+	const auto perms = fs::status(resolved->private_key).permissions();
+	BOOST_CHECK((perms & fs::perms::group_read) == fs::perms::none);
+	BOOST_CHECK((perms & fs::perms::others_read) == fs::perms::none);
+	BOOST_CHECK((perms & fs::perms::others_write) == fs::perms::none);
+#endif
+
+	fs::remove_all(base, rm);
+}
+
+BOOST_AUTO_TEST_CASE(Fallback_ReusesExistingPairAcrossCalls)
+{
+	const fs::path base = fs::temp_directory_path() / "aqualink_certgen_fallback_reuse";
+	std::error_code rm;
+	fs::remove_all(base, rm);
+
+	const fs::path secure_dir = base / "ssl";
+
+	// First call generates the pair.
+	const auto first = Certificates::Detail::GenerateOrReuseInDirectories({ secure_dir });
+	BOOST_REQUIRE(first.has_value());
+	const std::string key_after_first = ReadFile(first->private_key);
+	const std::string cert_after_first = ReadFile(first->certificate);
+	BOOST_REQUIRE(!key_after_first.empty());
+
+	// Second call must REUSE the existing pair -- same paths, byte-identical
+	// material (i.e. it must not regenerate and clobber the persisted key).
+	const auto second = Certificates::Detail::GenerateOrReuseInDirectories({ secure_dir });
+	BOOST_REQUIRE(second.has_value());
+	BOOST_CHECK(second->certificate == first->certificate);
+	BOOST_CHECK(second->private_key == first->private_key);
+	BOOST_CHECK(ReadFile(second->private_key) == key_after_first);
+	BOOST_CHECK(ReadFile(second->certificate) == cert_after_first);
+
+	fs::remove_all(base, rm);
+}
+
+BOOST_AUTO_TEST_CASE(Fallback_SkipsUnwritableCandidateAndUsesNext)
+{
+	const fs::path base = fs::temp_directory_path() / "aqualink_certgen_fallback_skip";
+	std::error_code rm;
+	fs::remove_all(base, rm);
+	fs::create_directories(base, rm);
+
+	// A candidate that cannot be used as a directory: a path that already exists
+	// as a regular file. create_directories() fails on it, so the fallback must
+	// skip it and move on to the next candidate. (Cross-platform: no reliance on
+	// POSIX-only read-only-directory semantics.)
+	const fs::path blocked_candidate = base / "not-a-directory";
+	{
+		std::ofstream f(blocked_candidate);
+		f << "occupied";
+	}
+	BOOST_REQUIRE(fs::is_regular_file(blocked_candidate));
+
+	const fs::path writable_dir = base / "ssl";
+
+	const auto resolved = Certificates::Detail::GenerateOrReuseInDirectories({ blocked_candidate, writable_dir });
+	BOOST_REQUIRE(resolved.has_value());
+
+	// It must have fallen through to the second (writable) candidate.
+	BOOST_CHECK(resolved->certificate == writable_dir / "cert.pem");
+	BOOST_CHECK(resolved->private_key == writable_dir / "key.pem");
+	BOOST_CHECK(fs::exists(resolved->certificate));
+	BOOST_CHECK(fs::exists(resolved->private_key));
+
+	fs::remove_all(base, rm);
+}
+
+BOOST_AUTO_TEST_CASE(Fallback_ReturnsNulloptWhenNoCandidateIsWritable)
+{
+	const fs::path base = fs::temp_directory_path() / "aqualink_certgen_fallback_none";
+	std::error_code rm;
+	fs::remove_all(base, rm);
+	fs::create_directories(base, rm);
+
+	// Every candidate is an existing regular file, so none can be created/written
+	// as a directory. With no usable candidate the fallback yields nullopt (the
+	// caller then surfaces the "could not be generated" error).
+	const fs::path blocked_a = base / "blocked-a";
+	const fs::path blocked_b = base / "blocked-b";
+	for (const auto& p : { blocked_a, blocked_b })
+	{
+		std::ofstream f(p);
+		f << "occupied";
+	}
+
+	// An empty path is also not writable and must be tolerated/skipped.
+	const auto resolved = Certificates::Detail::GenerateOrReuseInDirectories({ fs::path{}, blocked_a, blocked_b });
+	BOOST_CHECK(!resolved.has_value());
+
+	fs::remove_all(base, rm);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

Adds genuine unit-test coverage for the **security-critical read-only-install fallback** in `Certificates::EnsureSelfSignedMaterial` (`src/core/certificates/certificate_management.cpp`). That branch — which generates or reuses a per-install self-signed TLS pair in a writable runtime directory when the built-in default cert/key paths are read-only (the common packaged case) — previously had **no coverage**, which dropped SonarCloud `new_coverage` well below the 80% gate on the original security PR.

## How

- Extracts the generate-or-reuse fallback loop into a small, testable helper `Certificates::Detail::GenerateOrReuseInDirectories(candidate_dirs)`. `EnsureSelfSignedMaterial` now builds the candidate list (configured dir, then a per-user runtime dir) and delegates to it. **Public API and behaviour are unchanged.**
- Adds four `Boost.Test` cases in `test/unit/certificates/test_certificate_generation.cpp` that drive the helper directly with controlled directories, instead of depending on the real install-tree default paths being writable:
  - **generate** — a fresh, TLS-loadable pair lands in the first writable candidate (owner-only `0600` key asserted on POSIX);
  - **reuse** — a second call returns the same paths with byte-identical material (no clobber of the persisted key);
  - **skip-unwritable** — a candidate that can't be used as a directory is skipped and the next candidate is used;
  - **exhausted** — `std::nullopt` when no candidate directory is usable (the caller then surfaces the "could not be generated" error).

The unwritable-candidate cases use an existing regular file as the candidate path (cross-platform: `create_directories` fails on it), avoiding POSIX-only read-only-directory semantics.

## Verification

- `testaqualink-automate --run_test=TestSuite_CertificateGeneration` → 7/7 pass (3 existing + 4 new).
- Full suite: **2060/2060 test cases, no errors**.

No behaviour change, so no docs/swagger updates are needed. Can ride into a future release; not blocking anything.
