### PR TITLE
ci: add container (Trivy), dependency (OSV), and OpenSSF Scorecard scanning

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,60 @@
+name: OSV-Scanner
+
+# OSV-Scanner checks our declared dependencies against the OSV vulnerability
+# database. It is the ONLY scanner that understands the vcpkg C++ manifest
+# (vcpkg.json): Dependabot has no vcpkg ecosystem, so the entire C++ dependency
+# supply chain (Boost, OpenSSL, nlohmann, ...) was previously unscanned for CVEs.
+# It also cross-checks the npm lockfiles (root Playwright harness + matter-bridge);
+# Dependabot already tracks those, but OSV flags a fresh disclosure faster.
+#
+# Runs on GitHub-hosted runners (free for public repos) via the upstream reusable
+# workflow, which scans and uploads SARIF to Security > Code scanning itself.
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+      - '**/package-lock.json'
+      - '.github/workflows/osv-scanner.yml'
+  pull_request:
+    branches: [ "develop", "main" ]
+    paths:
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+      - '**/package-lock.json'
+      - '.github/workflows/osv-scanner.yml'
+  schedule:
+    - cron: '37 22 * * 2'   # weekly, Tuesday 22:37 UTC (offset from the codescanning cron)
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  OSV_Scan:
+    # Skip a develop->main promotion PR (already scanned on develop entry), and skip
+    # fork PRs -- a fork PR runs with a read-only token, so the SARIF upload would
+    # fail regardless.
+    if: >-
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'pull_request' ||
+       github.head_ref != 'develop' ||
+       github.base_ref != 'main')
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      # Recursively scan the working tree for supported manifests/lockfiles: this
+      # finds vcpkg.json plus the two npm lockfiles (root + matter-bridge).
+      # Submodules stay unchecked-out (default), so vcpkg's own bundled ports under
+      # deps/ are not scanned -- only our declared manifest is.
+      scan-args: |-
+        -r
+        ./
+      # A newly-disclosed CVE in an already-merged dependency must not block
+      # unrelated PRs; it still surfaces in Security > Code scanning.
+      fail-on-vuln: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: OpenSSF Scorecard
+
+# Scorecard grades the repository's SUPPLY-CHAIN posture -- GitHub Actions pinning
+# (every `uses:` here is pinned to a 40-char SHA), branch protection, token
+# permissions, dangerous-workflow patterns, dependency-update tooling, and more --
+# and publishes the result to Security > Code scanning. It complements the code
+# scanners: they inspect what the code DOES, Scorecard inspects how the project is
+# BUILT and RELEASED.
+#
+# Runs on GitHub-hosted `ubuntu-latest` (free for public repos). It does NOT run on
+# pull_request: the checks are repository-level and several need the elevated token
+# a PR does not grant.
+
+on:
+  # Re-grade when a branch protection rule changes (a Scorecard signal).
+  branch_protection_rule:
+  schedule:
+    - cron: '27 22 * * 2'   # weekly, Tuesday 22:27 UTC (offset from the codescanning cron)
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Least-privilege by default; the job elevates only what it needs.
+permissions: read-all
+
+jobs:
+  Scorecard_Analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write -> upload SARIF to the Security tab.
+      # id-token: write        -> OIDC token so publish_results can attest to the
+      #                           public OpenSSF Scorecard API (drives the badge).
+      security-events: write
+      id-token: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Run Scorecard analysis
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      with:
+        results_file: results.sarif
+        results_format: sarif
+        # Publish to the public OpenSSF Scorecard API (the repo is public). This
+        # feeds the Scorecard badge and the cross-project dashboard.
+        publish_results: true
+
+    - name: Upload Scorecard SARIF
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      with:
+        sarif_file: results.sarif
+        category: scorecard

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,94 @@
+name: Container Image Scanning
+
+# Trivy scans the RUNTIME CONTAINER for known-vulnerable OS packages and Node
+# dependencies -- the one supply-chain surface nothing else covers:
+#   * CodeQL / SonarCloud / MSVC   scan our own C++ / JS source.
+#   * Dependabot                    tracks the GitHub Actions + npm manifests.
+#   * OSV-Scanner (osv-scanner.yml) tracks the vcpkg C++ libraries.
+# But the shipped Docker image ALSO layers an Ubuntu base + a NodeSource Node
+# runtime + the Matter sidecar's node_modules, and CVEs in THOSE were invisible.
+#
+# The job builds only the `runtime-base` stage (Ubuntu + Node + the Matter sidecar)
+# -- NOT the app's `ci` stage -- so there is no expensive C++ compile: runtime-base
+# is exactly the OS/Node dependency surface Trivy understands. The app's own vcpkg
+# libraries carry no package metadata for Trivy to match and are covered by
+# OSV-Scanner instead, so scanning runtime-base loses nothing.
+#
+# Runs on GitHub-hosted `ubuntu-latest` (free for public repos): no self-hosted
+# runner needed, and findings go to Security > Code scanning (they never fail a PR).
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-entrypoint.sh'
+      - 'matter-bridge/**'
+      - '.github/workflows/trivy.yml'
+  pull_request:
+    branches: [ "develop", "main" ]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-entrypoint.sh'
+      - 'matter-bridge/**'
+      - '.github/workflows/trivy.yml'
+  schedule:
+    - cron: '17 22 * * 2'   # weekly, Tuesday 22:17 UTC (offset from the codescanning cron)
+  workflow_dispatch:
+
+concurrency:
+  group: trivy-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  Trivy_Image:
+    # Skip a develop->main promotion PR (the image was already scanned on develop
+    # entry), and skip fork PRs -- a fork PR runs with a read-only token, so the
+    # SARIF upload to the Security tab would fail regardless.
+    if: >-
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'pull_request' ||
+       github.head_ref != 'develop' ||
+       github.base_ref != 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    # Build ONLY the runtime-base stage: Ubuntu + NodeSource Node + the Matter
+    # sidecar (matter-builder is a build dependency of runtime-base). This does NOT
+    # build the `ci` stage, so the C++ toolchain/vcpkg compile is skipped. VERSION is
+    # not needed by runtime-base, so no --build-arg is required.
+    - name: Build runtime-base image
+      run: docker build --target runtime-base -t aqualink-automate:scan .
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: aqualink-automate:scan
+        format: sarif
+        output: trivy-results.sarif
+        # Only fixable HIGH/CRITICAL reach the Security tab, keeping it actionable
+        # (ignore-unfixed drops base-image CVEs with no upstream patch yet).
+        severity: CRITICAL,HIGH
+        ignore-unfixed: true
+        limit-severities-for-sarif: true
+
+    # Upload whatever Trivy produced. The scan step does not fail the job on findings
+    # (default exit-code 0), so this always has a SARIF to publish.
+    - name: Upload Trivy SARIF
+      if: ${{ !cancelled() }}
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      with:
+        sarif_file: trivy-results.sarif
+        category: trivy-image

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,7 +4,7 @@
 
 ## Workflow set
 
