### PR TITLE
ci(codescanning): add CodeQL JavaScript/TypeScript analysis

### DIFF
--- a/.github/codeql/codeql-config-js.yml
+++ b/.github/codeql/codeql-config-js.yml
@@ -1,0 +1,23 @@
+# CodeQL configuration for the JavaScript/TypeScript analysis (used by the
+# CodeScanning_CodeQL_JS job in .github/workflows/automated-codescanning.yml).
+#
+# Scope the scan to FIRST-PARTY source only:
+#   * assets/web/scripts -- the Alpine.js web UI (stores, views, components)
+#   * assets/web/sw.js    -- the service worker
+#   * matter-bridge/src   -- the TypeScript Matter sidecar
+#
+# Everything else under assets/web is either vendored third-party code we cannot
+# action (assets/web/vendor/*.min.js: Alpine, Chart.js, QRCode, ...), pure
+# translation data (assets/web/i18n/*.js), or generated output. Scanning those only
+# produces un-actionable noise, so they are left out of `paths`. The paths-ignore
+# entries are belt-and-braces against any stray minified/vendored file.
+name: "CodeQL config (JavaScript/TypeScript)"
+
+paths:
+  - assets/web/scripts
+  - assets/web/sw.js
+  - matter-bridge/src
+
+paths-ignore:
+  - "**/*.min.js"
+  - "**/node_modules"

--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -167,6 +167,52 @@ jobs:
         retention-days: 1
 
   ##
