### PR TITLE
docs(readme): add status, quality, and supply-chain badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Local control of Jandy/Zodiac (Fluidra) Aqualink RS pool controllers over RS-485 — Web UI, HTTP API, MQTT, and a Matter bridge, with no cloud service required.
 
+<!-- Build & code health -->
+[![CI](https://github.com/iainchesworth/aqualink-automate/actions/workflows/ci.yml/badge.svg)](https://github.com/iainchesworth/aqualink-automate/actions/workflows/ci.yml)
+[![Code Scanning](https://github.com/iainchesworth/aqualink-automate/actions/workflows/automated-codescanning.yml/badge.svg)](https://github.com/iainchesworth/aqualink-automate/actions/workflows/automated-codescanning.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=coverage)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+<!-- Supply chain & project meta -->
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/iainchesworth/aqualink-automate/badge)](https://scorecard.dev/viewer/?uri=github.com/iainchesworth/aqualink-automate)
+[![Latest release](https://img.shields.io/github/v/release/iainchesworth/aqualink-automate?include_prereleases&sort=semver)](https://github.com/iainchesworth/aqualink-automate/releases/latest)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE.txt)
+
 Aqualink Automate is a C++ service that talks to your pool equipment over an RS-485 serial link and exposes it on your own network. It reads status from the panel and lets you control it through a built-in Web UI, an HTTP and WebSocket API, MQTT (with Home Assistant discovery), and a Matter bridge for Apple Home, Google Home, Alexa, and SmartThings. Everything runs on hardware you own; nothing is sent to a vendor cloud.
 
 ![The Aqualink Automate web dashboard — temperatures, circulation, water chemistry, and equipment controls](docs/assets/aqualink-automate-dashboard.png)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,18 @@ Local control of Jandy/Zodiac (Fluidra) Aqualink RS and Pentair pool controllers
 over RS-485 — Web UI, HTTP API, MQTT, and a Matter bridge, with **no cloud
 service required**.
 
+<!-- Build & code health -->
+[![CI](https://github.com/iainchesworth/aqualink-automate/actions/workflows/ci.yml/badge.svg)](https://github.com/iainchesworth/aqualink-automate/actions/workflows/ci.yml)
+[![Code Scanning](https://github.com/iainchesworth/aqualink-automate/actions/workflows/automated-codescanning.yml/badge.svg)](https://github.com/iainchesworth/aqualink-automate/actions/workflows/automated-codescanning.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=coverage)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=iainchesworth_aqualink-automate&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=iainchesworth_aqualink-automate)
+<!-- Supply chain & project meta -->
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/iainchesworth/aqualink-automate/badge)](https://scorecard.dev/viewer/?uri=github.com/iainchesworth/aqualink-automate)
+[![Latest release](https://img.shields.io/github/v/release/iainchesworth/aqualink-automate?include_prereleases&sort=semver)](https://github.com/iainchesworth/aqualink-automate/releases/latest)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/iainchesworth/aqualink-automate/blob/main/LICENSE.txt)
+
 Aqualink Automate is a C++ service that talks to your pool equipment over an
 RS-485 serial link and exposes it on your own network. It reads status from the
 panel and lets you control it through a built-in Web UI, an HTTP and WebSocket


### PR DESCRIPTION
## What

Adds a status/quality/supply-chain **badge block** to the top of `README.md` (it previously had none), placed under the tagline:

**Build & code health**
- **CI** — `ci.yml` workflow status
- **Code Scanning** — `automated-codescanning.yml` status
- **Quality Gate**, **Coverage**, **Security Rating**, **Maintainability Rating** — SonarCloud (`iainchesworth_aqualink-automate`)

**Supply chain & project meta**
- **OpenSSF Scorecard**
- **Latest release** (shields.io, includes pre-releases)
- **License: GPL-3.0** → `LICENSE.txt`

## Notes

- The SonarCloud badge endpoints were verified live (HTTP 200, `image/svg+xml`), so those render immediately.
- The **OpenSSF Scorecard badge shows "no data" until [#87](https://github.com/iainchesworth/aqualink-automate/pull/87) merges and `scorecard.yml` runs on `main`** (Scorecard only publishes from the default branch). It lights up automatically after that first run — no README change needed.
- CI and Code Scanning badges track the default branch (`main`), where both workflows already exist.