-The pipeline is five workflow files plus two composite actions, all under `.github/`.
+The pipeline is eight workflow files plus two composite actions, all under `.github/`.
 
 | File | Kind | Purpose |
 |------|------|---------|
@@ -13,6 +13,9 @@ The pipeline is five workflow files plus two composite actions, all under `.gith
 | `.github/workflows/release.yml` | Workflow | Build packages, publish the Docker image, and create the GitHub release for a `v*` tag. |
 | `.github/workflows/automated-codescanning.yml` | Workflow | CodeQL, SonarCloud, and MSVC static analysis on PRs and a weekly cron. |
 | `.github/workflows/cleanup-branch-caches.yml` | Workflow | Delete a PR's branch caches when it closes. |
+| `.github/workflows/trivy.yml` | Workflow | Trivy scan of the runtime container image (OS packages + Node deps) → Security tab. |
+| `.github/workflows/osv-scanner.yml` | Workflow | OSV-Scanner CVE check of declared dependencies, incl. the vcpkg C++ manifest → Security tab. |
+| `.github/workflows/scorecard.yml` | Workflow | OpenSSF Scorecard supply-chain posture grade → Security tab. |
 | `.github/actions/setup-cpp-toolchain` | Composite action | Install the platform-appropriate compiler and build tools. |
 | `.github/actions/setup-vcpkg-cache` | Composite action | Configure and restore the OS-keyed vcpkg binary cache. |
 
@@ -206,6 +209,20 @@ There is **no `push` trigger.** Scanning happens on PRs into `develop` or `main`
 Each job has the same skip condition: it does not run for a `develop` -> `main` promotion PR, because that code was already scanned when it entered `develop`. Re-scanning the promotion is pure duplication.
 
 **Coverage = unit + e2e.** The SonarCloud new-code coverage gate reflects what *both* test layers exercise. The unit/integration binary's coverage alone misses every line only the running app reaches (HTTP routes, WebSocket, MQTT, bootstrap), which read as uncovered and depressed the gate. `CodeScanning_E2ECoverage` instruments the app, drives the Playwright suite against it (the app exits cleanly on Playwright's `SIGTERM` — see `gracefulShutdown` in `playwright.config.ts` — so gcov flushes `.gcda`), and emits a second report. `CodeScanning_SonarCloud` `needs:` it and merges the two; if the e2e job fails, the scan still runs with unit-only coverage (it never drops the whole gate).
+
+## Supply-chain scanning (trivy.yml, osv-scanner.yml, scorecard.yml)
+
+Three lightweight workflows cover the supply-chain surfaces the compile-heavy `automated-codescanning.yml` does not. Unlike the code scanners, they run on GitHub-hosted `ubuntu-latest` (free for public repos, no self-hosted runner), need no C++ build, and publish to **Security > Code scanning**. None fails a PR — a finding surfaces in the Security tab rather than blocking the merge.
+
+| Workflow | Scanner | Covers | Triggers |
+|----------|---------|--------|----------|
+| `trivy.yml` | [Trivy](https://github.com/aquasecurity/trivy-action) | The runtime **container image**: Ubuntu base packages + NodeSource Node + the Matter sidecar's `node_modules`. Builds only the `runtime-base` Docker stage (no C++ `ci` compile), which is exactly that OS/Node surface. Reports fixable HIGH/CRITICAL. | PR/push touching `Dockerfile`, `matter-bridge/**`, etc.; weekly cron; dispatch |
+| `osv-scanner.yml` | [OSV-Scanner](https://github.com/google/osv-scanner-action) | Declared **dependencies** vs. the OSV database. The only scanner that reads the **vcpkg C++ manifest** (`vcpkg.json`) — Dependabot has no vcpkg ecosystem — plus the npm lockfiles. Uses the upstream reusable workflow, which uploads its own SARIF. | PR/push touching `vcpkg.json`, `**/package-lock.json`, etc.; weekly cron; dispatch |
+| `scorecard.yml` | [OpenSSF Scorecard](https://github.com/ossf/scorecard-action) | **Supply-chain posture**: Action SHA-pinning, branch protection, token permissions, dangerous-workflow patterns, dependency tooling. `publish_results: true` feeds the public Scorecard badge/API. | `branch_protection_rule`; push to `main`; weekly cron; dispatch |
+
+Division of labour with the existing tooling: **CodeQL / SonarCloud / MSVC** scan first-party source; **Dependabot** *updates* the Actions + npm manifests (and raises its own vulnerability alerts for them); **OSV-Scanner** closes the vcpkg gap Dependabot cannot see; **Trivy** covers the image layers no source or manifest scanner reaches. The vcpkg-built C++ libraries inside the image carry no package metadata for Trivy to match, so OSV-Scanner (reading the manifest) is what covers them — the two do not overlap.
+
+The three PR-facing jobs (`trivy.yml`, `osv-scanner.yml`) share the code scanners' promotion-PR skip and fork-PR gating. `scorecard.yml` does not run on `pull_request` at all (its checks are repository-level and need a token a fork PR lacks). The weekly crons are staggered (22:17 / 22:27 / 22:37 UTC) so they do not all contend at once.
 
 ## cleanup-branch-caches.yml
 


### PR DESCRIPTION
## What

Adds three lightweight, free (GitHub-hosted) supply-chain scanning workflows that cover surfaces the existing compile-heavy `automated-codescanning.yml` (CodeQL/SonarCloud/MSVC) does not. All publish to **Security → Code scanning** and **none fails a PR**.

| Workflow | Scanner | Gap it closes |
|----------|---------|---------------|
| `trivy.yml` | Trivy | The shipped **container image** — Ubuntu base packages + NodeSource Node + the Matter sidecar's `node_modules`. Nothing scanned these before. |
| `osv-scanner.yml` | OSV-Scanner | The **vcpkg C++ dependency manifest** (`vcpkg.json`) — Dependabot has no vcpkg ecosystem, so the C++ supply chain had zero CVE scanning. Also cross-checks npm lockfiles. |
| `scorecard.yml` | OpenSSF Scorecard | **Supply-chain posture** — Action SHA-pinning, branch protection, token permissions, dangerous-workflow patterns. |

## How / design notes

- **Trivy** builds only the `runtime-base` Docker stage (Ubuntu + Node + sidecar) — **not** the app's `ci` stage — so there's no C++ compile. That stage *is* the OS/Node dependency surface Trivy understands. Reports fixable HIGH/CRITICAL only (`ignore-unfixed`, `limit-severities-for-sarif`).
- **OSV-Scanner** uses the upstream reusable workflow (uploads its own SARIF). Recursive scan finds `vcpkg.json` + both npm lockfiles; submodules stay unchecked-out so vcpkg's own bundled ports aren't scanned. `fail-on-vuln: false` so a fresh disclosure in a merged dep doesn't block unrelated PRs.
- **Scorecard** runs on push-to-`main` / weekly cron / `branch_protection_rule` — **not** on PRs (repo-level checks need a token a PR lacks). `publish_results: true` feeds the public badge/API.
- **Division of labour** (no overlap): OSV reads the manifest (covers the vcpkg C++ libs, which carry no package metadata for Trivy to match); Trivy covers the image layers no source/manifest scanner reaches; Dependabot still *updates* the Actions + npm manifests.
- `trivy` + `osv` jobs share the code scanners' promotion-PR skip and fork-PR gating. Weekly crons staggered (22:17 / 22:27 / 22:37 UTC).
- All three actions are SHA-pinned (Trivy `v0.36.0`, OSV `v2.3.8`, Scorecard `v2.4.3`) so Dependabot will keep them current, per the repo's pinning discipline.
- Docs: `docs/ci-cd.md` — inventory table + new "Supply-chain scanning" section.

## Cost

All GitHub-hosted `ubuntu-latest`, free for public repos. No paid services, no tokens/secrets required.

## Follow-up

This is PR 2 of 2. PR 1 (#86) adds CodeQL JavaScript/TypeScript analysis.