+  ## CODEQL JOB (JAVASCRIPT / TYPESCRIPT)
+  ##
+  ## The CodeQL job above only scans compiled C/C++. The Alpine.js web UI
+  ## (assets/web/scripts) and the TypeScript Matter sidecar (matter-bridge/src) are
+  ## just as attacker-reachable -- the UI renders live device + server data into the
+  ## DOM; the sidecar bridges to a Matter fabric -- yet were previously unscanned.
+  ## JS/TS needs NO compilation (build-mode: none), so this is a fast, GitHub-hosted
+  ## job: deliberately NOT on the self-hosted C++ fleet and carrying none of the
+  ## vcpkg/CMake build the c-cpp job needs. A config file scopes analysis to
+  ## first-party source (vendored/minified libraries and generated output excluded).
+  ##
+
+  CodeScanning_CodeQL_JS:
+    # Same gating as the c-cpp job: skip a develop->main promotion PR (already
+    # scanned on develop entry), and skip fork PRs -- a fork PR runs with a read-only
+    # token, so the SARIF upload to the Security tab would fail regardless.
+    if: >-
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'pull_request' ||
+       github.head_ref != 'develop' ||
+       github.base_ref != 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    # No submodules: JS/TS analysis needs none of the C++ deps under deps/.
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      with:
+        languages: javascript-typescript
+        build-mode: none
+        config-file: ./.github/codeql/codeql-config-js.yml
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      with:
+        category: "/language:javascript-typescript"
+
+  ##
   ## E2E COVERAGE JOB
   ##
   ## SonarCloud's new-code coverage previously read only the unit/integration

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -11,7 +11,7 @@ The pipeline is five workflow files plus two composite actions, all under `.gith
 | `.github/workflows/ci.yml` | Workflow | Build, test, e2e, and Docker verification on every push and PR. |
 | `.github/workflows/_build.yml` | Reusable workflow (`workflow_call`) | The shared configure/build/test/package matrix. Called by both `ci.yml` and `release.yml`. |
 | `.github/workflows/release.yml` | Workflow | Build packages, publish the Docker image, and create the GitHub release for a `v*` tag. |
-| `.github/workflows/automated-codescanning.yml` | Workflow | CodeQL, SonarCloud, and MSVC static analysis on PRs and a weekly cron. |
+| `.github/workflows/automated-codescanning.yml` | Workflow | CodeQL (C/C++ and JavaScript/TypeScript), SonarCloud, and MSVC static analysis on PRs and a weekly cron. |
 | `.github/workflows/cleanup-branch-caches.yml` | Workflow | Delete a PR's branch caches when it closes. |
 | `.github/actions/setup-cpp-toolchain` | Composite action | Install the platform-appropriate compiler and build tools. |
 | `.github/actions/setup-vcpkg-cache` | Composite action | Configure and restore the OS-keyed vcpkg binary cache. |
@@ -199,6 +199,7 @@ There is **no `push` trigger.** Scanning happens on PRs into `develop` or `main`
 | Job | Runs on | Scanner |
 |-----|---------|---------|
 | `CodeScanning_CodeQL` | Linux | CodeQL (`c-cpp`). Runs its own full build, filters the SARIF to `src/**`, and uploads to the Security tab. |
+| `CodeScanning_CodeQL_JS` | Linux (GitHub-hosted) | CodeQL (`javascript-typescript`, `build-mode: none`) for the Alpine.js web UI (`assets/web/scripts`, `sw.js`) and the TypeScript Matter sidecar (`matter-bridge/src`). No compile, so it runs on `ubuntu-latest` (not the self-hosted C++ fleet); `.github/codeql/codeql-config-js.yml` scopes it to first-party source (vendored/minified libraries and `i18n/` data excluded). |
 | `CodeScanning_E2ECoverage` | Linux | Builds a gcov-instrumented `aqualink-automate` (`config-linux-gcc-coverage`), runs the four Playwright modes against it, and `gcovr`s the `.gcda` into a SonarQube coverage report (`coverage-e2e.xml`) uploaded as the `e2e-coverage-xml` artifact. |
 | `CodeScanning_SonarCloud` | Linux | SonarCloud via build-wrapper over a coverage build (`config-linux-gcc-coverage`, `-DUSE_SONARQUBE=ON`). Runs its own full compile, produces the unit/integration coverage report, downloads the e2e report, and scans with **both** (`sonar.coverageReportPaths` comma-separated; Sonar merges line coverage). |
 | `CodeScanning_MSVCCodeAnalysis` | Windows | MSVC code analysis (`NativeRecommendedRules.ruleset`) over the `config-windows-msvc` build; uploads SARIF. |


### PR DESCRIPTION
## What

Adds a **CodeQL JavaScript/TypeScript** analysis job to `automated-codescanning.yml`. Our CodeQL scanning previously covered only compiled C/C++, leaving the entire frontend and Node sidecar unscanned:

- **Alpine.js web UI** — `assets/web/scripts/**` (stores, views, components) + `assets/web/sw.js`. This renders live device- and server-originated data into the DOM, so it's the natural home for the DOM-XSS class of bug.
- **TypeScript Matter sidecar** — `matter-bridge/src/**`, which bridges the app to a Matter fabric.

## How

- New job `CodeScanning_CodeQL_JS`:
  - `languages: javascript-typescript`, `build-mode: none` — **no compilation**, so it runs on `ubuntu-latest` (GitHub-hosted, free for public repos) rather than the self-hosted C++ fleet, and carries none of the vcpkg/CMake build the `c-cpp` job needs.
  - `config-file: .github/codeql/codeql-config-js.yml` scopes analysis to first-party source only; vendored/minified libraries (`assets/web/vendor/*.min.js`), `i18n/` translation data, and generated output are excluded as un-actionable noise.
  - Same promotion-PR skip and fork-PR gating as the existing `c-cpp` job.
- Docs: `docs/ci-cd.md` workflow inventory + jobs table updated.

## Cost

Zero new tooling and no paid services — reuses the CodeQL action already in the workflow; JS/TS analysis needs no build.

## Follow-up

This is PR 1 of 2. A second PR adds container-image (Trivy), dependency (OSV-Scanner, covering the vcpkg C++ supply chain), and supply-chain-posture (OpenSSF Scorecard) scanning as standalone workflows.
