### PR TITLE
fix(sonar): reliability S1048, CI docs/fuzzing, 966 maintainability fixes

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -97,6 +97,19 @@ jobs:
         with:
           compiler: llvm
 
+      # aminya/setup-cpp installs clang from apt.llvm.org, which does NOT include the
+      # compiler-rt static runtimes. libFuzzer + the ASan build (SANITIZE_ADDRESS) link
+      # against libclang_rt.fuzzer.a / libclang_rt.asan*.a, so install the matching
+      # libclang-rt-<major>-dev package for whatever clang version was selected.
+      - name: Install LLVM compiler-rt runtimes (fuzzer + sanitizers)
+        if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}
+        shell: bash
+        run: |
+          ver="$(clang --version | sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p' | head -1)"
+          echo "Installing compiler-rt runtimes for clang major version ${ver}"
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq "libclang-rt-${ver}-dev"
+
       - uses: ./.github/actions/setup-vcpkg-cache
         if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}
         with:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -97,18 +97,28 @@ jobs:
         with:
           compiler: llvm
 
-      # aminya/setup-cpp installs clang from apt.llvm.org, which does NOT include the
-      # compiler-rt static runtimes. libFuzzer + the ASan build (SANITIZE_ADDRESS) link
-      # against libclang_rt.fuzzer.a / libclang_rt.asan*.a, so install the matching
-      # libclang-rt-<major>-dev package for whatever clang version was selected.
+      # libFuzzer + the ASan build (SANITIZE_ADDRESS) link against the compiler-rt static
+      # runtimes (libclang_rt.fuzzer.a / libclang_rt.asan*.a). Neither aminya/setup-cpp's
+      # apt.llvm.org clang (hosted) NOR the self-hosted runner image ships them, so install
+      # the matching libclang-rt-<major>-dev for the selected clang. Runs on EVERY Linux
+      # runner (the autotools step below likewise apt-installs unconditionally); if the
+      # package isn't already indexed, add the apt.llvm.org source for that version + codename.
       - name: Install LLVM compiler-rt runtimes (fuzzer + sanitizers)
-        if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           ver="$(clang --version | sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p' | head -1)"
           echo "Installing compiler-rt runtimes for clang major version ${ver}"
           sudo apt-get update -qq
-          sudo apt-get install -y -qq "libclang-rt-${ver}-dev"
+          if ! sudo apt-get install -y -qq "libclang-rt-${ver}-dev"; then
+            echo "libclang-rt-${ver}-dev not indexed; adding apt.llvm.org source"
+            . /etc/os-release
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+            echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${ver} main" | sudo tee "/etc/apt/sources.list.d/llvm-${ver}.list" >/dev/null
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq "libclang-rt-${ver}-dev"
+          fi
+          echo "compiler-rt libs:"; ls "/usr/lib/llvm-${ver}/lib/clang/${ver}/lib/"*/ 2>/dev/null | grep -i "fuzzer\|asan" || true
 
       - uses: ./.github/actions/setup-vcpkg-cache
         if: ${{ !contains(vars.RUNNER_LINUX, 'self-hosted') }}

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -8,7 +8,7 @@ describes the libFuzzer harnesses that exercise those decoders, how to build and
 run them, where the corpus lives, and the discipline for acting on a crash.
 
 This also satisfies the OpenSSF Scorecard **Fuzzing** check with a real signal
-rather than a posture tick: [`fuzzing.yml`](../.github/workflows/fuzzing.yml) runs
+rather than a posture tick: [`fuzzing.yml`](https://github.com/iainchesworth/aqualink-automate/blob/main/.github/workflows/fuzzing.yml) runs
 the harnesses on a schedule (see [ci-cd.md](ci-cd.md)).
 
 ## What is fuzzed
@@ -106,7 +106,7 @@ layers**, so you never have to remember to run it:
 ### 1. Always-on in-suite regression guard (every build, every platform)
 
 The unit test
-[`test/unit/fuzz/test_protocol_fuzz_smoke.cpp`](../test/unit/fuzz/test_protocol_fuzz_smoke.cpp)
+[`test/unit/fuzz/test_protocol_fuzz_smoke.cpp`](https://github.com/iainchesworth/aqualink-automate/blob/main/test/unit/fuzz/test_protocol_fuzz_smoke.cpp)
 runs in the normal test suite (`testaqualink-automate`) — so it executes on **every**
 `ctest`/CI run on every platform, with **no Clang or fuzzing preset required**. It
 drives the same decode paths with:
@@ -126,7 +126,7 @@ covers the `ci.yml` build-and-test on every PR.
 
 ### 2. Coverage-guided libFuzzer on decoder-touching changes
 
-[`fuzzing.yml`](../.github/workflows/fuzzing.yml) runs the real libFuzzer harnesses
+[`fuzzing.yml`](https://github.com/iainchesworth/aqualink-automate/blob/main/.github/workflows/fuzzing.yml) runs the real libFuzzer harnesses
 on a weekly cron **and** on every PR whose diff touches `src/jandy/**`,
 `src/pentair/**`, `src/core/protocol/**`, `fuzz/**`, or the fuzzing scaffolding — so
 a change to how RS-485 is processed triggers an actual mutation-based fuzz run, not

--- a/src/core/alerting/alert_monitor.cpp
+++ b/src/core/alerting/alert_monitor.cpp
@@ -107,18 +107,22 @@ namespace AqualinkAutomate::Alerting
 	{
 		// Stop() cancels the asio timer, whose no-throw contract is not guaranteed
 		// (steady_timer::cancel() can throw boost::system::system_error). A throwing
-		// destructor would terminate, so swallow any failure here after logging.
+		// destructor would terminate (cpp:S1048), so swallow any failure. The diagnostic
+		// logging can itself throw (std::format / sink write), so it is guarded too —
+		// nothing, including the log call, may escape a destructor.
 		try
 		{
 			Stop();
 		}
 		catch (const std::exception& ex)   // NOSONAR(cpp:S1181) — destructor boundary: nothing may escape a dtor (S1048)
 		{
-			LogDebug(Channel::Equipment, [&ex] { return std::format("AlertMonitor destructor: Stop() threw and was swallowed: {}", ex.what()); });
+			try { LogDebug(Channel::Equipment, [&ex] { return std::format("AlertMonitor destructor: Stop() threw and was swallowed: {}", ex.what()); }); }
+			catch (...) { /* the diagnostic log itself must not escape the destructor (cpp:S1048) */ }
 		}
 		catch (...)   // NOSONAR(cpp:S1181) — destructor boundary: nothing may escape a dtor (S1048)
 		{
-			LogDebug(Channel::Equipment, "AlertMonitor destructor: Stop() threw a non-std exception and was swallowed");
+			try { LogDebug(Channel::Equipment, "AlertMonitor destructor: Stop() threw a non-std exception and was swallowed"); }
+			catch (...) { /* the diagnostic log itself must not escape the destructor (cpp:S1048) */ }
 		}
 	}
 

--- a/src/core/application/application_defaults.cpp
+++ b/src/core/application/application_defaults.cpp
@@ -1,14 +1,8 @@
 #include "application/application_defaults.h"
 
-namespace AqualinkAutomate::Application
-{
-
-	// PLATFORM-SPECIFIC IMPLEMENTATION
-	//
-	// application settings per platform
-	// 
-	// --> win32
-	// --> linux
-
-}
-// namespace AqualinkAutomate::Application
+// PLATFORM-SPECIFIC IMPLEMENTATION
+//
+// application settings per platform
+//
+// --> win32
+// --> linux

--- a/src/core/concepts/is_option_processor.cpp
+++ b/src/core/concepts/is_option_processor.cpp
@@ -1,9 +1,1 @@
 #include "concepts/is_option_processor.h"
-
-namespace AqualinkAutomate::Concepts
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Concepts

--- a/src/core/developer/asio_tracking.cpp
+++ b/src/core/developer/asio_tracking.cpp
@@ -19,6 +19,8 @@ namespace AqualinkAutomate::Developer
 
     void AsioTracking::init()
     {
+        // Intentionally empty: Asio's handler-tracking service requires this hook,
+        // but this implementation performs no one-time initialisation.
     }
 
     void AsioTracking::location(const char* file_name, int line, const char* function_name)
@@ -100,22 +102,23 @@ namespace AqualinkAutomate::Developer
     // Record an operation that is not directly associated with a handler.
     void AsioTracking::operation(boost::asio::execution_context& /*ctx*/, const char* /*object_type*/, void* /*object*/, std::uintmax_t /*native_handle*/, const char* /*op_name*/)
     {
+        // Intentionally empty: non-handler operations are not traced by this implementation.
     }
 
     // Record that a descriptor has been registered with the reactor.
-    void AsioTracking::reactor_registration(boost::asio::execution_context& context, uintmax_t native_handle, uintmax_t registration)
+    void AsioTracking::reactor_registration(boost::asio::execution_context& /*context*/, uintmax_t native_handle, uintmax_t registration)
     {
         LogTrace(Channel::Developer, std::format("Adding to reactor native_handle = {}, registration = {}", native_handle, registration));
     }
 
     // Record that a descriptor has been deregistered from the reactor.
-    void AsioTracking::reactor_deregistration(boost::asio::execution_context& context, uintmax_t native_handle, uintmax_t registration)
+    void AsioTracking::reactor_deregistration(boost::asio::execution_context& /*context*/, uintmax_t native_handle, uintmax_t registration)
     {
         LogTrace(Channel::Developer, std::format("Removing from reactor native_handle = {}, registration = {}", native_handle, registration));
     }
 
     // Record reactor-based readiness events associated with a descriptor.
-    void AsioTracking::reactor_events(boost::asio::execution_context& context, uintmax_t registration, unsigned events)
+    void AsioTracking::reactor_events(boost::asio::execution_context& /*context*/, uintmax_t registration, unsigned events)
     {
         LogTrace(
             Channel::Developer,

--- a/src/core/developer/mock_serial_port_impl.cpp
+++ b/src/core/developer/mock_serial_port_impl.cpp
@@ -10,7 +10,6 @@
 namespace AqualinkAutomate::Developer
 {
 	MockSerialPortImpl::MockSerialPortImpl() :
-		m_RandomDevice{},
 		m_Distribution(32, 127),
 		m_ProfilingDomain(std::move(Factory::ProfilerFactory::Instance().Get()->CreateDomain("MockSerialPortImpl")))
 	{
@@ -294,25 +293,27 @@ namespace AqualinkAutomate::Developer
 
 		auto convert_stop_bits_to_number = [](Serial::StopBits stop_bits)
 			{
+				using enum Serial::StopBits;
 				switch (stop_bits)
 				{
-				case Serial::StopBits::One: return 1.0;
-				case Serial::StopBits::OnePointFive: return 1.5;
-				case Serial::StopBits::Two: return 2.0;
+				case One: return 1.0;
+				case OnePointFive: return 1.5;
+				case Two: return 2.0;
 				default: LogWarning(Channel::Serial, "Attempted to convert an invalid stop bit value; assuming one (1)"); return 1.0;
 				}
 			};
 
 		auto convert_parity_bits_to_number = [](Serial::Parity the_parity)
 			{
+				using enum Serial::Parity;
 				switch (the_parity)
 				{
-				case Serial::Parity::None:
+				case None:
 					return 0;
 
-				case Serial::Parity::Odd:
+				case Odd:
 					[[fallthrough]];
-				case Serial::Parity::Even:
+				case Even:
 					return 1;
 
 				default:
@@ -382,9 +383,9 @@ namespace AqualinkAutomate::Developer
 				return ReadSuccessfully;
 			};
 
-		auto read_from_file = [&](auto& source_stream, uint8_t* output_buffer, std::size_t number_of_elems, boost::system::error_code& ec) -> std::size_t
+		auto read_from_file = [&](auto& source_stream, uint8_t* output_buffer, std::size_t number_of_elems, boost::system::error_code& out_ec) -> std::size_t
 			{
-				auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("MockSerialPortImpl::HandleFileRead -> read_block", std::source_location::current());
+				auto read_block_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("MockSerialPortImpl::HandleFileRead -> read_block", std::source_location::current());
 
 				std::size_t elems_read = 0;
 				bool keep_reading = true;
@@ -395,18 +396,18 @@ namespace AqualinkAutomate::Developer
 					switch (result)
 					{
 					case FileReadErrors::ErrorFileReachedEOF:
-						ec = boost::asio::error::eof;
+						out_ec = boost::asio::error::eof;
 						keep_reading = false;
 						break;
 
 					case FileReadErrors::ErrorDuringRead:
 					case FileReadErrors::NoDataWasRead:
-						ec = boost::asio::error::operation_aborted;
+						out_ec = boost::asio::error::operation_aborted;
 						keep_reading = false;
 						break;
 
 					case FileReadErrors::ReadSuccessfully:
-						ec = make_error_code(boost::system::errc::success);
+						out_ec = make_error_code(boost::system::errc::success);
 						elems_read++;
 						break;
 					}
@@ -418,9 +419,9 @@ namespace AqualinkAutomate::Developer
 				// Otherwise the caller (HandleFileRead) discards a partially-filled
 				// buffer, dropping the tail of any recording shorter than the read
 				// chunk (lossless replay regardless of recording size).
-				if (ec && (elems_read > 0))
+				if (out_ec && (elems_read > 0))
 				{
-					ec = make_error_code(boost::system::errc::success);
+					out_ec = make_error_code(boost::system::errc::success);
 				}
 
 				return elems_read;
@@ -559,13 +560,14 @@ namespace AqualinkAutomate::Developer
 		// input, so a W line decodes to zero bytes (skipped).
 		if ('[' == sv.front())
 		{
+			using enum ReplayHeaderResult;
 			switch (StripReplayHeader(sv, line))
 			{
-			case ReplayHeaderResult::Skip:
+			case Skip:
 				return true;
-			case ReplayHeaderResult::Error:
+			case Error:
 				return false;
-			case ReplayHeaderResult::Continue:
+			case Continue:
 				break;
 			}
 		}
@@ -587,7 +589,7 @@ namespace AqualinkAutomate::Developer
 		return DecodeTokenList(sv, out, line);
 	}
 
-	std::expected<std::size_t, boost::system::error_code> MockSerialPortImpl::HandleFileWrite(const boost::asio::const_buffer& buffer)
+	std::expected<std::size_t, boost::system::error_code> MockSerialPortImpl::HandleFileWrite(const boost::asio::const_buffer& /*buffer*/)
 	{
 		return 0;
 	}

--- a/src/core/developer/mock_serial_port_impl.h
+++ b/src/core/developer/mock_serial_port_impl.h
@@ -73,7 +73,6 @@ namespace AqualinkAutomate::Developer
 		std::expected<std::size_t, boost::system::error_code> HandleMockRead(const boost::asio::mutable_buffer& buffer);
 		std::expected<std::size_t, boost::system::error_code> HandleMockWrite(const boost::asio::const_buffer& buffer);
 
-	private:
 		std::expected<std::size_t, boost::system::error_code> HandleFileRead(const boost::asio::mutable_buffer& buffer);
 		std::expected<std::size_t, boost::system::error_code> HandleFileWrite(const boost::asio::const_buffer& buffer);
 
@@ -96,7 +95,6 @@ namespace AqualinkAutomate::Developer
 	private:
 		Developer::SerialPortOptions m_Options;
 
-	private:
 		std::random_device m_RandomDevice;
 		std::uniform_int_distribution<> m_Distribution;
 		std::string m_DeviceName;
@@ -104,14 +102,12 @@ namespace AqualinkAutomate::Developer
 		bool m_IsOpen{ false };
 		bool m_Cancelled{ false };
 
-	private:
 		boost::iostreams::stream<boost::iostreams::file_source> m_File;
 		// Replay bytes decoded from the current recording line but not yet handed
 		// to a read_some() caller.  Lets a single recording line span multiple
 		// reads (and multiple lines coalesce into one read) transparently.
 		std::deque<uint8_t> m_PendingReplayBytes;
 
-	private:
 		Profiling::DomainPtr m_ProfilingDomain;
 	};
 

--- a/src/core/devices/capabilities/restartable.h
+++ b/src/core/devices/capabilities/restartable.h
@@ -18,7 +18,7 @@ namespace AqualinkAutomate::Devices::Capabilities
 		static constexpr std::chrono::seconds DEFAULT_WATCHDOG_TIMEOUT{ std::chrono::seconds(30) };
 
 	protected:
-		Restartable(std::chrono::seconds timeout_in_seconds = DEFAULT_WATCHDOG_TIMEOUT, bool delayed_start = false);
+		explicit Restartable(std::chrono::seconds timeout_in_seconds = DEFAULT_WATCHDOG_TIMEOUT, bool delayed_start = false);
 		virtual ~Restartable();
 
 	public:
@@ -33,11 +33,9 @@ namespace AqualinkAutomate::Devices::Capabilities
 		void Kick();
 		void Stop();
 
-	protected:
 		std::chrono::seconds GetTimeout() const;
 		bool IsRunning() const;
 
-	protected:
 		// Fired when the watchdog deadline elapses without an intervening Kick().
 		virtual void WatchdogTimeoutOccurred() = 0;
 

--- a/src/core/errors/message_errors.cpp
+++ b/src/core/errors/message_errors.cpp
@@ -10,24 +10,26 @@ namespace AqualinkAutomate::ErrorCodes
 
 	std::string_view Message_ErrorCategory::Describe(Message_ErrorCodes e)
 	{
+		using enum Message_ErrorCodes;
+
 		switch (e)
 		{
-		case Message_ErrorCodes::Error_InvalidMessageData:
+		case Error_InvalidMessageData:
 			return "The serial data did not form a valid message and could not be decoded";
 
-		case Message_ErrorCodes::Error_CannotFindGenerator:
+		case Error_CannotFindGenerator:
 			return "No registered message generator recognised the serial data";
 
-		case Message_ErrorCodes::Error_UnknownMessageType:
+		case Error_UnknownMessageType:
 			return "The message type is not recognised by the factory";
 
-		case Message_ErrorCodes::Error_GeneratorFailed:
+		case Error_GeneratorFailed:
 			return "The message generator failed to produce a message from the serial data";
 
-		case Message_ErrorCodes::Error_FailedToSerialize:
+		case Error_FailedToSerialize:
 			return "The message could not be serialised to wire bytes";
 
-		case Message_ErrorCodes::Error_FailedToDeserialize:
+		case Error_FailedToDeserialize:
 			return "The serial data could not be deserialised into the message";
 
 		default:

--- a/src/core/errors/message_errors.h
+++ b/src/core/errors/message_errors.h
@@ -25,7 +25,6 @@ namespace AqualinkAutomate::ErrorCodes
 	public:
 		static const Message_ErrorCategory& Instance();
 
-	public:
 		static constexpr std::string_view CategoryName{ "AqualinkAutomate::Message Error Category" };
 		static std::string_view Describe(Message_ErrorCodes e);
 

--- a/src/core/errors/protocol_errors.cpp
+++ b/src/core/errors/protocol_errors.cpp
@@ -10,24 +10,26 @@ namespace AqualinkAutomate::ErrorCodes
 
 	std::string_view Protocol_ErrorCategory::Describe(Protocol_ErrorCodes e)
 	{
+		using enum Protocol_ErrorCodes;
+
 		switch (e)
 		{
-		case Protocol_ErrorCodes::DataAvailableToProcess:
+		case DataAvailableToProcess:
 			return "A complete frame is available in the buffer and ready to process";
 
-		case Protocol_ErrorCodes::WaitingForMoreData:
+		case WaitingForMoreData:
 			return "Not enough data has been received yet to decode a frame";
 
-		case Protocol_ErrorCodes::InvalidPacketFormat:
+		case InvalidPacketFormat:
 			return "The packet structure does not match the expected protocol format";
 
-		case Protocol_ErrorCodes::UnknownFailure:
+		case UnknownFailure:
 			return "An unspecified protocol processing failure occurred";
 
-		case Protocol_ErrorCodes::ChecksumFailure:
+		case ChecksumFailure:
 			return "The packet checksum did not match the computed value";
 
-		case Protocol_ErrorCodes::OverlappingPackets:
+		case OverlappingPackets:
 			return "Overlapping packet boundaries were detected in the buffer";
 
 		default:

--- a/src/core/errors/protocol_errors.h
+++ b/src/core/errors/protocol_errors.h
@@ -25,7 +25,6 @@ namespace AqualinkAutomate::ErrorCodes
 	public:
 		static const Protocol_ErrorCategory& Instance();
 
-	public:
 		static constexpr std::string_view CategoryName{ "AqualinkAutomate::Protocol Error Category" };
 		static std::string_view Describe(Protocol_ErrorCodes e);
 

--- a/src/core/exceptions/exception_developer_optionkeyhasnovalue.h
+++ b/src/core/exceptions/exception_developer_optionkeyhasnovalue.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
 	public:
 		Developer_OptionKeyHasNoValue();
-		Developer_OptionKeyHasNoValue(const std::string& message);
+		explicit Developer_OptionKeyHasNoValue(const std::string& message);
 	};
 
 }

--- a/src/core/exceptions/exception_developer_optionkeyinvalidtype.h
+++ b/src/core/exceptions/exception_developer_optionkeyinvalidtype.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
 	public:
 		Developer_OptionKeyInvalidType();
-		Developer_OptionKeyInvalidType(const std::string& message);
+		explicit Developer_OptionKeyInvalidType(const std::string& message);
 	};
 
 }

--- a/src/core/exceptions/exception_developer_optionkeynotprovided.h
+++ b/src/core/exceptions/exception_developer_optionkeynotprovided.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
 	public:
 		Developer_OptionKeyNotProvided();
-		Developer_OptionKeyNotProvided(const std::string& message);
+		explicit Developer_OptionKeyNotProvided(const std::string& message);
 	};
 
 }

--- a/src/core/exceptions/exception_genericaqualinkexception.h
+++ b/src/core/exceptions/exception_genericaqualinkexception.h
@@ -12,9 +12,8 @@ namespace AqualinkAutomate::Exceptions
 	class GenericAqualinkException : public std::exception
 	{
 	public:
-		GenericAqualinkException(std::string message, std::source_location location = std::source_location::current(), boost::stacktrace::stacktrace trace = boost::stacktrace::stacktrace());
+		explicit GenericAqualinkException(std::string message, std::source_location location = std::source_location::current(), boost::stacktrace::stacktrace trace = boost::stacktrace::stacktrace());
 
-	public:
 		const char* what() const noexcept override;
 		std::string& What();
 		const std::string& What() const noexcept;

--- a/src/core/exceptions/exception_http_duplicateroute.h
+++ b/src/core/exceptions/exception_http_duplicateroute.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
     public:
         HTTP_DuplicateRoute();
-        HTTP_DuplicateRoute(const std::string &message);
+        explicit HTTP_DuplicateRoute(const std::string &message);
     };
 
 }

--- a/src/core/exceptions/exception_optionparsingfailed.h
+++ b/src/core/exceptions/exception_optionparsingfailed.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
 	public:
 		OptionParsingFailed();
-		OptionParsingFailed(const std::string& message);
+		explicit OptionParsingFailed(const std::string& message);
 	};
 
 }

--- a/src/core/exceptions/exception_options_conflictingoptions.h
+++ b/src/core/exceptions/exception_options_conflictingoptions.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
 	public:
 		Options_ConflictingOptions();
-		Options_ConflictingOptions(const std::string& message);
+		explicit Options_ConflictingOptions(const std::string& message);
 	};
 
 }

--- a/src/core/exceptions/exception_options_missingdependency.h
+++ b/src/core/exceptions/exception_options_missingdependency.h
@@ -13,7 +13,7 @@ namespace AqualinkAutomate::Exceptions
 
 	public:
 		Options_MissingDependency();
-		Options_MissingDependency(const std::string& message);
+		explicit Options_MissingDependency(const std::string& message);
 	};
 
 }

--- a/src/core/formatters/array_standard_formatter.cpp
+++ b/src/core/formatters/array_standard_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/array_standard_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/asio_endpoint_formatter.cpp
+++ b/src/core/formatters/asio_endpoint_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/asio_endpoint_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/asio_endpoint_formatter.h
+++ b/src/core/formatters/asio_endpoint_formatter.h
@@ -9,13 +9,6 @@
 #include <boost/asio/ip/address_v6.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/beast_stringview_formatter.cpp
+++ b/src/core/formatters/beast_stringview_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/beast_stringview_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/beast_stringview_formatter.h
+++ b/src/core/formatters/beast_stringview_formatter.h
@@ -7,13 +7,6 @@
 
 #include <boost/beast/core/string.hpp>
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/circular_buffer_standard_formatter.cpp
+++ b/src/core/formatters/circular_buffer_standard_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/circular_buffer_standard_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/circular_buffer_standard_formatter.h
+++ b/src/core/formatters/circular_buffer_standard_formatter.h
@@ -10,13 +10,6 @@
 
 #include "formatters/formatter_helpers.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/orp_formatter.cpp
+++ b/src/core/formatters/orp_formatter.cpp
@@ -1,13 +1,6 @@
 #include "formatters/orp_formatter.h"
 #include "formatters/units_electric_potential_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/orp_formatter.h
+++ b/src/core/formatters/orp_formatter.h
@@ -7,13 +7,6 @@
 #include "formatters/units_electric_potential_formatter.h"
 #include "kernel/orp.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/ph_formatter.cpp
+++ b/src/core/formatters/ph_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/ph_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/ph_formatter.h
+++ b/src/core/formatters/ph_formatter.h
@@ -7,13 +7,6 @@
 
 #include "kernel/ph.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {
@@ -30,9 +23,7 @@ struct std::formatter<AqualinkAutomate::Kernel::pH>
 
 	constexpr auto parse(std::format_parse_context& ctx)
 	{
-		auto it = ctx.begin();
-
-		if (it == ctx.end() || *it == '}')
+		if (auto it = ctx.begin(); it == ctx.end() || *it == '}')
 		{
 			std::basic_format_parse_context<char> default_ctx(std::string_view(".01f"));
 			m_Base.parse(default_ctx);

--- a/src/core/formatters/temperature_formatter.cpp
+++ b/src/core/formatters/temperature_formatter.cpp
@@ -2,13 +2,6 @@
 
 #include "formatters/formatter_helpers.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/units_dimensionless_formatter.cpp
+++ b/src/core/formatters/units_dimensionless_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/units_dimensionless_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/units_dimensionless_formatter.h
+++ b/src/core/formatters/units_dimensionless_formatter.h
@@ -6,13 +6,6 @@
 #include "formatters/formatter_helpers.h"
 #include "types/units_dimensionless.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/units_electric_potential_formatter.cpp
+++ b/src/core/formatters/units_electric_potential_formatter.cpp
@@ -2,13 +2,6 @@
 
 #include "formatters/formatter_helpers.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/units_electric_potential_formatter.h
+++ b/src/core/formatters/units_electric_potential_formatter.h
@@ -6,13 +6,6 @@
 #include "formatters/formatter_helpers.h"
 #include "types/units_electric_potential.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/url_segments_encoded_view_formatter.cpp
+++ b/src/core/formatters/url_segments_encoded_view_formatter.cpp
@@ -1,12 +1,5 @@
 #include "formatters/url_segments_encoded_view_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/formatters/url_segments_encoded_view_formatter.h
+++ b/src/core/formatters/url_segments_encoded_view_formatter.h
@@ -8,13 +8,6 @@
 
 #include <boost/url/segments_encoded_view.hpp>
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
 
 namespace std
 {

--- a/src/core/http/json/json_data_hub.h
+++ b/src/core/http/json/json_data_hub.h
@@ -4,14 +4,6 @@
 
 #include "kernel/auxillary_devices/auxillary_device.h"
 
-namespace AqualinkAutomate::HTTP::JSON
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::HTTP::JSON
-
 namespace AqualinkAutomate::Kernel
 {
 	// Support the translation of the various DEVICE object types to JSON

--- a/src/core/http/server/routing/child_idx_vector.cpp
+++ b/src/core/http/server/routing/child_idx_vector.cpp
@@ -1,9 +1,1 @@
 #include "http/server/routing/child_idx_vector.h"
-
-namespace AqualinkAutomate::HTTP::Routing
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::HTTP::Routing

--- a/src/core/http/server/routing/node.cpp
+++ b/src/core/http/server/routing/node.cpp
@@ -1,9 +1,1 @@
 #include "http/server/routing/node.h"
-
-namespace AqualinkAutomate::HTTP::Routing
-{
-
-	// NOTHING HERE.
-
-}
-// namespace AqualinkAutomate::HTTP::Routing

--- a/src/core/http/server/routing/node.h
+++ b/src/core/http/server/routing/node.h
@@ -135,14 +135,12 @@ namespace AqualinkAutomate::HTTP::Routing
 				}
 
 				// look for child
-				auto cit = std::find_if(cur->child_idx.begin(), cur->child_idx.end(),
+				if (auto cit = std::find_if(cur->child_idx.begin(), cur->child_idx.end(),
 					[this, &it](std::size_t ci) -> bool
 					{
 						return nodes_[ci].seg == *it;
 					}
-				);
-
-				if (cit != cur->child_idx.end())
+				); cit != cur->child_idx.end())
 				{
 					// move to existing child
 					cur = &nodes_[*cit];
@@ -316,10 +314,9 @@ namespace AqualinkAutomate::HTTP::Routing
 				// match_any) or return a terminal match; the branch lower-bound is
 				// computed inside.
 				bool match_any = false;
-				node<HANDLER_TYPE> const* r = match_children(s, it, end, cur, level, cursors, match_any);
 				// r represent we already found a terminal
 				// node which is a match
-				if (r)
+				if (node<HANDLER_TYPE> const* r = match_children(s, it, end, cur, level, cursors, match_any))
 				{
 					return r;
 				}
@@ -380,8 +377,7 @@ namespace AqualinkAutomate::HTTP::Routing
 				int branches_lb = 0;
 				for (auto i : cur->child_idx)
 				{
-					auto& c = nodes_[i];
-					if (c.seg.is_literal() || !c.seg.has_modifier())
+					if (auto& c = nodes_[i]; c.seg.is_literal() || !c.seg.has_modifier())
 					{
 						// a literal path counts only
 						// if it matches
@@ -615,8 +611,7 @@ namespace AqualinkAutomate::HTTP::Routing
 				auto ids0 = ids;
 				WriteCapture(matches, matches_end, {});
 				WriteCapture(ids, ids_end, c.seg.id());
-				auto n = find_optional_resource(&c, ns, matches, ids, matches_end, ids_end);
-				if (n)
+				if (auto n = find_optional_resource(&c, ns, matches, ids, matches_end, ids_end))
 				{
 					return n;
 				}

--- a/src/core/http/server/routing/segment_template.cpp
+++ b/src/core/http/server/routing/segment_template.cpp
@@ -47,8 +47,7 @@ namespace AqualinkAutomate::HTTP::Routing
             
             ++it;
             
-            auto send = boost::urls::grammar::find_if(it, end, boost::urls::grammar::lut_chars('}'));
-            if (send != end)
+            if (auto send = boost::urls::grammar::find_if(it, end, boost::urls::grammar::lut_chars('}')); send != end)
             {
                 std::string_view s(it, send);
                 

--- a/src/core/http/server/server_fields.h
+++ b/src/core/http/server/server_fields.h
@@ -9,8 +9,6 @@ namespace AqualinkAutomate::HTTP
 	{
 	public:
 		static constexpr std::string_view APPLICATION_JSON{ "application/json" };
-
-	public:
 		static constexpr std::string_view TEXT_HTML{ "text/html" };
 		static constexpr std::string_view TEXT_PLAIN{ "text/plain" };
 	};

--- a/src/core/http/server/server_types.cpp
+++ b/src/core/http/server/server_types.cpp
@@ -1,9 +1,1 @@
 #include "http/server/server_types.h"
-
-namespace AqualinkAutomate::HTTP
-{
-
-    // NOTHING HERE
-
-}
-// namespace AqualinkAutomate::HTTP

--- a/src/core/http/server/static_file_handler.cpp
+++ b/src/core/http/server/static_file_handler.cpp
@@ -21,9 +21,7 @@ namespace AqualinkAutomate::HTTP
         m_Prefix(std::move(prefix)),
         m_DocRoot(std::filesystem::absolute(doc_root))
     {
-        std::error_code ec;
-
-        if (!std::filesystem::is_directory(m_DocRoot, ec))
+        if (std::error_code ec; !std::filesystem::is_directory(m_DocRoot, ec))
         {
             LogWarning(Channel::Web, std::format("Specified static directory '{}' was invalid; error was -> {}", m_DocRoot.string(), ec.message()));
         }
@@ -69,8 +67,7 @@ namespace AqualinkAutomate::HTTP
 
             while (it != end)
             {
-                auto seg = *it;
-                if (!seg.empty())
+                if (auto seg = *it; !seg.empty())
                 {
                     result.append(seg.begin(), seg.end());
                 }
@@ -131,8 +128,7 @@ namespace AqualinkAutomate::HTTP
         }
 
         // Trivially reject target that cannot contain the prefix
-        auto target_size = target.size();
-        if (target_size < non_empty_prefix_count)
+        if (auto target_size = target.size(); target_size < non_empty_prefix_count)
         {
             return -1;
         }

--- a/src/core/http/server/static_file_handler.h
+++ b/src/core/http/server/static_file_handler.h
@@ -16,7 +16,6 @@ namespace AqualinkAutomate::HTTP
 		StaticFileHandler(std::string_view prefix, const std::filesystem::path& root);
 		StaticFileHandler(boost::urls::url prefix, const std::filesystem::path& root);
 
-	public:
 		bool match(const boost::urls::url_view& target, std::filesystem::path& result);
 
 	private:

--- a/src/core/http/webroute_diagnostics_logging.cpp
+++ b/src/core/http/webroute_diagnostics_logging.cpp
@@ -40,19 +40,19 @@ namespace AqualinkAutomate::HTTP
 
 		// Build channel → current severity map
 		nlohmann::json channels = nlohmann::json::object();
-		magic_enum::enum_for_each<Channel>([&channels](auto const& channel)
+		magic_enum::enum_for_each<Channel>([&channels](auto const& channel_entry)
 			{
-				auto severity = SeverityFiltering::GetChannelFilterLevel(channel.value);
-				channels[std::string(magic_enum::enum_name(channel.value))] = std::string(magic_enum::enum_name(severity));
+				auto channel_severity = SeverityFiltering::GetChannelFilterLevel(channel_entry.value);
+				channels[std::string(magic_enum::enum_name(channel_entry.value))] = std::string(magic_enum::enum_name(channel_severity));
 			});
 
 		result["channels"] = channels;
 
 		// Build available severity levels array
 		nlohmann::json levels = nlohmann::json::array();
-		magic_enum::enum_for_each<Severity>([&levels](auto const& severity)
+		magic_enum::enum_for_each<Severity>([&levels](auto const& severity_entry)
 			{
-				levels.push_back(std::string(magic_enum::enum_name(severity.value)));
+				levels.push_back(std::string(magic_enum::enum_name(severity_entry.value)));
 			});
 
 		result["severity_levels"] = levels;
@@ -69,14 +69,14 @@ namespace AqualinkAutomate::HTTP
 			if (body.contains("global"))
 			{
 				auto level_name = body["global"].get<std::string>();
-				auto severity = magic_enum::enum_cast<Severity>(level_name);
+				auto severity_cast = magic_enum::enum_cast<Severity>(level_name);
 
-				if (!severity.has_value())
+				if (!severity_cast.has_value())
 				{
 					return MakeErrorResponse(req, HTTP::Status::bad_request, "invalid_severity", "Invalid severity level");
 				}
 
-				SeverityFiltering::SetGlobalFilterLevel(severity.value());
+				SeverityFiltering::SetGlobalFilterLevel(severity_cast.value());
 
 				LogInfo(Channel::Web, std::format("Global log level set to {} via web UI", level_name));
 			}
@@ -85,15 +85,15 @@ namespace AqualinkAutomate::HTTP
 				auto channel_name = body["channel"].get<std::string>();
 				auto level_name = body["level"].get<std::string>();
 
-				auto channel = magic_enum::enum_cast<Channel>(channel_name);
-				auto severity = magic_enum::enum_cast<Severity>(level_name);
+				auto channel_cast = magic_enum::enum_cast<Channel>(channel_name);
+				auto severity_cast = magic_enum::enum_cast<Severity>(level_name);
 
-				if (!channel.has_value() || !severity.has_value())
+				if (!channel_cast.has_value() || !severity_cast.has_value())
 				{
 					return MakeErrorResponse(req, HTTP::Status::bad_request, "invalid_channel_or_severity", "Invalid channel or severity level");
 				}
 
-				SeverityFiltering::SetChannelFilterLevel(channel.value(), severity.value());
+				SeverityFiltering::SetChannelFilterLevel(channel_cast.value(), severity_cast.value());
 
 				LogInfo(Channel::Web, std::format("Log level for channel {} set to {} via web UI", channel_name, level_name));
 			}

--- a/src/core/http/webroute_diagnostics_logging.h
+++ b/src/core/http/webroute_diagnostics_logging.h
@@ -15,7 +15,6 @@ namespace AqualinkAutomate::HTTP
 		WebRoute_Diagnostics_Logging() = default;
 		~WebRoute_Diagnostics_Logging() override = default;
 
-	public:
 		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb method) const override

--- a/src/core/http/webroute_equipment.h
+++ b/src/core/http/webroute_equipment.h
@@ -18,9 +18,8 @@ namespace AqualinkAutomate::HTTP
 	class WebRoute_Equipment : public Interfaces::IWebRoute<EQUIPMENT_ROUTE_URL>
 	{
 	public:
-		WebRoute_Equipment(Kernel::HubLocator& hub_locator);
+		explicit WebRoute_Equipment(Kernel::HubLocator& hub_locator);
 
-	public:
         HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb) const override

--- a/src/core/http/webroute_equipment_button.cpp
+++ b/src/core/http/webroute_equipment_button.cpp
@@ -25,8 +25,7 @@ namespace
 	std::optional<std::string> ExtractButtonId(const AqualinkAutomate::HTTP::Request& req)
 	{
 		// Try extracting from URL path first (e.g. /api/equipment/buttons/some-uuid)
-		auto url_result = boost::urls::parse_origin_form(req.target());
-		if (url_result.has_value())
+		if (auto url_result = boost::urls::parse_origin_form(req.target()); url_result.has_value())
 		{
 			auto segments = url_result->segments();
 			// Path: /api/equipment/buttons/{button_id} -> 4 segments
@@ -55,10 +54,10 @@ namespace
 namespace AqualinkAutomate::HTTP
 {
 
-	WebRoute_Equipment_Button::WebRoute_Equipment_Button(Kernel::HubLocator& hub_locator)
+	WebRoute_Equipment_Button::WebRoute_Equipment_Button(Kernel::HubLocator& hub_locator) :
+		m_DataHub(hub_locator.Find<Kernel::DataHub>()),
+		m_CommandDispatcher(hub_locator.TryFind<Interfaces::ICommandDispatcher>())
 	{
-		m_DataHub = hub_locator.Find<Kernel::DataHub>();
-		m_CommandDispatcher = hub_locator.TryFind<Interfaces::ICommandDispatcher>();
 	}
 
 	HTTP::Response WebRoute_Equipment_Button::OnRequest(const HTTP::Request& req)

--- a/src/core/http/webroute_equipment_button.h
+++ b/src/core/http/webroute_equipment_button.h
@@ -17,12 +17,10 @@ namespace AqualinkAutomate::HTTP
 	class WebRoute_Equipment_Button: public Interfaces::IWebRoute<EQUIPMENTBUTTONS_BUTTON_ROUTE_URL>
 	{
 	public:
-		WebRoute_Equipment_Button(Kernel::HubLocator& hub_locator);
+		explicit WebRoute_Equipment_Button(Kernel::HubLocator& hub_locator);
 
-	public:
 		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
-	public:
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb method) const override
 		{
 			if ((boost::beast::http::verb::get == method) || (boost::beast::http::verb::head == method))
@@ -39,7 +37,6 @@ namespace AqualinkAutomate::HTTP
 	private:
 		HTTP::Response ButtonToggle_MapResultToResponse(const HTTP::Request& req, const std::string& button_id, const std::shared_ptr<Kernel::AuxillaryDevice>& button_device, Interfaces::ICommandDispatcher::CommandResult result);
 
-	private:
 		HTTP::Response Report_ButtonDoesntExist(const HTTP::Request& req, const std::string& button_id);
 		HTTP::Response Report_SystemIsInactive(const HTTP::Request& req);
 

--- a/src/core/http/webroute_equipment_buttons.h
+++ b/src/core/http/webroute_equipment_buttons.h
@@ -17,12 +17,10 @@ namespace AqualinkAutomate::HTTP
 	class WebRoute_Equipment_Buttons : public Interfaces::IWebRoute<EQUIPMENTBUTTONS_ROUTE_URL>
 	{
 	public:
-        WebRoute_Equipment_Buttons(Kernel::HubLocator& hub_locator);
+        explicit WebRoute_Equipment_Buttons(Kernel::HubLocator& hub_locator);
 
-    public:
         HTTP::Response OnRequest(const HTTP::Request& req) final;
 
-	public:
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb) const override
 		{
 			return { .Action = Auth::Vocabulary::EQUIPMENT_VIEW };

--- a/src/core/http/webroute_equipment_devices.h
+++ b/src/core/http/webroute_equipment_devices.h
@@ -17,9 +17,8 @@ namespace AqualinkAutomate::HTTP
 	class WebRoute_Equipment_Devices : public Interfaces::IWebRoute<EQUIPMENTDEVICES_ROUTE_URL>
 	{
 	public:
-		WebRoute_Equipment_Devices(Kernel::HubLocator& hub_locator);
+		explicit WebRoute_Equipment_Devices(Kernel::HubLocator& hub_locator);
 
-	public:
         HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb) const override

--- a/src/core/http/webroute_equipment_setpoints.cpp
+++ b/src/core/http/webroute_equipment_setpoints.cpp
@@ -36,10 +36,10 @@ namespace
 namespace AqualinkAutomate::HTTP
 {
 
-	WebRoute_Equipment_Setpoints::WebRoute_Equipment_Setpoints(Kernel::HubLocator& hub_locator)
+	WebRoute_Equipment_Setpoints::WebRoute_Equipment_Setpoints(Kernel::HubLocator& hub_locator) :
+		m_DataHub(hub_locator.Find<Kernel::DataHub>()),
+		m_CommandDispatcher(hub_locator.TryFind<Interfaces::ICommandDispatcher>())
 	{
-		m_DataHub = hub_locator.Find<Kernel::DataHub>();
-		m_CommandDispatcher = hub_locator.TryFind<Interfaces::ICommandDispatcher>();
 	}
 
 	HTTP::Response WebRoute_Equipment_Setpoints::OnRequest(const HTTP::Request& req)

--- a/src/core/http/webroute_equipment_setpoints.h
+++ b/src/core/http/webroute_equipment_setpoints.h
@@ -23,9 +23,8 @@ namespace AqualinkAutomate::HTTP
 	class WebRoute_Equipment_Setpoints : public Interfaces::IWebRoute<EQUIPMENT_SETPOINTS_ROUTE_URL>
 	{
 	public:
-		WebRoute_Equipment_Setpoints(Kernel::HubLocator& hub_locator);
+		explicit WebRoute_Equipment_Setpoints(Kernel::HubLocator& hub_locator);
 
-	public:
 		HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb method) const override

--- a/src/core/http/webroute_equipment_version.cpp
+++ b/src/core/http/webroute_equipment_version.cpp
@@ -7,9 +7,9 @@ namespace AqualinkAutomate::HTTP
 {
 
 	WebRoute_Equipment_Version::WebRoute_Equipment_Version(Kernel::HubLocator& hub_locator) :
-		Interfaces::IWebRoute<EQUIPMENTVERSION_ROUTE_URL>()
+		Interfaces::IWebRoute<EQUIPMENTVERSION_ROUTE_URL>(),
+		m_DataHub(hub_locator.Find<Kernel::DataHub>())
 	{
-		m_DataHub = hub_locator.Find<Kernel::DataHub>();
 	}
 
 	HTTP::Response WebRoute_Equipment_Version::OnRequest(const HTTP::Request& req)

--- a/src/core/http/webroute_equipment_version.h
+++ b/src/core/http/webroute_equipment_version.h
@@ -16,9 +16,8 @@ namespace AqualinkAutomate::HTTP
 	class WebRoute_Equipment_Version : public Interfaces::IWebRoute<EQUIPMENTVERSION_ROUTE_URL>
 	{
 	public:
-		WebRoute_Equipment_Version(Kernel::HubLocator& hub_locator);
+		explicit WebRoute_Equipment_Version(Kernel::HubLocator& hub_locator);
 
-	public:
         HTTP::Response OnRequest(const HTTP::Request& req) final;
 
 		Interfaces::AccessRequirement RequiredAccess(boost::beast::http::verb) const override

--- a/src/core/http/webroute_preferences.cpp
+++ b/src/core/http/webroute_preferences.cpp
@@ -97,8 +97,7 @@ namespace AqualinkAutomate::HTTP
 			// whole document goes to the global service, which picks out the
 			// fields it knows (units, ui, alert, ...) and ignores the rest.
 			std::string error;
-			std::string error_code;
-			if (!m_Service->ApplyJson(json, error, error_code))
+			if (std::string error_code; !m_Service->ApplyJson(json, error, error_code))
 			{
 				return MakeErrorResponse(req, HTTP::Status::bad_request, error_code.empty() ? "invalid_preferences" : error_code, error);
 			}

--- a/src/core/http/webroute_version.h
+++ b/src/core/http/webroute_version.h
@@ -12,7 +12,6 @@ namespace AqualinkAutomate::HTTP
         WebRoute_Version() = default;
         ~WebRoute_Version() override = default;
 
-	public:
         HTTP::Response OnRequest(const HTTP::Request& req) final;
 	};
 

--- a/src/core/http/websocket_equipment.cpp
+++ b/src/core/http/websocket_equipment.cpp
@@ -14,12 +14,9 @@ namespace AqualinkAutomate::HTTP
 {
 
 	WebSocket_Equipment::WebSocket_Equipment(Kernel::HubLocator& hub_locator) :
-		m_ConfigChangeSlot(),
-		m_StatusChangeSlot()
+		m_DataHub(hub_locator.Find<Kernel::DataHub>()),
+		m_EquipmentHub(hub_locator.Find<Kernel::EquipmentHub>())
 	{
-		m_DataHub = hub_locator.Find<Kernel::DataHub>();
-		m_EquipmentHub = hub_locator.Find<Kernel::EquipmentHub>();
-
 		// Connect signals that broadcast messages to all connections
 		if (m_DataHub)
 		{
@@ -163,10 +160,14 @@ namespace AqualinkAutomate::HTTP
 
 	void WebSocket_Equipment::OnMessage(ConnectionId /*connId*/, const boost::beast::flat_buffer& /*buffer*/)
 	{
+		// Intentionally empty: this is a broadcast-only endpoint; inbound client
+		// messages are ignored.
 	}
 
 	void WebSocket_Equipment::OnPublish(ConnectionId /*connId*/)
 	{
+		// Intentionally empty: publishing is signal-driven via Broadcast(), so there
+		// is no per-connection publish work to perform here.
 	}
 
 	void WebSocket_Equipment::OnClose(ConnectionId connId)

--- a/src/core/http/websocket_equipment.h
+++ b/src/core/http/websocket_equipment.h
@@ -24,17 +24,15 @@ namespace AqualinkAutomate::HTTP
 	class WebSocket_Equipment : public Interfaces::IWebSocket<EQUIPMENT_WEBSOCKET_URL>
 	{
 	public:
-		WebSocket_Equipment(Kernel::HubLocator& hub_locator);
+		explicit WebSocket_Equipment(Kernel::HubLocator& hub_locator);
 
 		Interfaces::AccessRequirement RequiredAccess() const override
 		{
 			return { .Action = Auth::Vocabulary::EQUIPMENT_VIEW };
 		}
 
-	public:
 		std::optional<std::string> DequeueMessage(ConnectionId connId) override;
 
-	public:
         ConnectionId OnOpen() override;
         void OnMessage(ConnectionId connId, const boost::beast::flat_buffer& buffer) override;
 		void OnPublish(ConnectionId connId) override;

--- a/src/core/http/websocket_equipment_stats.cpp
+++ b/src/core/http/websocket_equipment_stats.cpp
@@ -15,10 +15,8 @@ namespace AqualinkAutomate::HTTP
 
 	WebSocket_Equipment_Stats::WebSocket_Equipment_Stats(Kernel::HubLocator& hub_locator) :
 		Interfaces::IWebSocket<EQUIPMENTSTATS_WEBSOCKET_URL>(),
-		m_StatsSlot()
+		m_StatisticsHub(hub_locator.Find<Kernel::StatisticsHub>())
 	{
-		m_StatisticsHub = hub_locator.Find<Kernel::StatisticsHub>();
-
 		if (m_StatisticsHub)
 		{
 			m_StatsSlot = m_StatisticsHub->MessageCounts.Signal().connect(
@@ -69,10 +67,14 @@ namespace AqualinkAutomate::HTTP
 
 	void WebSocket_Equipment_Stats::OnMessage(ConnectionId /*connId*/, const boost::beast::flat_buffer& /*buffer*/)
 	{
+		// Intentionally empty: this is a broadcast-only endpoint; inbound client
+		// messages are ignored.
 	}
 
 	void WebSocket_Equipment_Stats::OnPublish(ConnectionId /*connId*/)
 	{
+		// Intentionally empty: publishing is signal-driven, so there is no
+		// per-connection publish work to perform here.
 	}
 
 	void WebSocket_Equipment_Stats::OnClose(ConnectionId connId)

--- a/src/core/http/websocket_equipment_stats.h
+++ b/src/core/http/websocket_equipment_stats.h
@@ -20,17 +20,15 @@ namespace AqualinkAutomate::HTTP
 	class WebSocket_Equipment_Stats: public Interfaces::IWebSocket<EQUIPMENTSTATS_WEBSOCKET_URL>
 	{
 	public:
-		WebSocket_Equipment_Stats(Kernel::HubLocator& hub_locator);
+		explicit WebSocket_Equipment_Stats(Kernel::HubLocator& hub_locator);
 
 		Interfaces::AccessRequirement RequiredAccess() const override
 		{
 			return { .Action = Auth::Vocabulary::EQUIPMENT_VIEW };
 		}
 
-	public:
 		std::optional<std::string> DequeueMessage(ConnectionId connId) override;
 
-	public:
 		ConnectionId OnOpen() override;
 		void OnMessage(ConnectionId connId, const boost::beast::flat_buffer& buffer) override;
 		void OnPublish(ConnectionId connId) override;

--- a/src/core/http/websocket_event.cpp
+++ b/src/core/http/websocket_event.cpp
@@ -16,8 +16,7 @@ namespace AqualinkAutomate::HTTP
 	const std::string_view WebSocket_Event::WS_JSON_PAYLOAD_FIELD{ "payload" };
 
 	WebSocket_Event::WebSocket_Event(const HTTP::WebSocket_EventTypes& event_type, const nlohmann::json& payload) :
-		m_EventType(event_type),
-		m_EventPayload()
+		m_EventType(event_type)
 	{
 		m_EventPayload[WS_JSON_TYPE_FIELD] = magic_enum::enum_name(event_type);
 		m_EventPayload[WS_JSON_PAYLOAD_FIELD] = payload;

--- a/src/core/http/websocket_event.h
+++ b/src/core/http/websocket_event.h
@@ -26,20 +26,17 @@ namespace AqualinkAutomate::HTTP
 	public:
 		WebSocket_Event(const WebSocket_EventTypes& event_type, const nlohmann::json& payload);
 
-	public:
-		WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent>& config_event);
-		WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_ButtonStateChange>& button_config_event);
-		WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_Chemistry>& chem_config_event);
+		explicit WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent>& config_event);
+		explicit WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_ButtonStateChange>& button_config_event);
+		explicit WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_Chemistry>& chem_config_event);
 		explicit WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_Circulation>& circ_config_event);
-		WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_Temperature>& temp_config_event);
-		WebSocket_Event(const std::shared_ptr<Kernel::EquipmentHub_SystemEvent>& system_event);
-		WebSocket_Event(const std::shared_ptr<Kernel::EquipmentHub_SystemEvent_StatusChange>& status_system_event);
+		explicit WebSocket_Event(const std::shared_ptr<Kernel::DataHub_ConfigEvent_Temperature>& temp_config_event);
+		explicit WebSocket_Event(const std::shared_ptr<Kernel::EquipmentHub_SystemEvent>& system_event);
+		explicit WebSocket_Event(const std::shared_ptr<Kernel::EquipmentHub_SystemEvent_StatusChange>& status_system_event);
 
-	public:
 		WebSocket_EventTypes Type() const;
 		std::string Payload() const;
 
-	public:
 		std::string operator()() const;
 
 	private:

--- a/src/core/http/websocket_event_types.cpp
+++ b/src/core/http/websocket_event_types.cpp
@@ -1,9 +1,1 @@
 #include "http/websocket_event_types.h"
-
-namespace AqualinkAutomate::HTTP
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::HTTP

--- a/src/core/interfaces/icommanddispatcher.cpp
+++ b/src/core/interfaces/icommanddispatcher.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/icommanddispatcher.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/idevice.h
+++ b/src/core/interfaces/idevice.h
@@ -10,14 +10,12 @@ namespace AqualinkAutomate::Interfaces
     class IDevice
     {
     public:
-        IDevice(std::shared_ptr<IDeviceIdentifier> device_id);
+        explicit IDevice(std::shared_ptr<IDeviceIdentifier> device_id);
         virtual ~IDevice() = default;
 
-    public:
         IDevice(const IDevice& other) = delete;
         IDevice(IDevice&& other) noexcept = default;
 
-    public:
         const IDeviceIdentifier& DeviceId() const;
 
     private:

--- a/src/core/interfaces/ideviceidentifier.cpp
+++ b/src/core/interfaces/ideviceidentifier.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/ideviceidentifier.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/ideviceidentifier.h
+++ b/src/core/interfaces/ideviceidentifier.h
@@ -9,7 +9,6 @@ namespace AqualinkAutomate::Interfaces
 		IDeviceIdentifier() = default;
 		virtual ~IDeviceIdentifier() = default;
 
-	public:
 		bool operator==(const IDeviceIdentifier& other) const { return Equals(other); }
 		// NOTE: operator!= is intentionally retained (not redundant per SonarCloud
 		// cpp:S6186): derived types re-export it via `using ...::operator!=;`, which

--- a/src/core/interfaces/iequipment.cpp
+++ b/src/core/interfaces/iequipment.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/iequipment.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/ihub.cpp
+++ b/src/core/interfaces/ihub.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/ihub.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/imessage.cpp
+++ b/src/core/interfaces/imessage.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/imessage.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/imessage.h
+++ b/src/core/interfaces/imessage.h
@@ -10,25 +10,22 @@ namespace AqualinkAutomate::Interfaces
 	class IMessage
 	{
 	public:
-		constexpr IMessage(const MESSAGE_ID message_id) :
+		constexpr explicit IMessage(const MESSAGE_ID message_id) :
 			m_Id(message_id)
 		{
 		}
 
 		virtual ~IMessage() = default;
 
-	public:
 		constexpr MESSAGE_ID Id() const
 		{
 			return m_Id;
 		}
 
-	public:
 		virtual uint8_t MaxPermittedPacketLength() const = 0;
 		virtual uint8_t MinPermittedPacketLength() const = 0;
 		virtual std::string ToString() const = 0;
 
-	public:
 		constexpr bool operator==(const IMessage& other) const
 		{
 			bool is_equal = true;

--- a/src/core/interfaces/imessagesignal_recv.cpp
+++ b/src/core/interfaces/imessagesignal_recv.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/imessagesignal_recv.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/imessagesignal_recv.h
+++ b/src/core/interfaces/imessagesignal_recv.h
@@ -15,6 +15,7 @@ namespace AqualinkAutomate::Interfaces
 	class IMessageSignalRecvBase
 	{
 	public:
+		virtual ~IMessageSignalRecvBase() = default;
 		virtual void Signal_MessageWasReceived() = 0;
 	};
 
@@ -31,7 +32,6 @@ namespace AqualinkAutomate::Interfaces
 	public:
 		virtual ~IMessageSignalRecv() = default;
 
-	public:
 		using SignalRef = const MESSAGE_TYPE&;
 		using SignalFunc = boost::signals2::signal<void(SignalRef)>;
 		using SignalPtr = std::shared_ptr<SignalFunc>;
@@ -42,7 +42,6 @@ namespace AqualinkAutomate::Interfaces
 			return signal;
 		}
 
-	public:
 		void Signal_MessageWasReceived() final
 		{
 			// CRTP precondition: MESSAGE_TYPE must derive from this base so the

--- a/src/core/interfaces/imessagesignal_send.cpp
+++ b/src/core/interfaces/imessagesignal_send.cpp
@@ -1,8 +1,1 @@
 #include "interfaces/imessagesignal_send.h"
-
-namespace AqualinkAutomate::Interfaces
-{
-
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/imessagesignal_send.h
+++ b/src/core/interfaces/imessagesignal_send.h
@@ -17,6 +17,7 @@ namespace AqualinkAutomate::Interfaces
 	class IMessageSignalSendBase
 	{
 	public:
+		virtual ~IMessageSignalSendBase() = default;
 		virtual void Signal_MessageToSend() = 0;
 	};
 
@@ -29,7 +30,6 @@ namespace AqualinkAutomate::Interfaces
 	public:
 		virtual ~IMessageSignalSend() = default;
 
-	public:
 		using PublisherRef = std::reference_wrapper<const MESSAGE_TYPE>;
 		using PublisherFunc = boost::signals2::signal<void(PublisherRef)>;
 		using PublisherPtr = std::shared_ptr<PublisherFunc>;
@@ -40,23 +40,24 @@ namespace AqualinkAutomate::Interfaces
 			return publisher;
 		}
 
-	public:
 		void Signal_MessageToSend() final
 		{
+			using enum Channel;
+
 			if (auto publisher_ptr = GetPublisher(); nullptr == publisher_ptr)
 			{
-				LogTrace(Channel::Messages, "Could not retrieve signal shared_ptr from IMessageSignalSend::GetPublisher()");
+				LogTrace(Messages, "Could not retrieve signal shared_ptr from IMessageSignalSend::GetPublisher()");
 			}
 			else if (auto upcast_ptr = dynamic_cast<MESSAGE_TYPE *>(this); nullptr == upcast_ptr)
 			{
 				const std::type_info& src_type = typeid(this);
 				const std::type_info& dst_type = typeid(MESSAGE_TYPE*);
 
-				LogDebug(Channel::Messages, std::format("Could not convert from 'this' to the target message pointer type: src -> {}, dst -> {}", src_type.name(), dst_type.name()));
+				LogDebug(Messages, std::format("Could not convert from 'this' to the target message pointer type: src -> {}, dst -> {}", src_type.name(), dst_type.name()));
 			}
 			else
 			{
-				LogTrace(Channel::Signals, "Signalling all registered slots for published message");
+				LogTrace(Signals, "Signalling all registered slots for published message");
 				(*publisher_ptr)(*upcast_ptr);
 			}
 		}

--- a/src/core/interfaces/iprofiler.cpp
+++ b/src/core/interfaces/iprofiler.cpp
@@ -23,38 +23,47 @@ namespace AqualinkAutomate::Interfaces
 
 	void IProfiler::Resume()
 	{
+		// No-op default: the null profiler backend has nothing to resume.
 	}
 
 	void IProfiler::Pause()
 	{
+		// No-op default: the null profiler backend has nothing to pause.
 	}
 
 	void IProfiler::Message(std::string_view) const
 	{
+		// No-op default: the null profiler backend discards messages.
 	}
 
 	void IProfiler::Message(std::string_view, uint32_t) const
 	{
+		// No-op default: the null profiler backend discards messages.
 	}
 
 	void IProfiler::PlotValue(const std::string&, int64_t)
 	{
+		// No-op default: the null profiler backend discards plotted values.
 	}
 
 	void IProfiler::PlotValue(const std::string&, double)
 	{
+		// No-op default: the null profiler backend discards plotted values.
 	}
 
 	void IProfiler::SetThreadName(const char*) const
 	{
+		// No-op default: the null profiler backend does not track thread names.
 	}
 
 	void IProfiler::AppInfo(std::string_view) const
 	{
+		// No-op default: the null profiler backend discards application info.
 	}
 
 	void IProfiler::EmitFrameMark(const char*) const
 	{
+		// No-op default: the null profiler backend does not mark frames.
 	}
 
 }

--- a/src/core/interfaces/iprofiler.h
+++ b/src/core/interfaces/iprofiler.h
@@ -16,12 +16,10 @@ namespace AqualinkAutomate::Interfaces
 	public:
 		virtual ~IProfiler() = default;
 
-	public:
 		// Process lifecycle: called once at startup / shutdown.
 		virtual void StartProfiling() = 0;
 		virtual void StopProfiling() = 0;
 
-	public:
 		// Runtime capture gating, distinct from the process lifecycle above.
 		// Lets the runtime control surface (e.g. the diagnostics endpoint) pause
 		// and resume sample/trace collection without tearing the profiler down.
@@ -30,12 +28,10 @@ namespace AqualinkAutomate::Interfaces
 		virtual void Resume();
 		virtual void Pause();
 
-	public:
 		virtual Profiling::DomainPtr CreateDomain(const std::string& name) const;
 		virtual Profiling::FramePtr CreateFrame(Profiling::DomainPtr domain, const std::string& name) const;
 		virtual Profiling::ZonePtr CreateZone(Profiling::FramePtr frame, const std::string& name) const;
 
-	public:
 		virtual void Message(std::string_view text) const;
 		virtual void Message(std::string_view text, uint32_t colour) const;
 		virtual void PlotValue(const std::string& name, int64_t value);

--- a/src/core/interfaces/iprofilingunit.cpp
+++ b/src/core/interfaces/iprofilingunit.cpp
@@ -15,10 +15,12 @@ namespace AqualinkAutomate::Interfaces
 
 	void IProfilingUnit::Text(std::string_view) const
 	{
+		// No-op default: the null profiling unit discards text annotations.
 	}
 
 	void IProfilingUnit::Value(uint64_t) const
 	{
+		// No-op default: the null profiling unit discards value annotations.
 	}
 
 }

--- a/src/core/interfaces/iprofilingunit.h
+++ b/src/core/interfaces/iprofilingunit.h
@@ -10,19 +10,16 @@ namespace AqualinkAutomate::Interfaces
 	class IProfilingUnit
 	{
 	public:
-		IProfilingUnit(std::string_view name);
+		explicit IProfilingUnit(std::string_view name);
 		virtual ~IProfilingUnit() = default;
 
-	public:
 		virtual void Start() const = 0;
 		virtual void Mark() const = 0;
 		virtual void End() const = 0;
 
-	public:
 		virtual void Text(std::string_view text) const;
 		virtual void Value(uint64_t value) const;
 
-	public:
 		std::string_view Name() const;
 
 	private:

--- a/src/core/interfaces/iserializable.cpp
+++ b/src/core/interfaces/iserializable.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/iserializable.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/iserializable.h
+++ b/src/core/interfaces/iserializable.h
@@ -14,7 +14,6 @@ namespace AqualinkAutomate::Interfaces
         ISerializable() = default;
         virtual ~ISerializable() = default;
 
-    public:
         virtual bool Serialize(std::vector<uint8_t>& message_bytes) const = 0;
         virtual bool Deserialize(const std::span<const std::byte>& message_bytes) = 0;
     };

--- a/src/core/interfaces/iserialport.cpp
+++ b/src/core/interfaces/iserialport.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/iserialport.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/iserialportimpl.cpp
+++ b/src/core/interfaces/iserialportimpl.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/iserialportimpl.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/iserialportimpl.h
+++ b/src/core/interfaces/iserialportimpl.h
@@ -19,13 +19,11 @@ namespace AqualinkAutomate::Interfaces
         ISerialPortImpl() = default;
         virtual ~ISerialPortImpl() = default;
 
-    public:
         ISerialPortImpl(const ISerialPortImpl&) = delete;
         ISerialPortImpl& operator=(const ISerialPortImpl&) = delete;
         ISerialPortImpl(ISerialPortImpl&& other) noexcept = delete;
         ISerialPortImpl& operator=(ISerialPortImpl&& other) = delete;
 
-    public:
         virtual void open(const std::string& device) = 0;
         virtual void open(const std::string& device, boost::system::error_code& ec) = 0;
         virtual bool is_open() const = 0;
@@ -34,7 +32,6 @@ namespace AqualinkAutomate::Interfaces
         virtual void close() = 0;
         virtual void close(boost::system::error_code& ec) = 0;
 
-    public:
         virtual void set_baud_rate(uint32_t rate, boost::system::error_code& ec) = 0;
         virtual void set_character_size(uint8_t bits, boost::system::error_code& ec) = 0;
         virtual void set_flow_control(Serial::FlowControl fc, boost::system::error_code& ec) = 0;
@@ -42,7 +39,6 @@ namespace AqualinkAutomate::Interfaces
         virtual void set_stop_bits(Serial::StopBits sb, boost::system::error_code& ec) = 0;
         virtual void set_read_timeout(std::chrono::milliseconds timeout, boost::system::error_code& ec) = 0;
 
-    public:
         virtual std::size_t read_some(const boost::asio::mutable_buffer& b) = 0;
         virtual std::size_t read_some(const boost::asio::mutable_buffer& b, boost::system::error_code& ec) = 0;
         virtual std::size_t write_some(const boost::asio::const_buffer& b) = 0;

--- a/src/core/interfaces/iserialportprotocol.cpp
+++ b/src/core/interfaces/iserialportprotocol.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/iserialportprotocol.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/iserialportprotocol.h
+++ b/src/core/interfaces/iserialportprotocol.h
@@ -13,11 +13,9 @@ namespace AqualinkAutomate::Interfaces
 		ISerialPortProtocol() = default;
 		virtual ~ISerialPortProtocol() = default;
 
-	public:
 		virtual void Initialize() = 0;
 		virtual void Shutdown() = 0;
 
-	public:
 		virtual void set_baud_rate(uint32_t baud_rate) = 0;
 		virtual void set_character_size(uint8_t size) = 0;
 		virtual void set_parity(Serial::Parity parity) = 0;

--- a/src/core/interfaces/istatus.cpp
+++ b/src/core/interfaces/istatus.cpp
@@ -18,7 +18,7 @@ namespace AqualinkAutomate::Interfaces
 		};
 	}
 
-	void from_json(const nlohmann::json& json_object, IStatus& status)
+	void from_json(const nlohmann::json& /*json_object*/, IStatus& /*status*/)
 	{
 		throw Exceptions::NotImplemented();
 	}

--- a/src/core/interfaces/istatus.h
+++ b/src/core/interfaces/istatus.h
@@ -19,11 +19,9 @@ namespace AqualinkAutomate::Interfaces
 		IStatus(IStatus&& other) = default;
 		virtual ~IStatus() = default;
 
-	public:
 		IStatus& operator=(const IStatus&) = default;
 		IStatus& operator=(IStatus&& other) = default;
 
-	public:
 		virtual std::string_view SourceName() const = 0;
 		virtual std::string_view SourceType() const = 0;
 		virtual std::string_view StatusType() const = 0;

--- a/src/core/interfaces/istatuspublisher.h
+++ b/src/core/interfaces/istatuspublisher.h
@@ -21,10 +21,9 @@ namespace AqualinkAutomate::Interfaces
 		IStatusPublisher() = delete;
 		~IStatusPublisher() = default;
 
-	public:
 		template<typename DEVICE_STATUS>
 			requires std::derived_from<DEVICE_STATUS, Interfaces::IStatus>
-		IStatusPublisher(const DEVICE_STATUS& status)
+		explicit IStatusPublisher(const DEVICE_STATUS& status)
 		{
 			Status(status);
 		}
@@ -35,7 +34,6 @@ namespace AqualinkAutomate::Interfaces
 	public:
 		StatusType Status() const;
 
-	public:
 		template<typename DEVICE_STATUS>
 			requires std::derived_from<DEVICE_STATUS, Interfaces::IStatus>
 		void Status(const DEVICE_STATUS& status)

--- a/src/core/interfaces/iwebroute.cpp
+++ b/src/core/interfaces/iwebroute.cpp
@@ -1,9 +1,2 @@
 #include "interfaces/iwebroute.h"
 
-namespace AqualinkAutomate::Interfaces
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/iwebroute.h
+++ b/src/core/interfaces/iwebroute.h
@@ -30,10 +30,8 @@ namespace AqualinkAutomate::Interfaces
         IWebRouteBase() = default;
         virtual ~IWebRouteBase() = default;
 
-    public:
         virtual std::string_view Route() const = 0;
 
-    public:
         // Returns a mutable Response (not a type-erased message_generator) so the
         // router can stamp response-wide policy — e.g. Cache-Control: no-store on
         // dynamic API data — in one place before serialising. See HTTP_OnRequest.
@@ -83,7 +81,6 @@ namespace AqualinkAutomate::Interfaces
         IWebRoute() = default;
         virtual ~IWebRoute() = default;
 
-	public:
         virtual std::string_view Route() const final
 		{
             return ROUTE_URL;

--- a/src/core/interfaces/iwebsocket.cpp
+++ b/src/core/interfaces/iwebsocket.cpp
@@ -1,9 +1,1 @@
 #include "interfaces/iwebsocket.h"
-
-namespace AqualinkAutomate::Interfaces
-{
-   
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Interfaces

--- a/src/core/interfaces/iwebsocket.h
+++ b/src/core/interfaces/iwebsocket.h
@@ -21,7 +21,6 @@ namespace AqualinkAutomate::Interfaces
         IWebSocketBase() = default;
         virtual ~IWebSocketBase() = default;
 
-    public:
         virtual std::string_view Route() const = 0;
 
         // The entitlement required to complete the upgrade handshake (evaluated
@@ -30,10 +29,8 @@ namespace AqualinkAutomate::Interfaces
         // per-subject payload filtering behind it.
         virtual AccessRequirement RequiredAccess() const { return {}; }
 
-    public:
         virtual std::optional<std::string> DequeueMessage(ConnectionId connId) = 0;
 
-    public:
         virtual ConnectionId OnOpen() = 0;
         virtual void OnMessage(ConnectionId connId, const boost::beast::flat_buffer& buffer) = 0;
         virtual void OnPublish(ConnectionId connId) = 0;
@@ -49,7 +46,6 @@ namespace AqualinkAutomate::Interfaces
         IWebSocket() = default;
         virtual ~IWebSocket() = default;
 
-	public:
         std::string_view Route() const final
         {
             return ROUTE_URL;

--- a/src/core/kernel/auxillary_devices/auxillary_device.cpp
+++ b/src/core/kernel/auxillary_devices/auxillary_device.cpp
@@ -92,21 +92,22 @@ namespace AqualinkAutomate::Kernel
 	AuxillaryHealthStates AuxillaryDevice::Health() const
 	{
 		using AuxillaryTraitsTypes::ErrorCodesTrait;
+		using enum AuxillaryHealthStates;
 
 		if (AuxillaryTraits.Has(ErrorCodesTrait{}))
 		{
 			if (ErrorCodesTrait::TraitValue errors{AuxillaryTraits[ErrorCodesTrait{}]}; 0 != errors.size())
 			{
 				// Presense of errors means the device is unhealthy.
-				return AuxillaryHealthStates::Unhealthy;
+				return Unhealthy;
 			}
-			
+
 			// No errors...assume device is healthy.
-			return AuxillaryHealthStates::Healthy;
+			return Healthy;
 		}
-		
-		// No mechanism available to determine health. 
-		return AuxillaryHealthStates::Unknown;
+
+		// No mechanism available to determine health.
+		return Unknown;
 	}
 
 }

--- a/src/core/kernel/auxillary_devices/auxillary_device.h
+++ b/src/core/kernel/auxillary_devices/auxillary_device.h
@@ -18,23 +18,19 @@ namespace AqualinkAutomate::Kernel
 	{
 	public:
 		AuxillaryDevice();
-		AuxillaryDevice(std::string_view label);
+		explicit AuxillaryDevice(std::string_view label);
 		// Reconstruct with a specific id (used to restore stable ids from the
 		// equipment cache so device UUIDs survive a restart).
 		explicit AuxillaryDevice(boost::uuids::uuid id);
 
-	public:
 		boost::uuids::uuid Id() const;
 
-	public:
 		bool operator==(const AuxillaryDevice& other) const;
 		bool operator==(const boost::uuids::uuid id) const;
 		bool operator==(const std::string& id) const;
 
-	public:
 		bool operator!=(const AuxillaryDevice& other) const;
 
-	public:
 		Traits AuxillaryTraits{};
 
 	public:

--- a/src/core/kernel/auxillary_devices/auxillary_health_states.cpp
+++ b/src/core/kernel/auxillary_devices/auxillary_health_states.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_devices/auxillary_device.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_devices/auxillary_status.cpp
+++ b/src/core/kernel/auxillary_devices/auxillary_status.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_devices/auxillary_status.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_devices/pump_speed.cpp
+++ b/src/core/kernel/auxillary_devices/pump_speed.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_devices/pump_speed.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_devices/pump_type.cpp
+++ b/src/core/kernel/auxillary_devices/pump_type.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_devices/pump_type.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_traits/auxillary_traits.cpp
+++ b/src/core/kernel/auxillary_traits/auxillary_traits.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_traits/auxillary_traits.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_traits/auxillary_traits.h
+++ b/src/core/kernel/auxillary_traits/auxillary_traits.h
@@ -47,7 +47,6 @@ namespace AqualinkAutomate::Kernel
             return ConstTraitValueProxy<Traits, TRAIT_TYPE>(*this, it->second);
         }
 
-    public:
         template<IsTraitType TRAIT_TYPE>
         TraitValueProxy<Traits, TRAIT_TYPE> operator[](const TRAIT_TYPE& trait_type)
         {
@@ -60,14 +59,12 @@ namespace AqualinkAutomate::Kernel
             return Get(trait_type);
         }
 
-    public:
         template<IsTraitType TRAIT_TYPE>
         bool Has(TRAIT_TYPE trait_type) const
         {
             return m_Traits.contains(trait_type.Name());
         }
 
-    public:
         template<IsTraitType TRAIT_TYPE>
         bool Remove(TRAIT_TYPE trait_type)
         {
@@ -82,7 +79,6 @@ namespace AqualinkAutomate::Kernel
             return (0 < m_Traits.erase(trait_type.Name()));
         }
 
-    public:
         template<IsTraitType TRAIT_TYPE>
         void Set(const TRAIT_TYPE& trait_type, TRAIT_TYPE::TraitValue trait_value)
         {
@@ -108,7 +104,6 @@ namespace AqualinkAutomate::Kernel
             }
         }
 
-    public:
         template<IsTraitType TRAIT_TYPE>
         std::optional<typename TRAIT_TYPE::TraitValue> TryGet(const TRAIT_TYPE& trait_type) const
         {
@@ -135,7 +130,6 @@ namespace AqualinkAutomate::Kernel
             return std::nullopt;
         }
 
-    public:
         template<IsTraitType TRAIT_TYPE>
         std::expected<std::reference_wrapper<Traits>, boost::system::error_code> TrySet(const TRAIT_TYPE& trait_type, TRAIT_TYPE::TraitValue trait_value)
         {

--- a/src/core/kernel/auxillary_traits/auxillary_traits_base.cpp
+++ b/src/core/kernel/auxillary_traits/auxillary_traits_base.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_traits/auxillary_traits_base.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_traits/auxillary_traits_base.h
+++ b/src/core/kernel/auxillary_traits/auxillary_traits_base.h
@@ -10,6 +10,8 @@ namespace AqualinkAutomate::Kernel
     class TraitType
     {
     public:
+        virtual ~TraitType() = default;
+
         using TraitKey = std::string;
         using TraitValue = TRAIT_TYPE;
 

--- a/src/core/kernel/auxillary_traits/auxillary_traits_helpers.cpp
+++ b/src/core/kernel/auxillary_traits/auxillary_traits_helpers.cpp
@@ -15,41 +15,43 @@ namespace AqualinkAutomate::Kernel::AuxillaryTraitsTypes
 		// to a human-readable string. Returns std::nullopt when no status is available for the type.
 		std::optional<std::string_view> ResolveStatusString(const AuxillaryDevice& device, AuxillaryTypes type)
 		{
+			using enum AuxillaryTypes;
+
 			switch (type)
 			{
-			case AuxillaryTypes::Auxillary:
-			case AuxillaryTypes::Cleaner:
-			case AuxillaryTypes::Spillover:
-			case AuxillaryTypes::Sprinkler:
+			case Auxillary:
+			case Cleaner:
+			case Spillover:
+			case Sprinkler:
 				if (auto status = device.AuxillaryTraits.TryGet(AuxillaryStatusTrait{}); status.has_value())
 				{
 					return magic_enum::enum_name(status.value());
 				}
 				break;
 
-			case AuxillaryTypes::Chlorinator:
+			case Chlorinator:
 				if (auto status = device.AuxillaryTraits.TryGet(ChlorinatorStatusTrait{}); status.has_value())
 				{
 					return magic_enum::enum_name(status.value());
 				}
 				break;
 
-			case AuxillaryTypes::Heater:
+			case Heater:
 				if (auto status = device.AuxillaryTraits.TryGet(HeaterStatusTrait{}); status.has_value())
 				{
 					return magic_enum::enum_name(status.value());
 				}
 				break;
 
-			case AuxillaryTypes::Pump:
+			case Pump:
 				if (auto status = device.AuxillaryTraits.TryGet(PumpStatusTrait{}); status.has_value())
 				{
 					return magic_enum::enum_name(status.value());
 				}
 				break;
 
-			case AuxillaryTypes::Light:
-			case AuxillaryTypes::Unknown:
+			case Light:
+			case Unknown:
 			default:
 				// No status mapping for this device type.
 				break;

--- a/src/core/kernel/auxillary_traits/auxillary_traits_proxy.cpp
+++ b/src/core/kernel/auxillary_traits/auxillary_traits_proxy.cpp
@@ -1,9 +1,1 @@
 #include "kernel/auxillary_traits/auxillary_traits_proxy.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/auxillary_traits/auxillary_traits_proxy.h
+++ b/src/core/kernel/auxillary_traits/auxillary_traits_proxy.h
@@ -26,20 +26,17 @@ namespace AqualinkAutomate::Kernel
         {
         }
 
-    public:
         TraitValueProxy& operator=(TRAIT_TYPE::TraitValue trait_value)
         {
             m_TraitsRef.Set(TRAIT_TYPE{}, trait_value);
             return *this;
         }
 
-    public:
         operator auto() const
         {
             return CastOrThrow<ValueType>(m_ValueAny);
         }
 
-    public:
         Reference operator*()
         {
             return CastOrThrow<Reference>(m_ValueAny);
@@ -88,13 +85,11 @@ namespace AqualinkAutomate::Kernel
         {
         }
 
-    public:
         operator auto() const
         {
             return CastOrThrow<ValueType>(m_ValueAny);
         }
 
-    public:
         Reference operator*() const
         {
             return CastOrThrow<Reference>(m_ValueAny);

--- a/src/core/kernel/body_of_water.h
+++ b/src/core/kernel/body_of_water.h
@@ -19,7 +19,6 @@ namespace AqualinkAutomate::Kernel
 		BodyOfWater(BodyOfWater&& other) noexcept = default;
 		BodyOfWater& operator=(BodyOfWater&& other) noexcept = default;
 
-	public:
 		BodyOfWaterIds Id() const;
 		const std::string& Label() const;
 

--- a/src/core/kernel/circulation.cpp
+++ b/src/core/kernel/circulation.cpp
@@ -1,9 +1,1 @@
 #include "kernel/circulation.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/data_hub.h
+++ b/src/core/kernel/data_hub.h
@@ -105,7 +105,6 @@ namespace AqualinkAutomate::Kernel
 	// EQUIPMENT STATUS
 	//---------------------------------------------------------------------
 
-	public:
 		Utility::TimeoutDurationStringConverter TimeoutRemaining;
 		std::chrono::year_month_day Date{ std::chrono::year{2000}, std::chrono::month{1}, std::chrono::day{1} };
 		std::chrono::hh_mm_ss<std::chrono::milliseconds> Time{ std::chrono::milliseconds(0) };
@@ -114,7 +113,6 @@ namespace AqualinkAutomate::Kernel
 	// EQUIPMENT VERSIONS
 	//---------------------------------------------------------------------
 
-	public:
 		Kernel::EquipmentVersions EquipmentVersions;
 
 	//---------------------------------------------------------------------
@@ -148,9 +146,10 @@ namespace AqualinkAutomate::Kernel
 
 		bool SpaMode() const
 		{
-			return CirculationModes::Spa == CirculationMode
-				|| CirculationModes::SpaFill == CirculationMode
-				|| CirculationModes::SpaDrain == CirculationMode;
+			using enum CirculationModes;
+			return Spa == CirculationMode
+				|| SpaFill == CirculationMode
+				|| SpaDrain == CirculationMode;
 		}
 
 		bool InCleanMode{ false };
@@ -159,7 +158,6 @@ namespace AqualinkAutomate::Kernel
 	// BODIES OF WATER
 	//---------------------------------------------------------------------
 
-	public:
 		// single_body_kind selects which body a SingleBody configuration creates: Pool (default)
 		// or Spa. Pool-only and spa-only installs are indistinguishable on the wire (single body,
 		// single equipment - set by the Power Center DIP switches), so a spa-only install can only
@@ -190,7 +188,6 @@ namespace AqualinkAutomate::Kernel
 		std::optional<Kernel::Temperature> FreezeProtectPoint() const;
 		Kernel::TemperatureUnits SystemTemperatureUnits() const;
 
-	public:
 		// Wall-clock time each temperature channel was last written from the wire (nullopt until
 		// first set). The controller only reports temperatures while the filter pump runs, and for
 		// a combo system only for the active body, so a cached value can persist long after it
@@ -219,7 +216,6 @@ namespace AqualinkAutomate::Kernel
 		// --temperature-staleness-threshold; default 10 minutes.
 		std::chrono::seconds TemperatureStalenessThreshold{ std::chrono::seconds(600) };
 
-	public:
 		void AirTemp(const Kernel::Temperature& air_temp);
 		void PoolTemp(const Kernel::Temperature& pool_temp);
 		void SpaTemp(const Kernel::Temperature& spa_temp);
@@ -265,7 +261,6 @@ namespace AqualinkAutomate::Kernel
 		Kernel::pH pH() const;
 		ppm_quantity SaltLevel() const;
 
-	public:
 		void ORP(const Kernel::ORP& orp);
 		void pH(const Kernel::pH& pH);
 		void SaltLevel(const ppm_quantity& salt_level_in_ppm);
@@ -291,7 +286,6 @@ namespace AqualinkAutomate::Kernel
 		std::vector<std::shared_ptr<Kernel::AuxillaryDevice>> Pumps() const;
 		std::vector<std::shared_ptr<Kernel::AuxillaryDevice>> FilterPumps() const;
 
-	public:
 		// Count / existence predicates that avoid materialising a vector for the
 		// common size() / empty() checks on the status hot path.
 		uint32_t CountOfType(AuxillaryTraitsTypes::AuxillaryTypes type) const;
@@ -299,7 +293,6 @@ namespace AqualinkAutomate::Kernel
 		uint32_t CountFilterPumps() const;
 		bool HasAnyFilterPumps() const;
 
-	public:
 		[[deprecated("Use FilterPumps() instead; that returns a collection of pumps as there might be more than one")]]
 		std::optional<std::shared_ptr<Kernel::AuxillaryDevice>> FilterPump();
 

--- a/src/core/kernel/device_graph/device_graph.cpp
+++ b/src/core/kernel/device_graph/device_graph.cpp
@@ -18,10 +18,10 @@ namespace AqualinkAutomate::Kernel
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("DeviceGraph::Add", std::source_location::current());
 
-		auto insert_device_in_graph = [&](auto& m_DevicesGraph, auto& source_vertex, auto& ptr) -> void
+		auto insert_device_in_graph = [&](auto& devices_graph, auto& source_vertex, auto& ptr) -> void
 		{
-			auto target_vertex = boost::add_vertex(ptr, m_DevicesGraph);
-			auto edge = boost::add_edge(source_vertex, target_vertex, m_DevicesGraph);
+			auto target_vertex = boost::add_vertex(ptr, devices_graph);
+			auto edge = boost::add_edge(source_vertex, target_vertex, devices_graph);
 		};
 
 		if (nullptr == device)

--- a/src/core/kernel/device_graph/device_graph.h
+++ b/src/core/kernel/device_graph/device_graph.h
@@ -27,21 +27,17 @@ namespace AqualinkAutomate::Kernel
 	public:
 		DevicesGraph();
 
-	public:
 		void Add(std::shared_ptr<AuxillaryDevice> device);
 		bool Contains(std::shared_ptr<AuxillaryDevice> device) const;
 		void Remove(const std::shared_ptr<AuxillaryDevice>& device);
 
-	public:
 		uint32_t CountByLabel(std::string_view device_label) const;
 		bool HasAnyByLabel(std::string_view device_label) const;
 		std::vector<std::shared_ptr<AuxillaryDevice>> FindByLabel(std::string_view device_label) const;
 
-	public:
 		uint32_t CountById(const boost::uuids::uuid& id) const;
 		std::shared_ptr<AuxillaryDevice> FindById(const boost::uuids::uuid& id) const;
 
-	public:
 		template<typename TRAIT_TYPE>
 		uint32_t CountByTrait(TRAIT_TYPE trait_type) const
 		{

--- a/src/core/kernel/device_graph/device_graph_filter_by_id.h
+++ b/src/core/kernel/device_graph/device_graph_filter_by_id.h
@@ -12,7 +12,6 @@ namespace AqualinkAutomate::Kernel
 	public:
 		DeviceIdFilter(const DevicesGraphType& graph, const boost::uuids::uuid& device_id);
 
-	public:
 		bool operator()(const DevicesGraphType::edge_descriptor) const;
 		bool operator()(const DevicesGraphType::vertex_descriptor vd) const;
 

--- a/src/core/kernel/device_graph/device_graph_filter_by_label.h
+++ b/src/core/kernel/device_graph/device_graph_filter_by_label.h
@@ -13,7 +13,6 @@ namespace AqualinkAutomate::Kernel
 	public:
 		DeviceLabelFilter(const DevicesGraphType& graph, std::string_view device_label);
 
-	public:
 		bool operator()(const DevicesGraphType::edge_descriptor) const;
 		bool operator()(const DevicesGraphType::vertex_descriptor vd) const;
 

--- a/src/core/kernel/device_graph/device_graph_filter_by_trait.cpp
+++ b/src/core/kernel/device_graph/device_graph_filter_by_trait.cpp
@@ -1,9 +1,1 @@
 #include "kernel/device_graph/device_graph_filter_by_trait.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/device_graph/device_graph_filter_by_trait.h
+++ b/src/core/kernel/device_graph/device_graph_filter_by_trait.h
@@ -28,7 +28,6 @@ namespace AqualinkAutomate::Kernel
 		{
 		}
 
-	public:
 		bool operator()(const DevicesGraphType::edge_descriptor) const { return false; }
 		bool operator()(const DevicesGraphType::vertex_descriptor vd) const
 		{

--- a/src/core/kernel/device_graph/device_graph_types.cpp
+++ b/src/core/kernel/device_graph/device_graph_types.cpp
@@ -1,9 +1,1 @@
 #include "kernel/device_graph/device_graph.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/flow_rate.h
+++ b/src/core/kernel/flow_rate.h
@@ -8,14 +8,12 @@ namespace AqualinkAutomate::Kernel
 	class FlowRate
 	{
 	public:
-		FlowRate(const Units::gallons_per_minute& rate_in_gpm);
-		FlowRate(const Units::liters_per_minute& rate_in_lpm);
+		explicit FlowRate(const Units::gallons_per_minute& rate_in_gpm);
+		explicit FlowRate(const Units::liters_per_minute& rate_in_lpm);
 
-	public:
 		Units::gallons_per_minute InGPM() const;
 		Units::liters_per_minute InLPM() const;
 
-	public:
 		static FlowRate ConvertToFlowRateInGPM(double flow_rate_in_gpm);
 		static FlowRate ConvertToFlowRateInLPM(double flow_rate_in_lpm);
 

--- a/src/core/kernel/hub_events/data_hub_config_event.h
+++ b/src/core/kernel/hub_events/data_hub_config_event.h
@@ -12,7 +12,7 @@ namespace AqualinkAutomate::Kernel
 	class DataHub_ConfigEvent : public Hub_Event
 	{
 	public:
-		DataHub_ConfigEvent(Hub_EventTypes event_type);
+		explicit DataHub_ConfigEvent(Hub_EventTypes event_type);
 		~DataHub_ConfigEvent() override = default;
 	};
 

--- a/src/core/kernel/hub_events/data_hub_config_event_button_state_change.h
+++ b/src/core/kernel/hub_events/data_hub_config_event_button_state_change.h
@@ -17,12 +17,10 @@ namespace AqualinkAutomate::Kernel
 		DataHub_ConfigEvent_ButtonStateChange(const boost::uuids::uuid& button_id, std::string_view status, std::string_view label);
 		~DataHub_ConfigEvent_ButtonStateChange() override = default;
 
-	public:
 		boost::uuids::uuid ButtonId() const;
 		std::string_view Status() const;
 		std::string_view Label() const;
 
-	public:
 		nlohmann::json ToJSON() const override;
 
 	private:

--- a/src/core/kernel/hub_events/data_hub_config_event_chemistry.cpp
+++ b/src/core/kernel/hub_events/data_hub_config_event_chemistry.cpp
@@ -12,10 +12,7 @@ namespace AqualinkAutomate::Kernel
 {
 
 	DataHub_ConfigEvent_Chemistry::DataHub_ConfigEvent_Chemistry() :
-		DataHub_ConfigEvent(Hub_EventTypes::Chemistry),
-		m_ORP(std::nullopt),
-		m_pH(std::nullopt),
-		m_SaltLevel(std::nullopt)
+		DataHub_ConfigEvent(Hub_EventTypes::Chemistry)
 	{
 	}
 

--- a/src/core/kernel/hub_events/data_hub_config_event_chemistry.h
+++ b/src/core/kernel/hub_events/data_hub_config_event_chemistry.h
@@ -18,23 +18,20 @@ namespace AqualinkAutomate::Kernel
 		DataHub_ConfigEvent_Chemistry();
 		~DataHub_ConfigEvent_Chemistry() override = default;
 
-	public:
 		std::optional<Kernel::ORP> ORP() const;
 		std::optional<Kernel::pH> pH() const;
 		std::optional<Units::ppm_quantity> SaltLevel() const;
 
-	public:
 		void ORP(const Kernel::ORP& orp);
 		void pH(const Kernel::pH& pH);
 		void SaltLevel(const Units::ppm_quantity& salt_level_in_ppm);
 
-	public:
 		nlohmann::json ToJSON() const override;
 
 	private:
-		std::optional<Kernel::ORP> m_ORP;
-		std::optional<Kernel::pH> m_pH;
-		std::optional<Units::ppm_quantity> m_SaltLevel;
+		std::optional<Kernel::ORP> m_ORP{ std::nullopt };
+		std::optional<Kernel::pH> m_pH{ std::nullopt };
+		std::optional<Units::ppm_quantity> m_SaltLevel{ std::nullopt };
 	};
 
 }

--- a/src/core/kernel/hub_events/data_hub_config_event_temperature.cpp
+++ b/src/core/kernel/hub_events/data_hub_config_event_temperature.cpp
@@ -5,12 +5,7 @@ namespace AqualinkAutomate::Kernel
 {
 
 	DataHub_ConfigEvent_Temperature::DataHub_ConfigEvent_Temperature() :
-		DataHub_ConfigEvent(Hub_EventTypes::Temperature),
-		m_PoolTemp(std::nullopt),
-		m_SpaTemp(std::nullopt),
-		m_AirTemp(std::nullopt),
-		m_PoolSetpoint(std::nullopt),
-		m_SpaSetpoint(std::nullopt)
+		DataHub_ConfigEvent(Hub_EventTypes::Temperature)
 	{
 	}
 

--- a/src/core/kernel/hub_events/data_hub_config_event_temperature.h
+++ b/src/core/kernel/hub_events/data_hub_config_event_temperature.h
@@ -16,7 +16,6 @@ namespace AqualinkAutomate::Kernel
 		DataHub_ConfigEvent_Temperature();
 		~DataHub_ConfigEvent_Temperature() override = default;
 
-	public:
 		std::optional<Kernel::Temperature> PoolTemp() const;
 		std::optional<Kernel::Temperature> SpaTemp() const;
 		std::optional<Kernel::Temperature> AirTemp() const;
@@ -25,7 +24,6 @@ namespace AqualinkAutomate::Kernel
 		std::optional<bool> PoolHeater2Enabled() const;
 		std::optional<Kernel::Temperature> SpaSetpoint() const;
 
-	public:
 		void PoolTemp(const Kernel::Temperature& pool);
 		void SpaTemp(const Kernel::Temperature& spa);
 		void AirTemp(const Kernel::Temperature& air);
@@ -34,17 +32,16 @@ namespace AqualinkAutomate::Kernel
 		void PoolHeater2Enabled(bool pool_heater_2_enabled);
 		void SpaSetpoint(const Kernel::Temperature& spa_setpoint);
 
-	public:
 		nlohmann::json ToJSON() const override;
 
 	private:
-		std::optional<Kernel::Temperature> m_PoolTemp;
-		std::optional<Kernel::Temperature> m_SpaTemp;
-		std::optional<Kernel::Temperature> m_AirTemp;
-		std::optional<Kernel::Temperature> m_PoolSetpoint;
+		std::optional<Kernel::Temperature> m_PoolTemp{ std::nullopt };
+		std::optional<Kernel::Temperature> m_SpaTemp{ std::nullopt };
+		std::optional<Kernel::Temperature> m_AirTemp{ std::nullopt };
+		std::optional<Kernel::Temperature> m_PoolSetpoint{ std::nullopt };
 		std::optional<Kernel::Temperature> m_PoolSetpoint2{ std::nullopt };
 		std::optional<bool> m_PoolHeater2Enabled{ std::nullopt };
-		std::optional<Kernel::Temperature> m_SpaSetpoint;
+		std::optional<Kernel::Temperature> m_SpaSetpoint{ std::nullopt };
 	};
 
 }

--- a/src/core/kernel/hub_events/equipment_hub_system_event.h
+++ b/src/core/kernel/hub_events/equipment_hub_system_event.h
@@ -12,7 +12,7 @@ namespace AqualinkAutomate::Kernel
 	class EquipmentHub_SystemEvent : public Hub_Event
 	{
 	public:
-		EquipmentHub_SystemEvent(Hub_EventTypes event_type);
+		explicit EquipmentHub_SystemEvent(Hub_EventTypes event_type);
 		~EquipmentHub_SystemEvent() override = default;
 	};
 

--- a/src/core/kernel/hub_events/equipment_hub_system_event_status_change.h
+++ b/src/core/kernel/hub_events/equipment_hub_system_event_status_change.h
@@ -11,10 +11,9 @@ namespace AqualinkAutomate::Kernel
 	class EquipmentHub_SystemEvent_StatusChange : public EquipmentHub_SystemEvent
 	{
 	public:
-		EquipmentHub_SystemEvent_StatusChange(const Interfaces::IStatus& status);
+		explicit EquipmentHub_SystemEvent_StatusChange(const Interfaces::IStatus& status);
 		~EquipmentHub_SystemEvent_StatusChange() override = default;
 
-	public:
 		nlohmann::json ToJSON() const override;
 
 	private:

--- a/src/core/kernel/hub_events/hub_event.h
+++ b/src/core/kernel/hub_events/hub_event.h
@@ -10,13 +10,11 @@ namespace AqualinkAutomate::Kernel
 	class Hub_Event
 	{
 	public:
-		Hub_Event(Hub_EventTypes event_type);
+		explicit Hub_Event(Hub_EventTypes event_type);
 		virtual ~Hub_Event() = default;
 
-	public:
 		Hub_EventTypes Type() const;
 
-	public:
 		virtual nlohmann::json ToJSON() const = 0;
 
 	private:

--- a/src/core/kernel/hub_events/hub_eventtypes.cpp
+++ b/src/core/kernel/hub_events/hub_eventtypes.cpp
@@ -1,9 +1,1 @@
 #include "kernel/hub_events/hub_eventtypes.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/hub_locator.cpp
+++ b/src/core/kernel/hub_locator.cpp
@@ -1,9 +1,1 @@
 #include "kernel/hub_locator.h"
-
-namespace AqualinkAutomate::Kernel
-{
-
-	
-
-}
-// namespace AqualinkAutomate::Kernel

--- a/src/core/kernel/hub_locator.h
+++ b/src/core/kernel/hub_locator.h
@@ -42,7 +42,6 @@ namespace AqualinkAutomate::Kernel
 			return *this;
 		}
 
-	public:
 		template <RegistrableHub T>
 		std::shared_ptr<T> Find()
 		{
@@ -54,7 +53,6 @@ namespace AqualinkAutomate::Kernel
 			throw Exceptions::Hub_NotFound();
 		}
 
-	public:
 		template <RegistrableHub T>
 		std::shared_ptr<T> TryFind()
 		{
@@ -66,7 +64,6 @@ namespace AqualinkAutomate::Kernel
 			return nullptr;
 		}
 
-	public:
 		template <RegistrableHub T>
 		HubLocator& Unregister()
 		{

--- a/src/core/kernel/orp.h
+++ b/src/core/kernel/orp.h
@@ -12,20 +12,17 @@ namespace AqualinkAutomate::Kernel
     class ORP
     {
     public:
-        ORP(boost::float64_t value_in_mV);
+        ORP(boost::float64_t value_in_mV);  // NOSONAR(cpp:S1709) — implicit numeric conversion is part of this value-wrapper's contract (see operator= / operator== on float64_t)
         ORP(const ORP& other) = default;
         ORP& operator=(const ORP& other) = default;
         ORP(ORP&& other) noexcept = default;
         ORP& operator=(ORP&& other) noexcept = default;
 
-    public:
         Units::millivolt_quantity operator()() const;
 
-    public:
         ORP& operator=(const Units::millivolt_quantity& value_in_mV);
         ORP& operator=(boost::float64_t value_in_mV);
 
-    public:
         bool operator==(const ORP& other) const;
         bool operator==(const boost::float64_t value_in_mV) const;
         bool operator==(const Units::millivolt_quantity& value_in_mV) const;

--- a/src/core/kernel/ph.h
+++ b/src/core/kernel/ph.h
@@ -11,15 +11,12 @@ namespace AqualinkAutomate::Kernel
 		static constexpr boost::float32_t MAXIMUM_PH_VALUE = 14.0f;
 
 	public:
-		pH(boost::float32_t value);
+		pH(boost::float32_t value);  // NOSONAR(cpp:S1709) — implicit numeric conversion is part of this value-wrapper's contract (see operator= on float32_t)
 
-	public:
 		boost::float32_t operator()() const;
 
-	public:
 		pH& operator=(boost::float32_t value);
 
-	public:
 		bool operator==(const pH& other) const;
 
 	private:

--- a/src/core/kernel/pool_configurations.cpp
+++ b/src/core/kernel/pool_configurations.cpp
@@ -5,12 +5,14 @@ namespace AqualinkAutomate::Kernel
 
 	std::string ToDisplayString(PoolConfigurations config)
 	{
+		using enum PoolConfigurations;
+
 		switch (config)
 		{
-			case PoolConfigurations::SingleBody:               return "Single Body";
-			case PoolConfigurations::DualBody_SharedEquipment: return "Dual Body (Shared Equipment)";
-			case PoolConfigurations::DualBody_DualEquipment:   return "Dual Body (Dual Equipment)";
-			case PoolConfigurations::Unknown:                  return "Unknown";
+			case SingleBody:               return "Single Body";
+			case DualBody_SharedEquipment: return "Dual Body (Shared Equipment)";
+			case DualBody_DualEquipment:   return "Dual Body (Dual Equipment)";
+			case Unknown:                  return "Unknown";
 		}
 
 		return "Unknown";

--- a/src/core/kernel/statistics_hub.h
+++ b/src/core/kernel/statistics_hub.h
@@ -18,21 +18,17 @@ namespace AqualinkAutomate::Kernel
 		StatisticsHub();
 		~StatisticsHub() override = default;
 
-	public:
 		// The total number of messages sent or received.
 		// This is a generic counter that works with any enum type (e.g., JandyMessageIds, PentairMessageIds).
 		// Use ++MessageCounts[SomeMessageIdEnum::Value] to increment.
 		Utility::SignallingStatsCounter MessageCounts;
 
-	public:
 		Utility::BandwidthMetricsCollection BandwidthMetrics;
 
-	public:
 		// Latency metrics for serial and message processing operations.
 		// These track percentiles (p1, p50, p95, p99) in real-time.
 		Utility::SerialLatencyMetrics LatencyMetrics;
 
-	public:
 		struct SerialMetrics
 		{
 			uint64_t MessageErrorRate{ 0 };
@@ -45,7 +41,6 @@ namespace AqualinkAutomate::Kernel
 
 		SerialMetrics Serial;
 
-	public:
 		struct MessageErrorMetrics
 		{
 			uint64_t ChecksumFailures{ 0 };

--- a/src/core/kernel/system_boards.cpp
+++ b/src/core/kernel/system_boards.cpp
@@ -5,33 +5,35 @@ namespace AqualinkAutomate::Kernel
 
 	std::string ToDisplayString(SystemBoards board)
 	{
+		using enum SystemBoards;
+
 		switch (board)
 		{
-			case SystemBoards::RS4_Only:    return "RS-4 Only";
-			case SystemBoards::RS6_Only:    return "RS-6 Only";
-			case SystemBoards::RS8_Only:    return "RS-8 Only";
+			case RS4_Only:    return "RS-4 Only";
+			case RS6_Only:    return "RS-6 Only";
+			case RS8_Only:    return "RS-8 Only";
 
-			case SystemBoards::RS2_6_Dual:  return "RS-2/6 Dual";
-			case SystemBoards::RS2_10_Dual: return "RS-2/10 Dual";
-			case SystemBoards::RS2_14_Dual: return "RS-2/14 Dual";
-			case SystemBoards::RS2_22_Dual: return "RS-2/22 Dual";
-			case SystemBoards::RS2_30_Dual: return "RS-2/30 Dual";
+			case RS2_6_Dual:  return "RS-2/6 Dual";
+			case RS2_10_Dual: return "RS-2/10 Dual";
+			case RS2_14_Dual: return "RS-2/14 Dual";
+			case RS2_22_Dual: return "RS-2/22 Dual";
+			case RS2_30_Dual: return "RS-2/30 Dual";
 
-			case SystemBoards::RS4_Combo:   return "RS-4 Combo";
-			case SystemBoards::RS6_Combo:   return "RS-6 Combo";
-			case SystemBoards::RS8_Combo:   return "RS-8 Combo";
-			case SystemBoards::RS12_Combo:  return "RS-12 Combo";
-			case SystemBoards::RS16_Combo:  return "RS-16 Combo";
-			case SystemBoards::RS24_Combo:  return "RS-24 Combo";
-			case SystemBoards::RS32_Combo:  return "RS-32 Combo";
+			case RS4_Combo:   return "RS-4 Combo";
+			case RS6_Combo:   return "RS-6 Combo";
+			case RS8_Combo:   return "RS-8 Combo";
+			case RS12_Combo:  return "RS-12 Combo";
+			case RS16_Combo:  return "RS-16 Combo";
+			case RS24_Combo:  return "RS-24 Combo";
+			case RS32_Combo:  return "RS-32 Combo";
 
-			case SystemBoards::PD4_Only:    return "PD-4 Only";
-			case SystemBoards::PD8_Only:    return "PD-8 Only";
-			case SystemBoards::PD4_Combo:   return "PD-4 Combo";
-			case SystemBoards::PD6_Combo:   return "PD-6 Combo";
-			case SystemBoards::PD8_Combo:   return "PD-8 Combo";
+			case PD4_Only:    return "PD-4 Only";
+			case PD8_Only:    return "PD-8 Only";
+			case PD4_Combo:   return "PD-4 Combo";
+			case PD6_Combo:   return "PD-6 Combo";
+			case PD8_Combo:   return "PD-8 Combo";
 
-			case SystemBoards::Unknown:     return "Unknown";
+			case Unknown:     return "Unknown";
 		}
 
 		return "Unknown";

--- a/src/core/kernel/temperature.h
+++ b/src/core/kernel/temperature.h
@@ -17,14 +17,13 @@ namespace AqualinkAutomate::Kernel
 	class Temperature
 	{
 	public:
-		Temperature(const boost::units::quantity<boost::units::absolute<boost::units::celsius::temperature>>& degrees_celsius);
-		Temperature(const boost::units::quantity<boost::units::absolute<boost::units::fahrenheit::temperature>>& degrees_fahrenheit);
+		explicit Temperature(const boost::units::quantity<boost::units::absolute<boost::units::celsius::temperature>>& degrees_celsius);
+		explicit Temperature(const boost::units::quantity<boost::units::absolute<boost::units::fahrenheit::temperature>>& degrees_fahrenheit);
 		Temperature(const Temperature& other) = default;
 		Temperature& operator=(const Temperature& other) = default;
 		Temperature(Temperature&& other) noexcept = default;
 		Temperature& operator=(Temperature&& other) noexcept = default;
 
-	public:
 		// Compares the underlying Kelvin quantity directly (no unit-conversion round-trip), so two
 		// temperatures built from the same reading compare equal.
 		bool operator==(const Temperature& other) const = default;
@@ -32,7 +31,6 @@ namespace AqualinkAutomate::Kernel
 		boost::units::quantity<boost::units::absolute<boost::units::celsius::temperature>> InCelsius() const;
 		boost::units::quantity<boost::units::absolute<boost::units::fahrenheit::temperature>> InFahrenheit() const;
 
-	public:
 		static Temperature ConvertToTemperatureInCelsius(double degrees_celsius);
 		static Temperature ConvertToTemperatureInFahrenheit(double degrees_fahrenheit);
 

--- a/src/core/logging/logging.h
+++ b/src/core/logging/logging.h
@@ -90,60 +90,62 @@ namespace AqualinkAutomate::Logging
 
 		auto GetGlobalLogger = [](auto lookup_channel) -> Logger&
 		{
+			using enum Channel;
+
 			switch (lookup_channel)
 			{
-			case Channel::Certificates:
+			case Certificates:
 				return GlobalLogger_Certificates::get();
 
-			case Channel::Coroutines:
+			case Coroutines:
 				return GlobalLogger_Coroutines::get();
 
-			case Channel::Developer:
+			case Developer:
 				return GlobalLogger_Developer::get();
 
-			case Channel::Devices:
+			case Devices:
 				return GlobalLogger_Devices::get();
 
-			case Channel::Equipment:
+			case Equipment:
 				return GlobalLogger_Equipment::get();
 
-			case Channel::Exceptions:
+			case Exceptions:
 				return GlobalLogger_Exceptions::get();
 
-			case Channel::Main:
+			case Main:
 				return GlobalLogger_Main::get();
 
-			case Channel::Messages:
+			case Messages:
 				return GlobalLogger_Messages::get();
 
-			case Channel::Mqtt:
+			case Mqtt:
 				return GlobalLogger_Mqtt::get();
 
-			case Channel::Navigation:
+			case Navigation:
 				return GlobalLogger_Navigation::get();
 
-			case Channel::Options:
+			case Options:
 				return GlobalLogger_Options::get();
 
-			case Channel::Platform:
+			case Platform:
 				return GlobalLogger_Platform::get();
 
-			case Channel::Profiling:
+			case Profiling:
 				return GlobalLogger_Profiling::get();
 
-			case Channel::Protocol:
+			case Protocol:
 				return GlobalLogger_Protocol::get();
 
-			case Channel::Scraping:
+			case Scraping:
 				return GlobalLogger_Scraping::get();
 
-			case Channel::Serial:
+			case Serial:
 				return GlobalLogger_Serial::get();
 
-			case Channel::Signals:
+			case Signals:
 				return GlobalLogger_Signals::get();
 
-			case Channel::Web:
+			case Web:
 				return GlobalLogger_Web::get();
 
 			default:

--- a/src/core/logging/logging_attributes.h
+++ b/src/core/logging/logging_attributes.h
@@ -21,11 +21,3 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(source_file, "File", std::string)
 // records that carry it, and every operational sink is built through the shared
 // filter that excludes it (see sinks/sink_filters.h).
 BOOST_LOG_ATTRIBUTE_KEYWORD(is_audit, "IsAudit", bool)
-
-namespace AqualinkAutomate::Logging
-{
-
-	//
-
-}
-// namespace AqualinkAutomate::Logging

--- a/src/core/logging/logging_severity_filter.cpp
+++ b/src/core/logging/logging_severity_filter.cpp
@@ -45,23 +45,23 @@ namespace AqualinkAutomate::Logging
 		}
 		// namespace (anonymous)
 
-		void SetGlobalFilterLevel(Severity severity)
+		void SetGlobalFilterLevel(Severity severity_level)
 		{
-			magic_enum::enum_for_each<Channel>([severity](auto const& channel)
+			magic_enum::enum_for_each<Channel>([severity_level](auto const& channel_entry)
 				{
-					SetChannelFilterLevel(channel.value, severity);
+					SetChannelFilterLevel(channel_entry.value, severity_level);
 				}
 			);
 		}
 
-		void SetChannelFilterLevel(Channel channel, Severity severity)
+		void SetChannelFilterLevel(Channel channel_id, Severity severity_level)
 		{
-			MinimumSeverityLevelPerChannel()[ChannelIndex(channel)] = severity;
+			MinimumSeverityLevelPerChannel()[ChannelIndex(channel_id)] = severity_level;
 		}
 
-		Severity GetChannelFilterLevel(Channel channel)
+		Severity GetChannelFilterLevel(Channel channel_id)
 		{
-			return MinimumSeverityLevelPerChannel()[ChannelIndex(channel)];
+			return MinimumSeverityLevelPerChannel()[ChannelIndex(channel_id)];
 		}
 
 		bool ShouldLog(Channel channel_id, Severity severity_level)
@@ -69,15 +69,15 @@ namespace AqualinkAutomate::Logging
 			return severity_level >= MinimumSeverityLevelPerChannel()[ChannelIndex(channel_id)];
 		}
 
-		bool PerChannelTest(boost::log::value_ref<Channel, tag::channel> const& channel, boost::log::value_ref<Severity, tag::severity> const& severity)
+		bool PerChannelTest(boost::log::value_ref<Channel, tag::channel> const& channel_ref, boost::log::value_ref<Severity, tag::severity> const& severity_ref)
 		{
-			if (!channel || !severity)
+			if (!channel_ref || !severity_ref)
 			{
 				// Missing channel/severity attributes default to the configured channel filter.
-				return (severity ? (*severity >= GetChannelFilterLevel(DEFAULT_CHANNEL)) : true);
+				return (severity_ref ? (*severity_ref >= GetChannelFilterLevel(DEFAULT_CHANNEL)) : true);
 			}
 
-			return (*severity >= MinimumSeverityLevelPerChannel()[ChannelIndex(*channel)]);
+			return (*severity_ref >= MinimumSeverityLevelPerChannel()[ChannelIndex(*channel_ref)]);
 		}
 	}
 	// namespace SeverityFiltering

--- a/src/core/mqtt/ha_discovery.cpp
+++ b/src/core/mqtt/ha_discovery.cpp
@@ -795,8 +795,7 @@ namespace AqualinkAutomate::Mqtt
 
 		if (auto data_hub = m_DataHub.lock())
 		{
-			auto model = data_hub->EquipmentVersions.ModelNumber();
-			if (!model.empty())
+			if (auto model = data_hub->EquipmentVersions.ModelNumber(); !model.empty())
 			{
 				device["model"] = model;
 			}

--- a/src/core/mqtt/mqtt_client.h
+++ b/src/core/mqtt/mqtt_client.h
@@ -61,7 +61,6 @@ namespace AqualinkAutomate::Mqtt
 		MqttClient(const MqttClient&) = delete;
 		MqttClient& operator=(const MqttClient&) = delete;
 
-	public:
 		struct WillConfig
 		{
 			std::string topic;
@@ -71,7 +70,6 @@ namespace AqualinkAutomate::Mqtt
 
 		void SetWill(const std::string& topic, const std::string& payload, bool retain = true);
 
-	public:
 		void Start();
 		void Stop() noexcept;
 		void Poll();
@@ -88,7 +86,6 @@ namespace AqualinkAutomate::Mqtt
 		std::string BuildTopic(const std::string& subtopic) const;
 		const std::string& TopicPrefix() const noexcept;
 
-	public:
 		// Read-only diagnostics accessors. Safe to call from the HTTP handler: the
 		// client is single-threaded and the handler runs on the same io_context
 		// thread, so no synchronisation is required.

--- a/src/core/mqtt/mqtt_hub.cpp
+++ b/src/core/mqtt/mqtt_hub.cpp
@@ -887,9 +887,7 @@ namespace AqualinkAutomate::Mqtt
 
 	std::string MqttHub::ExtractCommand(const std::string& topic) const
 	{
-		std::string prefix = m_Client->BuildTopic(std::format("{}/", COMMAND_PREFIX));
-
-		if (topic.find(prefix) == 0)
+		if (std::string prefix = m_Client->BuildTopic(std::format("{}/", COMMAND_PREFIX)); topic.find(prefix) == 0)
 		{
 			return topic.substr(prefix.length());
 		}

--- a/src/core/mqtt/mqtt_hub.h
+++ b/src/core/mqtt/mqtt_hub.h
@@ -59,7 +59,6 @@ namespace AqualinkAutomate::Mqtt
 		MqttHub(MqttHub&&) = delete;
 		MqttHub& operator=(MqttHub&&) = delete;
 
-	public:
 		//---------------------------------------------------------------------
 		// LIFECYCLE
 		//---------------------------------------------------------------------

--- a/src/core/mqtt/mqtt_integration.cpp
+++ b/src/core/mqtt/mqtt_integration.cpp
@@ -36,17 +36,19 @@ namespace AqualinkAutomate::Mqtt
 		/// Convert CommandResult enum to a string for MQTT responses.
 		std::string CommandResultToString(Interfaces::ICommandDispatcher::CommandResult result)
 		{
+			using enum Interfaces::ICommandDispatcher::CommandResult;
+
 			switch (result)
 			{
-			case Interfaces::ICommandDispatcher::CommandResult::Success:
+			case Success:
 				return "success";
-			case Interfaces::ICommandDispatcher::CommandResult::DeviceNotFound:
+			case DeviceNotFound:
 				return "device_not_found";
-			case Interfaces::ICommandDispatcher::CommandResult::NoSerialAdapter:
+			case NoSerialAdapter:
 				return "no_serial_adapter";
-			case Interfaces::ICommandDispatcher::CommandResult::UnknownEquipmentType:
+			case UnknownEquipmentType:
 				return "unknown_equipment_type";
-			case Interfaces::ICommandDispatcher::CommandResult::InvalidValue:
+			case InvalidValue:
 				return "invalid_value";
 			default:
 				return "error";
@@ -657,7 +659,7 @@ namespace AqualinkAutomate::Mqtt
 
 		// Register refresh command - forces status refresh
 		m_Hub->RegisterCommand("refresh",
-			[weak_hub](const std::string& topic, const nlohmann::json& /*payload*/)
+			[weak_hub](const std::string& /*topic*/, const nlohmann::json& /*payload*/)
 			{
 				LogDebug(Channel::Mqtt, "Received refresh command");
 				try
@@ -870,7 +872,7 @@ namespace AqualinkAutomate::Mqtt
 		if (!m_Hub->HasCommand("chlorinator/percentage"))
 		{
 			m_Hub->RegisterCommand("chlorinator/percentage",
-				[weak_dispatcher](const std::string& topic, const nlohmann::json& payload)
+				[weak_dispatcher](const std::string& /*topic*/, const nlohmann::json& payload)
 				{
 					LogDebug(Channel::Mqtt, "Received chlorinator percentage command");
 					try
@@ -897,7 +899,7 @@ namespace AqualinkAutomate::Mqtt
 		if (!m_Hub->HasCommand("chlorinator/boost"))
 		{
 			m_Hub->RegisterCommand("chlorinator/boost",
-				[weak_dispatcher](const std::string& topic, const nlohmann::json& payload)
+				[weak_dispatcher](const std::string& /*topic*/, const nlohmann::json& payload)
 				{
 					LogDebug(Channel::Mqtt, "Received chlorinator boost command");
 					try

--- a/src/core/mqtt/mqtt_integration.h
+++ b/src/core/mqtt/mqtt_integration.h
@@ -38,7 +38,6 @@ namespace AqualinkAutomate::Mqtt
 		MqttIntegration(MqttIntegration&&) = delete;
 		MqttIntegration& operator=(MqttIntegration&&) = delete;
 
-	public:
 		//---------------------------------------------------------------------
 		// LIFECYCLE
 		//---------------------------------------------------------------------

--- a/src/core/options/options.cpp
+++ b/src/core/options/options.cpp
@@ -1,9 +1,1 @@
 #include "options/options.h"
-
-namespace AqualinkAutomate::Options
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Options

--- a/src/core/options/options.h
+++ b/src/core/options/options.h
@@ -15,11 +15,3 @@
 #include "options/options_scheduling_options.h"
 #include "options/options_serial_options.h"
 #include "options/options_web_options.h"
-
-namespace AqualinkAutomate::Options
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Options

--- a/src/core/options/options_app_options.h
+++ b/src/core/options/options_app_options.h
@@ -64,7 +64,6 @@ namespace AqualinkAutomate::Options::App
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/core/options/options_developer_options.h
+++ b/src/core/options/options_developer_options.h
@@ -76,7 +76,6 @@ namespace AqualinkAutomate::Options::Developer
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/core/options/options_equipment_options.cpp
+++ b/src/core/options/options_equipment_options.cpp
@@ -23,7 +23,7 @@ namespace AqualinkAutomate::Options::Equipment
 		return options;
 	}
 
-	void OptionsProcessor::Validate(const boost::program_options::variables_map& vm) const
+	void OptionsProcessor::Validate(const boost::program_options::variables_map& /*vm*/) const
 	{
 		// Validation is performed during Process(); nothing to check here
 		// since boost::program_options already validates presence.

--- a/src/core/options/options_equipment_options.h
+++ b/src/core/options/options_equipment_options.h
@@ -23,12 +23,7 @@ namespace AqualinkAutomate::Options::Equipment
 			return AREA_NAME;
 		}
 
-		tagEquipmentSettings() :
-			pool_configuration{ Kernel::PoolConfigurations::Unknown }
-		{
-		}
-
-		Kernel::PoolConfigurations pool_configuration;
+		Kernel::PoolConfigurations pool_configuration{ Kernel::PoolConfigurations::Unknown };
 		bool pool_configuration_is_user_specified{ false };
 
 		/// For a SingleBody (pool-only / spa-only) install, which body the single body is.
@@ -69,7 +64,6 @@ namespace AqualinkAutomate::Options::Equipment
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/core/options/options_logging_options.cpp
+++ b/src/core/options/options_logging_options.cpp
@@ -63,8 +63,7 @@ namespace
 		while (start <= spec.size())
 		{
 			const auto comma = spec.find(',', start);
-			const auto piece = NormaliseToken(std::string_view{ spec }.substr(start, (comma == std::string::npos ? spec.size() : comma) - start));
-			if (!ApplySinkToken(piece, settings))
+			if (const auto piece = NormaliseToken(std::string_view{ spec }.substr(start, (comma == std::string::npos ? spec.size() : comma) - start)); !ApplySinkToken(piece, settings))
 			{
 				return false;
 			}

--- a/src/core/options/options_mqtt_options.h
+++ b/src/core/options/options_mqtt_options.h
@@ -239,7 +239,6 @@ namespace AqualinkAutomate::Options::Mqtt
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/core/options/options_option_type.cpp
+++ b/src/core/options/options_option_type.cpp
@@ -23,7 +23,6 @@ namespace AqualinkAutomate::Options
 	AppOption::AppOption(const std::string& long_name, const std::string& description, const boost::program_options::value_semantic* s) :
 		boost::program_options::option_description(long_name.c_str(), s, description.c_str()),
 		m_LongName(long_name),
-		m_ShortName(),
 		m_Description(description)
 	{
 		MetadataRegistry()[m_LongName] = OptionMetadata{ m_LongName, m_ShortName, m_Description };

--- a/src/core/options/options_option_type.h
+++ b/src/core/options/options_option_type.h
@@ -38,18 +38,15 @@ namespace AqualinkAutomate::Options
 		explicit AppOption(const std::string& long_name, const std::string& short_name, const std::string& description);
 		explicit AppOption(const std::string& long_name, const std::string& short_name, const std::string& description, const boost::program_options::value_semantic* s);
 
-	private:
 		AppOption(const AppOption&) = delete;
 		AppOption(AppOption&&) = delete;
 
 	public:
 		boost::shared_ptr<boost::program_options::option_description> operator()();
 
-	public:
 		bool IsPresent(boost::program_options::variables_map& vm) const;
 		bool IsPresentAndNotJustDefaulted(boost::program_options::variables_map& vm) const;
 
-	public:
 		const std::string& LongName() const { return m_LongName; }
 		const std::string& ShortName() const { return m_ShortName; }
 		const std::string& Description() const { return m_Description; }
@@ -58,7 +55,6 @@ namespace AqualinkAutomate::Options
 		// by long name. Populated as options are constructed during option parsing.
 		static std::vector<OptionMetadata> RegisteredOptions();
 
-	public:
 		template<typename T>
 		const T& As(boost::program_options::variables_map& vm) const
 		{

--- a/src/core/options/options_registry.cpp
+++ b/src/core/options/options_registry.cpp
@@ -1,9 +1,1 @@
 #include "options/options_registry.h"
-
-namespace AqualinkAutomate::Options
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Options

--- a/src/core/options/options_registry.h
+++ b/src/core/options/options_registry.h
@@ -76,8 +76,7 @@ namespace AqualinkAutomate::Options
 						.options(*desc)
 						.run();
 
-					auto unrecognized = boost::program_options::collect_unrecognized(parsed.options, boost::program_options::include_positional);
-					if (!unrecognized.empty())
+					if (auto unrecognized = boost::program_options::collect_unrecognized(parsed.options, boost::program_options::include_positional); !unrecognized.empty())
 					{
 						std::string unknown_args;
 						for (const auto& arg : unrecognized)

--- a/src/core/options/options_serial_options.h
+++ b/src/core/options/options_serial_options.h
@@ -23,20 +23,12 @@ namespace AqualinkAutomate::Options::Serial
 			return AREA_NAME;
 		}
 
-		tagSerialSettings() :
-			serial_port{ "/dev/ttyUSB0" },
-			baud_rate{ 9600 },
-			use_rfc2217{ false },
-			use_rawtcp{ false }
-		{
-		}
-
-		std::string serial_port;
-		uint16_t baud_rate;
+		std::string serial_port{ "/dev/ttyUSB0" };
+		uint16_t baud_rate{ 9600 };
 
 		std::string remote_serial_port;
-		bool use_rfc2217;
-		bool use_rawtcp;
+		bool use_rfc2217{ false };
+		bool use_rawtcp{ false };
 
 		bool UsingPhysicalSerialPort() const
 		{
@@ -78,7 +70,6 @@ namespace AqualinkAutomate::Options::Serial
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/core/options/options_settings.cpp
+++ b/src/core/options/options_settings.cpp
@@ -1,10 +1,2 @@
 #include "options/options_settings.h"
 
-namespace AqualinkAutomate::Options
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Options
-

--- a/src/core/options/options_web_options.h
+++ b/src/core/options/options_web_options.h
@@ -32,24 +32,15 @@ namespace AqualinkAutomate::Options::Web
 			return AREA_NAME;
 		}
 
-		tagWebSettings() :
-			http_port{ 80 },
-			https_port{ 443 },
-			http_content_is_disabled{ false },
-			http_server_is_enabled{ true },
-			https_server_is_enabled{ true }
-		{
-		}
-
 		std::string bind_address;
-		uint16_t http_port;
-		uint16_t https_port;
+		uint16_t http_port{ 80 };
+		uint16_t https_port{ 443 };
 
 		std::string doc_root;
 
-		bool http_content_is_disabled;
-		bool http_server_is_enabled;
-		bool https_server_is_enabled;
+		bool http_content_is_disabled{ false };
+		bool http_server_is_enabled{ true };
+		bool https_server_is_enabled{ true };
 
 		SslCertificate ssl_certificate;
 		std::optional<std::filesystem::path> ca_chain_certificate;
@@ -126,7 +117,6 @@ namespace AqualinkAutomate::Options::Web
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/core/preferences/preferences_service.cpp
+++ b/src/core/preferences/preferences_service.cpp
@@ -106,8 +106,7 @@ namespace AqualinkAutomate::Preferences
 			{
 				return true;
 			}
-			const auto& h = json["history"];
-			if (h.contains("retention_days"))
+			if (const auto& h = json["history"]; h.contains("retention_days"))
 			{
 				if (!h["retention_days"].is_number_integer() || h["retention_days"].get<std::int64_t>() <= 0)
 				{

--- a/src/core/profiling/factories/profiler_factory.cpp
+++ b/src/core/profiling/factories/profiler_factory.cpp
@@ -5,9 +5,7 @@
 namespace AqualinkAutomate::Factory
 {
 
-	ProfilerFactory::ProfilerFactory() :
-		m_Profilers{},
-		m_DesiredProfiler(std::nullopt)
+	ProfilerFactory::ProfilerFactory()
 	{
 	}
 

--- a/src/core/profiling/factories/profiler_factory.h
+++ b/src/core/profiling/factories/profiler_factory.h
@@ -17,16 +17,13 @@ namespace AqualinkAutomate::Factory
         ProfilerFactory();
         ~ProfilerFactory() = default;
 
-    public:
         ProfilerFactory(const ProfilerFactory&) = delete;
         ProfilerFactory& operator=(const ProfilerFactory&) = delete;
         ProfilerFactory(ProfilerFactory&&) = delete;
         ProfilerFactory& operator=(ProfilerFactory&&) = delete;
 
-	public:
         static ProfilerFactory& Instance();
 
-    public:
         bool Register(Types::ProfilerTypes type, Types::ProfilerTypePtr&& instance_ptr);
         void SetDesired(Types::ProfilerTypes type);
         Types::ProfilerTypePtr Get();
@@ -40,8 +37,8 @@ namespace AqualinkAutomate::Factory
         std::optional<Types::ProfilerTypes> Selected() const;
 
     private:
-        std::unordered_map<Types::ProfilerTypes, Types::ProfilerTypePtr> m_Profilers;
-        std::optional<Types::ProfilerTypes> m_DesiredProfiler;
+        std::unordered_map<Types::ProfilerTypes, Types::ProfilerTypePtr> m_Profilers{};
+        std::optional<Types::ProfilerTypes> m_DesiredProfiler{ std::nullopt };
 
 	};
 

--- a/src/core/profiling/factories/profiling_unit_factory.cpp
+++ b/src/core/profiling/factories/profiling_unit_factory.cpp
@@ -6,9 +6,7 @@
 namespace AqualinkAutomate::Factory
 {
 
-	ProfilingUnitFactory::ProfilingUnitFactory() :
-		m_Generators{},
-		m_DesiredProfiler(std::nullopt)
+	ProfilingUnitFactory::ProfilingUnitFactory()
 	{
 	}
 

--- a/src/core/profiling/factories/profiling_unit_factory.h
+++ b/src/core/profiling/factories/profiling_unit_factory.h
@@ -22,20 +22,16 @@ namespace AqualinkAutomate::Factory
         ProfilingUnitFactory();
         ~ProfilingUnitFactory() = default;
 
-    public:
         ProfilingUnitFactory(const ProfilingUnitFactory&) = delete;
         ProfilingUnitFactory& operator=(const ProfilingUnitFactory&) = delete;
         ProfilingUnitFactory(ProfilingUnitFactory&&) = delete;
         ProfilingUnitFactory& operator=(ProfilingUnitFactory&&) = delete;
 
-    public:
         static ProfilingUnitFactory& Instance();
 
-    public:
         bool Register(const Types::ProfilerTypes type, ProfilingUnitGenerators&& generators);
         void SetDesired(Types::ProfilerTypes type);
 
-    public:
         Types::ProfilingUnitTypePtr CreateDomain(std::string_view name, const std::source_location& src_loc = std::source_location::current(), Profiling::UnitColours colour = Profiling::UnitColours::NotSpecified);
         Types::ProfilingUnitTypePtr CreateFrame(std::string_view name, const std::source_location& src_loc = std::source_location::current(), Profiling::UnitColours colour = Profiling::UnitColours::NotSpecified);
         Types::ProfilingUnitTypePtr CreateZone(std::string_view name, const std::source_location& src_loc, Profiling::UnitColours colour = Profiling::UnitColours::NotSpecified);
@@ -44,8 +40,8 @@ namespace AqualinkAutomate::Factory
         const ProfilingUnitGenerators& Get();
 
     private:
-        std::unordered_map<Types::ProfilerTypes, const ProfilingUnitGenerators> m_Generators;
-        std::optional<Types::ProfilerTypes> m_DesiredProfiler;
+        std::unordered_map<Types::ProfilerTypes, const ProfilingUnitGenerators> m_Generators{};
+        std::optional<Types::ProfilerTypes> m_DesiredProfiler{ std::nullopt };
 	};
 
 }

--- a/src/core/profiling/noop_profiler.cpp
+++ b/src/core/profiling/noop_profiler.cpp
@@ -5,10 +5,14 @@ namespace AqualinkAutomate::Profiling
 
 	void NoOp_Profiler::StartProfiling()
 	{
+		// Intentionally empty: the no-op profiler is the fallback when no backend
+		// is selected, so starting profiling does nothing.
 	}
 
 	void NoOp_Profiler::StopProfiling()
 	{
+		// Intentionally empty: the no-op profiler is the fallback when no backend
+		// is selected, so stopping profiling does nothing.
 	}
 
 }

--- a/src/core/profiling/profiling.cpp
+++ b/src/core/profiling/profiling.cpp
@@ -23,7 +23,7 @@
 namespace AqualinkAutomate::Profiling
 {
 
-	void RegisterAvailableProfilers(Factory::ProfilerFactory& profiler, Factory::ProfilingUnitFactory& profiler_units)
+	void RegisterAvailableProfilers([[maybe_unused]] Factory::ProfilerFactory& profiler, [[maybe_unused]] Factory::ProfilingUnitFactory& profiler_units)
 	{
 #if defined(TRACY_ENABLE)
 		profiler.Register(Types::ProfilerTypes::Tracy, std::make_shared<Tracy_Profiler>());

--- a/src/core/profiling/profiling_units/domain.cpp
+++ b/src/core/profiling/profiling_units/domain.cpp
@@ -3,21 +3,24 @@
 namespace AqualinkAutomate::Profiling
 {
 
-	Domain::Domain(std::string_view name, const std::source_location& src_loc, UnitColours colour) :
+	Domain::Domain(std::string_view name, [[maybe_unused]] const std::source_location& src_loc, [[maybe_unused]] UnitColours colour) :
 		Interfaces::IProfilingUnit(name)
 	{
 	}
 
 	void Domain::Start() const
 	{
+		// Intentionally empty: the base Domain unit is a no-op; concrete backends override this.
 	}
 
 	void Domain::End() const
 	{
+		// Intentionally empty: the base Domain unit is a no-op; concrete backends override this.
 	}
 
 	void Domain::Mark() const
 	{
+		// Intentionally empty: the base Domain unit is a no-op; concrete backends override this.
 	}
 
 }

--- a/src/core/profiling/profiling_units/domain.h
+++ b/src/core/profiling/profiling_units/domain.h
@@ -12,10 +12,9 @@ namespace AqualinkAutomate::Profiling
 	class Domain : public Interfaces::IProfilingUnit
 	{
 	public:
-		Domain(std::string_view name, const std::source_location& src_loc = std::source_location::current(), UnitColours colour = UnitColours::NotSpecified);
+		explicit Domain(std::string_view name, const std::source_location& src_loc = std::source_location::current(), UnitColours colour = UnitColours::NotSpecified);
 		~Domain() override = default;
 
-	public:
 		void Start() const override;
 		void Mark() const override;
 		void End() const override;

--- a/src/core/profiling/profiling_units/frame.cpp
+++ b/src/core/profiling/profiling_units/frame.cpp
@@ -3,21 +3,24 @@
 namespace AqualinkAutomate::Profiling
 {
 
-	Frame::Frame(std::string_view name, const std::source_location& src_loc, UnitColours colour) :
+	Frame::Frame(std::string_view name, [[maybe_unused]] const std::source_location& src_loc, [[maybe_unused]] UnitColours colour) :
 		Interfaces::IProfilingUnit(name)
 	{
 	}
 
 	void Frame::Start() const
 	{
+		// Intentionally empty: the base Frame unit is a no-op; concrete backends override this.
 	}
 
 	void Frame::End() const
 	{
+		// Intentionally empty: the base Frame unit is a no-op; concrete backends override this.
 	}
 
 	void Frame::Mark() const
 	{
+		// Intentionally empty: the base Frame unit is a no-op; concrete backends override this.
 	}
 
 }

--- a/src/core/profiling/profiling_units/frame.h
+++ b/src/core/profiling/profiling_units/frame.h
@@ -12,10 +12,9 @@ namespace AqualinkAutomate::Profiling
 	class Frame : public Interfaces::IProfilingUnit
 	{
 	public:
-		Frame(std::string_view name, const std::source_location& src_loc = std::source_location::current(), UnitColours colour = UnitColours::NotSpecified);
+		explicit Frame(std::string_view name, const std::source_location& src_loc = std::source_location::current(), UnitColours colour = UnitColours::NotSpecified);
 		~Frame() override = default;
 
-	public:
 		void Start() const override;
 		void Mark() const override;
 		void End() const override;

--- a/src/core/profiling/profiling_units/zone.cpp
+++ b/src/core/profiling/profiling_units/zone.cpp
@@ -3,21 +3,24 @@
 namespace AqualinkAutomate::Profiling
 {
 
-	Zone::Zone(std::string_view name, const std::source_location& src_loc, UnitColours colour) :
+	Zone::Zone(std::string_view name, [[maybe_unused]] const std::source_location& src_loc, [[maybe_unused]] UnitColours colour) :
 		Interfaces::IProfilingUnit(name)
 	{
 	}
 
 	void Zone::Start() const
 	{
+		// Intentionally empty: the base Zone unit is a no-op; concrete backends override this.
 	}
 
 	void Zone::Mark() const
 	{
+		// Intentionally empty: the base Zone unit is a no-op; concrete backends override this.
 	}
 
 	void Zone::End() const
 	{
+		// Intentionally empty: the base Zone unit is a no-op; concrete backends override this.
 	}
 
 }

--- a/src/core/profiling/profiling_units/zone.h
+++ b/src/core/profiling/profiling_units/zone.h
@@ -12,10 +12,9 @@ namespace AqualinkAutomate::Profiling
 	class Zone : public Interfaces::IProfilingUnit
 	{
 	public:
-		Zone(std::string_view name, const std::source_location& src_loc = std::source_location::current(), UnitColours colour = UnitColours::NotSpecified);
+		explicit Zone(std::string_view name, const std::source_location& src_loc = std::source_location::current(), UnitColours colour = UnitColours::NotSpecified);
 		~Zone() override = default;
 
-	public:
 		void Start() const override;
 		void Mark() const override;
 		void End() const override;

--- a/src/core/profiling/types/profiling_types.cpp
+++ b/src/core/profiling/types/profiling_types.cpp
@@ -1,9 +1,1 @@
 #include "profiling/types/profiling_types.h"
-
-namespace AqualinkAutomate::Types
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Types

--- a/src/core/protocol/protocol_handler.cpp
+++ b/src/core/protocol/protocol_handler.cpp
@@ -1,9 +1,1 @@
 #include "protocol/protocol_handler.h"
-
-namespace AqualinkAutomate::Protocol
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Protocol

--- a/src/core/protocol/protocol_handler.h
+++ b/src/core/protocol/protocol_handler.h
@@ -1,11 +1,3 @@
 #pragma once
 
 #include "protocol/protocol_thread.h"
-
-namespace AqualinkAutomate::Protocol
-{
-
-    // NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Protocol

--- a/src/core/protocol/protocol_handler_constants.cpp
+++ b/src/core/protocol/protocol_handler_constants.cpp
@@ -1,9 +1,1 @@
 #include "protocol/protocol_handler_constants.h"
-
-namespace AqualinkAutomate::Protocol
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Protocol

--- a/src/core/protocol/protocol_handler_read_handler_messages.cpp
+++ b/src/core/protocol/protocol_handler_read_handler_messages.cpp
@@ -13,7 +13,7 @@ using namespace AqualinkAutomate::Profiling;
 namespace AqualinkAutomate::Protocol
 {
 
-	void ProtocolHandler_ReadOp_MessageHandler(const ProtocolMessagePtr& wrapper, const std::shared_ptr<Kernel::StatisticsHub>& statistics_hub)
+	void ProtocolHandler_ReadOp_MessageHandler(const ProtocolMessagePtr& wrapper, [[maybe_unused]] const std::shared_ptr<Kernel::StatisticsHub>& statistics_hub)
 	{
 		LogTrace(Channel::Protocol, "Message received; emitting signal to listening consumer slots.");
 

--- a/src/core/protocol/protocol_handler_types.cpp
+++ b/src/core/protocol/protocol_handler_types.cpp
@@ -1,9 +1,1 @@
 #include "protocol/protocol_handler_types.h"
-
-namespace AqualinkAutomate::Protocol
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Protocol

--- a/src/core/protocol/protocol_message_types.cpp
+++ b/src/core/protocol/protocol_message_types.cpp
@@ -1,11 +1,5 @@
 #include "protocol/protocol_message_types.h"
 
-namespace AqualinkAutomate::Protocol
-{
-
-	// ProtocolMessageWrapper provides type-erased access to protocol-specific messages.
-	// Implementations are provided by protocol-specific libraries (e.g., Jandy, Pentair)
-
-}
-// namespace AqualinkAutomate::Protocol
+// ProtocolMessageWrapper provides type-erased access to protocol-specific messages.
+// Implementations are provided by protocol-specific libraries (e.g., Jandy, Pentair)
 

--- a/src/core/protocol/protocol_thread.h
+++ b/src/core/protocol/protocol_thread.h
@@ -98,7 +98,6 @@ namespace AqualinkAutomate::Protocol
 		// When true, read at most one serial chunk per Poll() (see constructor).
 		bool m_SingleReadPerPoll;
 
-	private:
 		std::vector<boost::signals2::scoped_connection> m_WriteSignalConnections;
 	};
 

--- a/src/core/scheduling/scheduler_service.cpp
+++ b/src/core/scheduling/scheduler_service.cpp
@@ -51,13 +51,16 @@ namespace AqualinkAutomate::Scheduling
 	{
 		// Stop() cancels the asio timer, whose throwing overload can raise
 		// boost::system::system_error. A destructor must not let that escape (cpp:S1048).
+		// The diagnostic logging can itself throw (std::format / sink write), so it is
+		// guarded too — nothing, including the log call, may escape a destructor.
 		try
 		{
 			Stop();
 		}
 		catch (const std::exception& ex)
 		{
-			LogError(Channel::Main, [&ex] { return std::format("Scheduler: error during shutdown: {}", ex.what()); });
+			try { LogError(Channel::Main, [&ex] { return std::format("Scheduler: error during shutdown: {}", ex.what()); }); }
+			catch (...) { /* the diagnostic log itself must not escape the destructor (cpp:S1048) */ }
 		}
 		catch (...)
 		{

--- a/src/core/serial/port_types/network_serial_port_impl.cpp
+++ b/src/core/serial/port_types/network_serial_port_impl.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <span>
+#include <utility>
 
 #include <boost/asio/basic_socket.hpp>
 #include <boost/asio/connect.hpp>
@@ -300,7 +301,7 @@ namespace AqualinkAutomate::Serial::PortTypes
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("NetworkSerialPortImpl::set_flow_control", std::source_location::current());
 
-		LogDebug(Channel::Serial, std::format("Setting flow control: {}", static_cast<int>(fc)));
+		LogDebug(Channel::Serial, std::format("Setting flow control: {}", std::to_underlying(fc)));
 		m_Options.flow_control = fc;
 
 		if (m_ProtocolHandler)
@@ -319,7 +320,7 @@ namespace AqualinkAutomate::Serial::PortTypes
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("NetworkSerialPortImpl::set_parity", std::source_location::current());
 
-		LogDebug(Channel::Serial, std::format("Setting parity: {}", static_cast<int>(p)));
+		LogDebug(Channel::Serial, std::format("Setting parity: {}", std::to_underlying(p)));
 		m_Options.parity = p;
 
 		if (m_ProtocolHandler)
@@ -338,7 +339,7 @@ namespace AqualinkAutomate::Serial::PortTypes
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("NetworkSerialPortImpl::set_stop_bits", std::source_location::current());
 
-		LogDebug(Channel::Serial, std::format("Setting stop bits: {}", static_cast<int>(sb)));
+		LogDebug(Channel::Serial, std::format("Setting stop bits: {}", std::to_underlying(sb)));
 		m_Options.stop_bits = sb;
 
 		if (m_ProtocolHandler)

--- a/src/core/serial/port_types/network_serial_port_impl.h
+++ b/src/core/serial/port_types/network_serial_port_impl.h
@@ -61,13 +61,11 @@ namespace AqualinkAutomate::Serial::PortTypes
 	private:
 		Developer::SerialPortOptions m_Options;
 
-	private:
 		boost::asio::any_io_executor m_Executor;
 		boost::asio::ip::tcp::socket m_Socket;
 		std::string m_EndpointName;
 		bool m_IsOpen{ false };
 
-	private:
 		bool m_UseRfc2217{ true };
 		std::unique_ptr<Interfaces::ISerialPortProtocol> CreateProtocolHandler();
 		std::unique_ptr<Interfaces::ISerialPortProtocol> m_ProtocolHandler;
@@ -77,7 +75,6 @@ namespace AqualinkAutomate::Serial::PortTypes
 		// success path does not nest control flow too deeply.
 		void InitialiseConnectedSocket(const std::string& endpoint_name, boost::system::error_code& ec);
 
-	private:
 		Profiling::DomainPtr m_ProfilingDomain;
 	};
 

--- a/src/core/serial/port_types/physical_serial_port_impl.cpp
+++ b/src/core/serial/port_types/physical_serial_port_impl.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "serial/port_types/physical_serial_port_impl.h"
 
 namespace AqualinkAutomate::Serial::PortTypes
@@ -90,21 +92,21 @@ namespace AqualinkAutomate::Serial::PortTypes
     {
         auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("PhysicalSerialPortImpl::set_flow_control", std::source_location::current());
         m_SerialPort.set_option(boost::asio::serial_port_base::flow_control(
-            static_cast<boost::asio::serial_port_base::flow_control::type>(fc)), ec);
+            static_cast<boost::asio::serial_port_base::flow_control::type>(std::to_underlying(fc))), ec);
     }
 
     void PhysicalSerialPortImpl::set_parity(Serial::Parity p, boost::system::error_code& ec)
     {
         auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("PhysicalSerialPortImpl::set_parity", std::source_location::current());
         m_SerialPort.set_option(boost::asio::serial_port_base::parity(
-            static_cast<boost::asio::serial_port_base::parity::type>(p)), ec);
+            static_cast<boost::asio::serial_port_base::parity::type>(std::to_underlying(p))), ec);
     }
 
     void PhysicalSerialPortImpl::set_stop_bits(Serial::StopBits sb, boost::system::error_code& ec)
     {
         auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("PhysicalSerialPortImpl::set_stop_bits", std::source_location::current());
         m_SerialPort.set_option(boost::asio::serial_port_base::stop_bits(
-            static_cast<boost::asio::serial_port_base::stop_bits::type>(sb)), ec);
+            static_cast<boost::asio::serial_port_base::stop_bits::type>(std::to_underlying(sb))), ec);
     }
 
     std::size_t PhysicalSerialPortImpl::read_some(const boost::asio::mutable_buffer& buffer)

--- a/src/core/serial/port_types/physical_serial_port_impl.h
+++ b/src/core/serial/port_types/physical_serial_port_impl.h
@@ -28,7 +28,6 @@ namespace AqualinkAutomate::Serial::PortTypes
 		PhysicalSerialPortImpl(PhysicalSerialPortImpl&& other) noexcept = delete;
 		PhysicalSerialPortImpl& operator=(PhysicalSerialPortImpl&& other) noexcept = delete;
 
-	public:
 		void open(const std::string& device_name) override;
 		void open(const std::string& device_name, boost::system::error_code& ec) override;
 		bool is_open() const override;

--- a/src/core/serial/rfc2217/rfc2217_protocol_handler.cpp
+++ b/src/core/serial/rfc2217/rfc2217_protocol_handler.cpp
@@ -117,11 +117,12 @@ namespace AqualinkAutomate::Serial::RFC2217
 
 		constexpr auto to_rfc2217_parity = [](Serial::Parity p) -> uint8_t
 			{
+				using enum Serial::Parity;
 				switch (p)
 				{
-				case Serial::Parity::None:  return 1;
-				case Serial::Parity::Odd:   return 2;
-				case Serial::Parity::Even:  return 3;
+				case None:  return 1;
+				case Odd:   return 2;
+				case Even:  return 3;
 				}
 				std::unreachable();
 			};
@@ -144,11 +145,12 @@ namespace AqualinkAutomate::Serial::RFC2217
 
 		constexpr auto to_rfc2217_stop = [](Serial::StopBits s) -> uint8_t
 			{
+				using enum Serial::StopBits;
 				switch (s)
 				{
-				case Serial::StopBits::One:           return 1;
-				case Serial::StopBits::OnePointFive:   return 2;
-				case Serial::StopBits::Two:            return 3;
+				case One:           return 1;
+				case OnePointFive:   return 2;
+				case Two:            return 3;
 				}
 				std::unreachable();
 			};
@@ -171,11 +173,12 @@ namespace AqualinkAutomate::Serial::RFC2217
 
 		constexpr auto to_rfc2217_flow = [](Serial::FlowControl f) -> uint8_t
 			{
+				using enum Serial::FlowControl;
 				switch (f)
 				{
-				case Serial::FlowControl::None:      return 0;
-				case Serial::FlowControl::Software:  return 1;
-				case Serial::FlowControl::Hardware:  return 2;
+				case None:      return 0;
+				case Software:  return 1;
+				case Hardware:  return 2;
 				}
 				std::unreachable();
 			};
@@ -254,8 +257,7 @@ namespace AqualinkAutomate::Serial::RFC2217
 		}
 
 		// Security: Validate parameter lengths for known commands
-		const uint8_t base_command = command - Constants::SERVER_OFFSET;
-		switch (base_command)
+		switch (const uint8_t base_command = command - Constants::SERVER_OFFSET; base_command)
 		{
 		case Constants::SET_BAUDRATE:
 			if (params.size() != 4)

--- a/src/core/serial/serial_port.h
+++ b/src/core/serial/serial_port.h
@@ -23,7 +23,6 @@ namespace AqualinkAutomate::Serial
 	public:
 		explicit SerialPort(std::unique_ptr<Interfaces::ISerialPortImpl> serial_port_impl, Kernel::HubLocator& hub_locator);
 
-	public:
 		void open(const std::string& device);
 		void open(const std::string& device, boost::system::error_code& ec);
 		bool is_open() const;
@@ -32,7 +31,6 @@ namespace AqualinkAutomate::Serial
 		void close();
 		void close(boost::system::error_code& ec);
 
-	public:
 		void set_baud_rate(uint32_t rate);
 		void set_baud_rate(uint32_t rate, boost::system::error_code& ec);
 		void set_character_size(uint8_t bits);
@@ -46,7 +44,6 @@ namespace AqualinkAutomate::Serial
 		void set_read_timeout(std::chrono::milliseconds timeout);
 		void set_read_timeout(std::chrono::milliseconds timeout, boost::system::error_code& ec);
 
-	public:
 		std::size_t read_some(const boost::asio::mutable_buffer& buffers);
 		std::size_t read_some(const boost::asio::mutable_buffer& buffers, boost::system::error_code& ec);
 		std::size_t write_some(const boost::asio::const_buffer& buffers);
@@ -55,7 +52,6 @@ namespace AqualinkAutomate::Serial
 	private:
 		std::unique_ptr<Interfaces::ISerialPortImpl> m_SerialPortImpl;
 
-	private:
 		std::shared_ptr<Kernel::StatisticsHub> m_StatisticsHub;
 	};
 

--- a/src/core/types/units_dimensionless.cpp
+++ b/src/core/types/units_dimensionless.cpp
@@ -1,9 +1,2 @@
 #include "types/units_dimensionless.h"
 
-namespace AqualinkAutomate::Units
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Units

--- a/src/core/types/units_electric_potential.cpp
+++ b/src/core/types/units_electric_potential.cpp
@@ -1,9 +1,2 @@
 #include "types/units_electric_potential.h"
 
-namespace AqualinkAutomate::Units
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Units

--- a/src/core/types/units_flow_rate.cpp
+++ b/src/core/types/units_flow_rate.cpp
@@ -1,9 +1,2 @@
 #include "types/units_flow_rate.h"
 
-namespace AqualinkAutomate::Units
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Units

--- a/src/core/utility/bandwidth_utilisation.h
+++ b/src/core/utility/bandwidth_utilisation.h
@@ -20,7 +20,7 @@ namespace AqualinkAutomate::Utility
 		using HistoryCollection = std::deque<HistoryElement>;
 
 	public:
-		UtilisationOverPeriod(std::chrono::seconds duration) :
+		explicit UtilisationOverPeriod(std::chrono::seconds duration) :
 			UtilisationOverPeriod(duration, Developer::SerialPortOptions{})
 		{
 		}
@@ -42,7 +42,6 @@ namespace AqualinkAutomate::Utility
 		UtilisationOverPeriod(UtilisationOverPeriod&&) noexcept = default;
 		UtilisationOverPeriod& operator=(UtilisationOverPeriod&&) noexcept = default;
 
-	public:
 		const HistoryCollection& History() const
 		{
 			return m_History;
@@ -63,7 +62,6 @@ namespace AqualinkAutomate::Utility
 			return CalculateCurrentUtilization();
 		}
 
-	public:
 		/// Returns a copy with the supplied bytes added.
 		/// NOTE: deep-copies the entire history; prefer operator+= on the hot path.
 		UtilisationOverPeriod operator+(BytesElement bytes) const
@@ -138,7 +136,6 @@ namespace AqualinkAutomate::Utility
 		std::chrono::seconds m_StatsDuration;
 		BytesElement m_RunningTotalBytes{ 0 };
 
-	private:
 		double m_MaxBandwidthBytesPerSec;
 	};
 
@@ -154,7 +151,6 @@ namespace AqualinkAutomate::Utility
 		FlowStatistics& operator=(FlowStatistics&&) noexcept = default;
 		~FlowStatistics() = default;
 
-	public:
 		FlowStatistics& operator+=(const uint64_t bytes)
 		{
 			TotalBytes += bytes;
@@ -169,7 +165,6 @@ namespace AqualinkAutomate::Utility
 	public:
 		uint64_t TotalBytes{ 0 };
 
-	public:
 		UtilisationOverPeriod<> Average_OneSecond{ std::chrono::seconds(1) };
 		UtilisationOverPeriod<> Average_ThirtySecond{ std::chrono::seconds(30) };
 		UtilisationOverPeriod<> Average_FiveMinute{ std::chrono::minutes(5) };

--- a/src/core/utility/endpoint_parser.cpp
+++ b/src/core/utility/endpoint_parser.cpp
@@ -133,8 +133,7 @@ namespace AqualinkAutomate::Utility
                 auto inner = input.substr(1, rb - 1);
 
                 // RFC 6874: zone id after '%'
-                const auto pct = inner.find('%');
-                if (pct != std::string_view::npos)
+                if (const auto pct = inner.find('%'); pct != std::string_view::npos)
                 {
                     out.scope_id = decode_zone_id(inner.substr(pct + 1));
                     inner = inner.substr(0, pct);

--- a/src/core/utility/get_terminal_column_width.cpp
+++ b/src/core/utility/get_terminal_column_width.cpp
@@ -1,14 +1,8 @@
 #include "utility/get_terminal_column_width.h"
 
-namespace AqualinkAutomate::Utility
-{
-
-	// PLATFORM-SPECIFIC IMPLEMENTATION
-	//
-	// uint32_t get_terminal_column_width()
-	// 
-	// --> win32
-	// --> linux
-
-}
-// namespace AqualinkAutomate::Utility
+// PLATFORM-SPECIFIC IMPLEMENTATION
+//
+// uint32_t get_terminal_column_width()
+//
+// --> win32
+// --> linux

--- a/src/core/utility/latency_percentile_tracker.h
+++ b/src/core/utility/latency_percentile_tracker.h
@@ -68,7 +68,6 @@ namespace AqualinkAutomate::Utility
 		LatencyPercentileTracker(LatencyPercentileTracker&&) noexcept = default;
 		LatencyPercentileTracker& operator=(LatencyPercentileTracker&&) noexcept = default;
 
-	public:
 		/// Records a latency sample with the current timestamp.
 		void Record(Duration latency)
 		{

--- a/src/core/utility/signalling_stats_counter.cpp
+++ b/src/core/utility/signalling_stats_counter.cpp
@@ -4,7 +4,6 @@ namespace AqualinkAutomate::Utility
 {
 
 	StatsCounter::StatsCounter(StatsSignal& stat_signal) :
-		m_Count{ 0 },
 		m_StatsSignal(stat_signal)
 	{
 	}

--- a/src/core/utility/signalling_stats_counter.h
+++ b/src/core/utility/signalling_stats_counter.h
@@ -37,23 +37,21 @@ namespace AqualinkAutomate::Utility
 	class StatsCounter
 	{
 	public:
-		StatsCounter(StatsSignal& stat_signal);
+		explicit StatsCounter(StatsSignal& stat_signal);
 		StatsCounter(const StatsCounter& other);
 		StatsCounter(StatsCounter&& other) noexcept;
 		StatsCounter& operator=(const StatsCounter& other) = delete;
 		StatsCounter& operator=(StatsCounter&& other) noexcept = delete;
 
-	public:
 		StatsCounter& operator=(const uint64_t count_to_assign);
 		StatsCounter& operator+=(const uint64_t count_to_add);
 		StatsCounter& operator++();
 
-	public:
 		uint64_t operator()() const;
 		uint64_t Count() const;
 
 	private:
-		std::uint64_t m_Count;
+		std::uint64_t m_Count{ 0 };
 		StatsSignal& m_StatsSignal;
 	};
 
@@ -94,9 +92,9 @@ namespace AqualinkAutomate::Utility
 		{
 			template<typename STAT_TYPE>
 				requires std::is_enum_v<STAT_TYPE>
-			AnyEnum(STAT_TYPE value) :
+			explicit AnyEnum(STAT_TYPE value) :
 				type_hash(typeid(STAT_TYPE).hash_code()),
-				value_hash(std::hash<std::underlying_type_t<STAT_TYPE>>{}(static_cast<std::underlying_type_t<STAT_TYPE>>(value))),
+				value_hash(std::hash<std::underlying_type_t<STAT_TYPE>>{}(std::to_underlying(value))),
 				name(magic_enum::enum_name(value))
 			{
 			}
@@ -168,19 +166,15 @@ namespace AqualinkAutomate::Utility
 	public:
 		using StatsTypesMap = std::unordered_map<AnyEnum, StatsCounter, AnyEnumHash, AnyEnumEqual>;
 
-	public:
 		using key_type = typename StatsTypesMap::key_type;
 		using mapped_type = typename StatsTypesMap::mapped_type;
 		using value_type = typename StatsTypesMap::value_type;
 
 	public:
-		SignallingStatsCounter() :
-			m_StatsMap(),
-			m_StatsSignal()
+		SignallingStatsCounter()
 		{
 		}
 
-	public:
 		template<typename STAT_TYPE>
 			requires std::is_enum_v<STAT_TYPE>
 		StatsCounter& operator[](const STAT_TYPE& stat_type)
@@ -201,7 +195,6 @@ namespace AqualinkAutomate::Utility
 			return it->second;
 		}
 
-	public:
 		template<typename STAT_TYPE>
 			requires std::is_enum_v<STAT_TYPE>
 		void AddStatsToCount(STAT_TYPE stat_type)
@@ -210,20 +203,18 @@ namespace AqualinkAutomate::Utility
 			(void)(*this)[stat_type];
 		}
 
-	public:
 		auto begin() const noexcept { return m_StatsMap.begin(); }
 		auto end() const noexcept { return m_StatsMap.end(); }
 		auto cbegin() const noexcept { return m_StatsMap.cbegin(); }
 		auto cend() const noexcept { return m_StatsMap.cend(); }
 
-	public:
 		StatsSignal& Signal() const
 		{
 			return m_StatsSignal;
 		}
 
 	private:
-		StatsTypesMap m_StatsMap;
+		StatsTypesMap m_StatsMap{};
 		mutable StatsSignal m_StatsSignal;
 	};
 

--- a/src/core/utility/slot_connection_manager.cpp
+++ b/src/core/utility/slot_connection_manager.cpp
@@ -3,8 +3,7 @@
 namespace AqualinkAutomate::Utility
 {
 
-	SlotConnectionManager::SlotConnectionManager() :
-		m_Connections()
+	SlotConnectionManager::SlotConnectionManager()
 	{
 	}
 

--- a/src/core/utility/slot_connection_manager.h
+++ b/src/core/utility/slot_connection_manager.h
@@ -68,7 +68,7 @@ namespace AqualinkAutomate::Utility
 		}
 
 	protected:
-		std::vector<ConnectionVariant> m_Connections;
+		std::vector<ConnectionVariant> m_Connections{};
 	};
 
 }

--- a/src/core/utility/timeout_duration_string_converter.cpp
+++ b/src/core/utility/timeout_duration_string_converter.cpp
@@ -11,8 +11,7 @@ namespace AqualinkAutomate::Utility
 {
 	using namespace std::chrono_literals;
 
-	TimeoutDurationStringConverter::TimeoutDurationStringConverter() noexcept :
-		m_TimeoutDuration(0s)
+	TimeoutDurationStringConverter::TimeoutDurationStringConverter() noexcept
 	{
 	}
 
@@ -86,13 +85,13 @@ namespace AqualinkAutomate::Utility
 		{
 			LogDebug(Channel::Devices, std::format("Failed to convert timeout duration; could not convert hours to number: error -> {}", std::make_error_code(ec).message()));
 		}
-		else if (auto [_, ec] = std::from_chars(timeout_string.data() + MINS_INDEX_START, timeout_string.data() + MINS_INDEX_END, minutes); std::errc() != ec)
+		else if (auto [ptr_mins, ec_mins] = std::from_chars(timeout_string.data() + MINS_INDEX_START, timeout_string.data() + MINS_INDEX_END, minutes); std::errc() != ec_mins)
 		{
-			LogDebug(Channel::Devices, std::format("Failed to convert timeout duration; could not convert minutes to number: error -> {}", std::make_error_code(ec).message()));
+			LogDebug(Channel::Devices, std::format("Failed to convert timeout duration; could not convert minutes to number: error -> {}", std::make_error_code(ec_mins).message()));
 		}
-		else if (auto [_, ec] = std::from_chars(timeout_string.data() + SECS_INDEX_START, timeout_string.data() + SECS_INDEX_END, seconds); std::errc() != ec)
+		else if (auto [ptr_secs, ec_secs] = std::from_chars(timeout_string.data() + SECS_INDEX_START, timeout_string.data() + SECS_INDEX_END, seconds); std::errc() != ec_secs)
 		{
-			LogDebug(Channel::Devices, std::format("Failed to convert timeout duration; could not convert seconds to number: error -> {}", std::make_error_code(ec).message()));
+			LogDebug(Channel::Devices, std::format("Failed to convert timeout duration; could not convert seconds to number: error -> {}", std::make_error_code(ec_secs).message()));
 		}
 		else
 		{

--- a/src/core/utility/timeout_duration_string_converter.h
+++ b/src/core/utility/timeout_duration_string_converter.h
@@ -22,23 +22,21 @@ namespace AqualinkAutomate::Utility
 
 	public:
 		TimeoutDurationStringConverter() noexcept;
-		TimeoutDurationStringConverter(const std::string& timeout_string) noexcept;
+		explicit TimeoutDurationStringConverter(const std::string& timeout_string) noexcept;
 		TimeoutDurationStringConverter(const TimeoutDurationStringConverter& other) noexcept;
 		TimeoutDurationStringConverter(TimeoutDurationStringConverter&& other) noexcept;
 
-	public:
 		TimeoutDurationStringConverter& operator=(const TimeoutDurationStringConverter& other) noexcept;
 		TimeoutDurationStringConverter& operator=(TimeoutDurationStringConverter&& other) noexcept;
 		TimeoutDurationStringConverter& operator=(const std::string& timeout_string) noexcept;
 
-	public:
 		std::chrono::seconds operator()() const noexcept;
 
 	private:
 		void ConvertStringToTimeoutDuration(const std::string& timeout_string) noexcept;
 
 	private:
-		std::chrono::seconds m_TimeoutDuration;
+		std::chrono::seconds m_TimeoutDuration{ std::chrono::seconds(0) };
 
 	};
 

--- a/src/core/utility/value_debouncer.h
+++ b/src/core/utility/value_debouncer.h
@@ -12,7 +12,6 @@ namespace AqualinkAutomate::Utility
 	template<typename DEBOUNCED_VALUE_TYPE, typename VALUE_COMPARATOR = std::equal_to<DEBOUNCED_VALUE_TYPE>>
 	class ValueDebouncer
 	{
-	public:
 		static_assert(std::is_default_constructible_v<DEBOUNCED_VALUE_TYPE>, "DEBOUNCED_VALUE_TYPE must be default constructible");
 		static_assert(std::is_copy_assignable_v<DEBOUNCED_VALUE_TYPE>, "DEBOUNCED_VALUE_TYPE must be copy-assignable");
 		static_assert(std::is_move_assignable_v<DEBOUNCED_VALUE_TYPE>, "DEBOUNCED_VALUE_TYPE must be move-assignable");
@@ -21,12 +20,8 @@ namespace AqualinkAutomate::Utility
 		static const uint32_t DEFAULT_DEBOUNCE_THRESHOLD = 10;
 
 	public:
-		ValueDebouncer(uint32_t threshold = DEFAULT_DEBOUNCE_THRESHOLD) :
-			m_Threshold(threshold),
-			m_UpdateCount(0),
-			m_CurrentValue(),
-			m_FutureValue(),
-			m_ValueComparator(VALUE_COMPARATOR())
+		explicit ValueDebouncer(uint32_t threshold = DEFAULT_DEBOUNCE_THRESHOLD) :
+			m_Threshold(threshold)
 		{
 		}
 
@@ -97,12 +92,11 @@ namespace AqualinkAutomate::Utility
 
 	private:
 		const uint32_t m_Threshold;
-		uint32_t m_UpdateCount;
+		uint32_t m_UpdateCount{ 0 };
 
-	private:
-		DEBOUNCED_VALUE_TYPE m_CurrentValue;
-		DEBOUNCED_VALUE_TYPE m_FutureValue;
-		VALUE_COMPARATOR m_ValueComparator;
+		DEBOUNCED_VALUE_TYPE m_CurrentValue{};
+		DEBOUNCED_VALUE_TYPE m_FutureValue{};
+		VALUE_COMPARATOR m_ValueComparator{};
 	};
 
 }

--- a/src/core/version/version_cmake.h
+++ b/src/core/version/version_cmake.h
@@ -26,7 +26,6 @@ namespace AqualinkAutomate::Version
 		static std::string ProjectDescription();
 		static std::string ProjectHomepageURL();
 
-	public:
 		static uint32_t Major();
 		static uint32_t Minor();
 		static uint32_t Patch();

--- a/src/jandy/auxillaries/jandy_auxillary_id.h
+++ b/src/jandy/auxillaries/jandy_auxillary_id.h
@@ -78,71 +78,73 @@ namespace magic_enum::customize
 	template<>
 	constexpr customize_t enum_name<JandyAuxillaryIds>(JandyAuxillaryIds value) noexcept
 	{
+		using enum AqualinkAutomate::Auxillaries::JandyAuxillaryIds;
+
 		switch (value)
 		{
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_1:
+		case Aux_1:
 			return "Aux1";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_2:
+		case Aux_2:
 			return "Aux2";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_3:
+		case Aux_3:
 			return "Aux3";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_4:
+		case Aux_4:
 			return "Aux4";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_5:
+		case Aux_5:
 			return "Aux5";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_6:
+		case Aux_6:
 			return "Aux6";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_7:
+		case Aux_7:
 			return "Aux7";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B1:
+		case Aux_B1:
 			return "Aux B1";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B2:
+		case Aux_B2:
 			return "Aux B2";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B3:
+		case Aux_B3:
 			return "Aux B3";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B4:
+		case Aux_B4:
 			return "Aux B4";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B5:
+		case Aux_B5:
 			return "Aux B5";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B6:
+		case Aux_B6:
 			return "Aux B6";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B7:
+		case Aux_B7:
 			return "Aux B7";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_B8:
+		case Aux_B8:
 			return "Aux B8";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C1:
+		case Aux_C1:
 			return "Aux C1";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C2:
+		case Aux_C2:
 			return "Aux C2";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C3:
+		case Aux_C3:
 			return "Aux C3";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C4:
+		case Aux_C4:
 			return "Aux C4";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C5:
+		case Aux_C5:
 			return "Aux C5";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C6:
+		case Aux_C6:
 			return "Aux C6";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C7:
+		case Aux_C7:
 			return "Aux C7";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_C8:
+		case Aux_C8:
 			return "Aux C8";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D1:
+		case Aux_D1:
 			return "Aux D1";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D2:
+		case Aux_D2:
 			return "Aux D2";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D3:
+		case Aux_D3:
 			return "Aux D3";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D4:
+		case Aux_D4:
 			return "Aux D4";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D5:
+		case Aux_D5:
 			return "Aux D5";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D6:
+		case Aux_D6:
 			return "Aux D6";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D7:
+		case Aux_D7:
 			return "Aux D7";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::Aux_D8:
+		case Aux_D8:
 			return "Aux D8";
-		case AqualinkAutomate::Auxillaries::JandyAuxillaryIds::ExtraAux:
+		case ExtraAux:
 			return "Extra Aux";
 		}
 

--- a/src/jandy/auxillaries/jandy_auxillary_traits_types.h
+++ b/src/jandy/auxillaries/jandy_auxillary_traits_types.h
@@ -11,6 +11,7 @@ namespace AqualinkAutomate::Auxillaries
 	class JandyAuxillaryId : public Kernel::ImmutableTraitType<const Auxillaries::JandyAuxillaryIds>
 	{
 	public:
+		virtual ~JandyAuxillaryId() = default;
 		TraitKey Name() const final { return std::string{"JandyAuxillaryId"}; }
 	};
 

--- a/src/jandy/auxillaries/jandy_powercenter_mapping.h
+++ b/src/jandy/auxillaries/jandy_powercenter_mapping.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <utility>
 
 #include "auxillaries/jandy_auxillary_id.h"
 #include "kernel/powercenter.h"
@@ -16,25 +17,27 @@ namespace AqualinkAutomate::Auxillaries
 	// is what makes it correct for dual-equipment models and DIP-repurposed relays.
 	inline constexpr std::optional<Kernel::PowerCenterIds> PowerCenterForAuxId(JandyAuxillaryIds id)
 	{
-		if (const auto value = static_cast<uint8_t>(id); value == static_cast<uint8_t>(JandyAuxillaryIds::ExtraAux))
+		using enum Kernel::PowerCenterIds;
+
+		if (const auto value = std::to_underlying(id); value == std::to_underlying(JandyAuxillaryIds::ExtraAux))
 		{
 			return std::nullopt;
 		}
 		else if ((value >= 0x01) && (value <= 0x07))
 		{
-			return Kernel::PowerCenterIds::A;
+			return A;
 		}
 		else if ((value >= 0x08) && (value <= 0x0F))
 		{
-			return Kernel::PowerCenterIds::B;
+			return B;
 		}
 		else if ((value >= 0x10) && (value <= 0x17))
 		{
-			return Kernel::PowerCenterIds::C;
+			return C;
 		}
 		else if ((value >= 0x18) && (value <= 0x1F))
 		{
-			return Kernel::PowerCenterIds::D;
+			return D;
 		}
 
 		return std::nullopt;

--- a/src/jandy/concepts/jandy_message_type.cpp
+++ b/src/jandy/concepts/jandy_message_type.cpp
@@ -1,9 +1,1 @@
 #include "concepts/jandy_message_type.h"
-
-namespace AqualinkAutomate::Concepts
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Concepts

--- a/src/jandy/devices/aquarite_device.cpp
+++ b/src/jandy/devices/aquarite_device.cpp
@@ -143,7 +143,7 @@ namespace AqualinkAutomate::Devices
 		return m_SaltPPM;
 	}
 
-	void AquariteDevice::Slot_Aquarite_GetId(const Messages::AquariteMessage_GetId& msg)
+	void AquariteDevice::Slot_Aquarite_GetId([[maybe_unused]] const Messages::AquariteMessage_GetId& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("AquariteDevice::Slot_Aquarite_GetId", std::source_location::current());
 

--- a/src/jandy/devices/aquarite_device.h
+++ b/src/jandy/devices/aquarite_device.h
@@ -108,7 +108,6 @@ namespace AqualinkAutomate::Devices
 		void Slot_Aquarite_Percent(const Messages::AquariteMessage_Percent& msg);
 		void Slot_Aquarite_PPM(const Messages::AquariteMessage_PPM& msg);
 
-	private:
 		void EnsureChlorinatorDeviceExists();
 		void PushPercentToDataHub(const Messages::AquariteMessage_Percent& msg);
 		void PushPPMToDataHub(const Messages::AquariteMessage_PPM& msg);

--- a/src/jandy/devices/capabilities/emulated.h
+++ b/src/jandy/devices/capabilities/emulated.h
@@ -18,9 +18,8 @@ namespace AqualinkAutomate::Devices::Capabilities
 	class Emulated : public Interfaces::IEmulatedDevice
 	{
 	protected:
-		Emulated(bool is_emulated);
+		explicit Emulated(bool is_emulated);
 
-	protected:
 		template<typename ACK_VALUE>
 			requires std::is_enum_v<ACK_VALUE> && std::same_as<std::underlying_type_t<ACK_VALUE>, uint8_t>
 		void Signal_AckMessage(Messages::AckTypes ack_type, ACK_VALUE data_value_to_send) const

--- a/src/jandy/devices/capabilities/scrapeable.cpp
+++ b/src/jandy/devices/capabilities/scrapeable.cpp
@@ -234,9 +234,7 @@ namespace AqualinkAutomate::Devices::Capabilities
 				(m_ExpectedSource == m_ExpectedDestination) ||
 				(m_ExpectedSource == Utility::ScreenDataPageTypes::Page_Unknown &&
 				 m_ExpectedDestination == Utility::ScreenDataPageTypes::Page_Unknown);
-			bool is_page_transition = !is_cursor_movement;
-
-			if (is_page_transition)
+			if (bool is_page_transition = !is_cursor_movement)
 			{
 				LogDebug(Channel::Scraping, std::format("Page transition: {} -> {}, waiting for 2 Status messages",
 					magic_enum::enum_name(m_ExpectedSource), magic_enum::enum_name(m_ExpectedDestination)));

--- a/src/jandy/devices/capabilities/scrapeable.h
+++ b/src/jandy/devices/capabilities/scrapeable.h
@@ -52,13 +52,11 @@ namespace AqualinkAutomate::Devices::Capabilities
 			Faulted                  // Unrecoverable error
 		};
 
-	public:
 		using ScrapeId = uint32_t;
 		using ScraperGraph = Utility::ScreenDataPageGraph;
 		using ScraperIter = Utility::ScreenDataPageGraphImpl::ForwardIterator;
 		using KeyCommand = Utility::ScreenDataPageGraphImpl::KeyCommand;
 
-	public:
 		static constexpr uint32_t MAX_RECOVERY_ATTEMPTS = 3;
 		static constexpr uint32_t MAX_BACK_PRESSES = 10;
 
@@ -74,9 +72,6 @@ namespace AqualinkAutomate::Devices::Capabilities
 		template<typename... MESSAGE_TYPES>
 		Scrapeable(const Devices::JandyDeviceType device_id, GraphDataMap graphs, MESSAGE_TYPES ...) :
 			m_ScraperGraphs(graphs),
-			m_ActiveScrape(std::nullopt),
-			m_Stack_WaitingForPage(),
-			m_Stack_WaitingForMessage(),
 			m_ParentDeviceId(device_id)
 		{
 			// Note: Message handling is now done via explicit OnStatusMessageReceived() calls
@@ -86,19 +81,15 @@ namespace AqualinkAutomate::Devices::Capabilities
 			// might pop messages before the current command's push, or run at unpredictable times.
 		}
 
-	public:
 		void ScrapingStart(ScrapeId scrape_graph_id, const uint32_t starting_index = 1);
 
-	public:
 		// Call this when a Status message is received to pop from the wait stack.
 		// This should be called BEFORE ScrapingNextWithValidation to ensure
 		// the wait stack is updated before processing.
 		void OnStatusMessageReceived();
 
-	public:
 		std::expected<KeyCommand, ErrorCodes::Scrapeable_ErrorCodes> ScrapingNext();
 
-	public:
 		// Main validation-aware scraping method
 		std::expected<KeyCommand, ErrorCodes::Scrapeable_ErrorCodes>
 			ScrapingNextWithValidation(Utility::ScreenDataPageTypes current_page);
@@ -119,14 +110,12 @@ namespace AqualinkAutomate::Devices::Capabilities
 
 	private:
 		GraphDataMap m_ScraperGraphs;
-		std::optional<std::tuple<ScrapeId, ScraperIter>> m_ActiveScrape;
+		std::optional<std::tuple<ScrapeId, ScraperIter>> m_ActiveScrape{ std::nullopt };
 
-	private:
 		std::stack<Utility::ScreenDataPageTypes> m_Stack_WaitingForPage;
 		std::stack<Messages::JandyMessageIds> m_Stack_WaitingForMessage;
 		const Devices::JandyDeviceType m_ParentDeviceId;
 
-	private:
 		ScrapeState m_ScrapeState{ ScrapeState::Idle };
 		uint32_t m_RecoveryAttempts{ 0 };
 		uint32_t m_RecoveryBackPresses{ 0 };

--- a/src/jandy/devices/capabilities/screen.cpp
+++ b/src/jandy/devices/capabilities/screen.cpp
@@ -16,9 +16,7 @@ namespace AqualinkAutomate::Devices::Capabilities
 
 	Screen::Screen(uint8_t screen_lines) :
 		m_DisplayedPage(screen_lines),
-		m_DisplayedPageType(Utility::ScreenDataPageTypes::Page_Unknown),
-		m_DisplayedPageUpdater(m_DisplayedPage),
-		m_DisplayedPageProcessors()
+		m_DisplayedPageUpdater(m_DisplayedPage)
 	{
 		m_DisplayedPageUpdater.initiate();
 	}
@@ -31,21 +29,21 @@ namespace AqualinkAutomate::Devices::Capabilities
 		{
 		case ScreenModes::Normal:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> normal_mode", std::source_location::current());
+			auto normal_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> normal_mode", std::source_location::current());
 			LogTrace(Channel::Devices, "Device screen mode -> normal");
 			break;
 		}
 
 		case ScreenModes::Updating:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> updating_mode", std::source_location::current());
+			auto updating_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> updating_mode", std::source_location::current());
 			LogTrace(Channel::Devices, "Device screen mode -> updating");
 			break;
 		}
 
 		case ScreenModes::UpdateComplete:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> update_complete", std::source_location::current());
+			auto update_complete_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> update_complete", std::source_location::current());
 			LogTrace(Channel::Devices, "Device screen mode -> update complete");
 
 			// Set the current page to "unknown"; if there's a page processor, we'll set the page to that later...
@@ -55,7 +53,7 @@ namespace AqualinkAutomate::Devices::Capabilities
 			auto actionable_processors = m_DisplayedPageProcessors | std::views::filter([this](const decltype(m_DisplayedPageProcessors)::value_type& processor) { return processor.CanProcess(m_DisplayedPage); });
 			for (auto& processor : actionable_processors)
 			{
-				auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> process_page", std::source_location::current());
+				auto process_page_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("Screen::ProcessScreenUpdates -> process_page", std::source_location::current());
 				LogTrace(Channel::Devices, std::format("Device screen mode -> processing page {}", magic_enum::enum_name(processor.PageType())));
 
 				// As there's a specific processor, set the page type to the processor's page type.

--- a/src/jandy/devices/capabilities/screen.h
+++ b/src/jandy/devices/capabilities/screen.h
@@ -22,9 +22,8 @@ namespace AqualinkAutomate::Devices::Capabilities
 	class Screen
 	{
 	public:
-		Screen(uint8_t screen_lines);
+		explicit Screen(uint8_t screen_lines);
 
-	public:
 		Utility::ScreenDataPage const& DisplayedPage() const;
 		Utility::ScreenDataPageTypes DisplayedPageType() const;
 
@@ -44,7 +43,7 @@ namespace AqualinkAutomate::Devices::Capabilities
 
 	private:
 		Utility::ScreenDataPage m_DisplayedPage;
-		Utility::ScreenDataPageTypes m_DisplayedPageType;
+		Utility::ScreenDataPageTypes m_DisplayedPageType{ Utility::ScreenDataPageTypes::Page_Unknown };
 
 	public:
 		template<typename EVENT_TYPE>
@@ -53,10 +52,8 @@ namespace AqualinkAutomate::Devices::Capabilities
 			m_DisplayedPageUpdater.process_event(event_type);
 		}
 
-	public:
 		void ProcessScreenUpdates();
 
-	public:
 		ScreenModes ScreenMode() const;
 		void ScreenMode(ScreenModes screen_mode);
 

--- a/src/jandy/devices/chemlink_device.h
+++ b/src/jandy/devices/chemlink_device.h
@@ -22,7 +22,7 @@ namespace AqualinkAutomate::Devices
 		using TimestampedFeederState = std::pair<bool, std::chrono::time_point<std::chrono::system_clock>>;
 
 	public:
-		ChemlinkDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
+		explicit ChemlinkDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
 		~ChemlinkDevice() override = default;
 
 	private:

--- a/src/jandy/devices/epump_device.h
+++ b/src/jandy/devices/epump_device.h
@@ -23,7 +23,7 @@ namespace AqualinkAutomate::Devices
 		using TimestampedWatts = std::pair<uint16_t, std::chrono::time_point<std::chrono::system_clock>>;
 
 	public:
-		EPumpDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
+		explicit EPumpDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
 		~EPumpDevice() override = default;
 
 	private:

--- a/src/jandy/devices/heater_device.h
+++ b/src/jandy/devices/heater_device.h
@@ -24,7 +24,7 @@ namespace AqualinkAutomate::Devices
 		using TimestampedError = std::pair<Messages::HeaterErrors, std::chrono::time_point<std::chrono::system_clock>>;
 
 	public:
-		HeaterDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
+		explicit HeaterDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
 		~HeaterDevice() override = default;
 
 	private:

--- a/src/jandy/devices/iaq/iaq_messageprocessors.cpp
+++ b/src/jandy/devices/iaq/iaq_messageprocessors.cpp
@@ -17,7 +17,7 @@ using namespace AqualinkAutomate::Profiling;
 namespace AqualinkAutomate::Devices
 {
 
-	void IAQDevice::Slot_IAQ_Poll(const Messages::IAQMessage_Poll& msg)
+	void IAQDevice::Slot_IAQ_Poll([[maybe_unused]] const Messages::IAQMessage_Poll& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_Poll", std::source_location::current(), UnitColours::Red);
 
@@ -128,7 +128,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_PageEnd(const Messages::IAQMessage_PageEnd& msg)
+	void IAQDevice::Slot_IAQ_PageEnd([[maybe_unused]] const Messages::IAQMessage_PageEnd& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_PageEnd", std::source_location::current(), UnitColours::Red);
 
@@ -192,7 +192,7 @@ namespace AqualinkAutomate::Devices
 		m_ControllerScheduleStore->Replace(Scheduling::ControllerScheduleStatus::Available, std::move(schedules), group);
 	}
 
-	void IAQDevice::Slot_IAQ_PageContinue(const Messages::IAQMessage_PageContinue& msg)
+	void IAQDevice::Slot_IAQ_PageContinue([[maybe_unused]] const Messages::IAQMessage_PageContinue& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_PageContinue", std::source_location::current(), UnitColours::Red);
 
@@ -313,7 +313,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_MessageLong(const Messages::IAQMessage_MessageLong& msg)
+	void IAQDevice::Slot_IAQ_MessageLong([[maybe_unused]] const Messages::IAQMessage_MessageLong& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_MessageLong", std::source_location::current(), UnitColours::Red);
 
@@ -324,7 +324,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_StartUp(const Messages::IAQMessage_StartUp& msg)
+	void IAQDevice::Slot_IAQ_StartUp([[maybe_unused]] const Messages::IAQMessage_StartUp& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_StartUp", std::source_location::current(), UnitColours::Red);
 
@@ -335,7 +335,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_ControlReady(const Messages::IAQMessage_ControlReady& msg)
+	void IAQDevice::Slot_IAQ_ControlReady([[maybe_unused]] const Messages::IAQMessage_ControlReady& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_ControlReady", std::source_location::current(), UnitColours::Red);
 
@@ -356,7 +356,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_CommandReady(const Messages::IAQMessage_CommandReady& msg)
+	void IAQDevice::Slot_IAQ_CommandReady([[maybe_unused]] const Messages::IAQMessage_CommandReady& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_CommandReady", std::source_location::current(), UnitColours::Red);
 
@@ -367,7 +367,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_OneTouchStatus(const Messages::IAQMessage_OneTouchStatus& msg)
+	void IAQDevice::Slot_IAQ_OneTouchStatus([[maybe_unused]] const Messages::IAQMessage_OneTouchStatus& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_OneTouchStatus", std::source_location::current(), UnitColours::Red);
 
@@ -378,7 +378,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void IAQDevice::Slot_IAQ_Heartbeat(const Messages::IAQMessage_Heartbeat& msg)
+	void IAQDevice::Slot_IAQ_Heartbeat([[maybe_unused]] const Messages::IAQMessage_Heartbeat& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("IAQDevice::Slot_IAQ_Heartbeat", std::source_location::current(), UnitColours::Red);
 

--- a/src/jandy/devices/iaq_device.cpp
+++ b/src/jandy/devices/iaq_device.cpp
@@ -56,8 +56,6 @@ namespace AqualinkAutomate::Devices
 		Capabilities::Restartable(IAQ_TIMEOUT_DURATION),
 		Capabilities::Screen(IAQ_STATUS_PAGE_LINES),
 		Capabilities::Emulated(is_emulated),
-		m_StatusPage(IAQ_STATUS_PAGE_LINES),
-		m_TableInfo(IAQ_MESSAGE_TABLE_LINES),
 		m_SM_PageUpdate(m_StatusPage),
 		m_SM_TableUpdate(m_TableInfo),
 		m_ProfilingDomain(std::move(Factory::ProfilingUnitFactory::Instance().CreateDomain("IAQDevice")))

--- a/src/jandy/devices/iaq_device.h
+++ b/src/jandy/devices/iaq_device.h
@@ -87,7 +87,6 @@ namespace AqualinkAutomate::Devices
 		IAQDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id, Kernel::HubLocator& hub_locator, bool is_emulated);
 		~IAQDevice() override;
 
-	public:
 		nlohmann::json DescribeDiagnostics() const override;
 
 		void QueueCommand(uint8_t command);
@@ -198,7 +197,6 @@ namespace AqualinkAutomate::Devices
 		void Slot_IAQ_TableMessage(const Messages::IAQMessage_TableMessage& msg);
 		void Slot_IAQ_TitleMessage(const Messages::IAQMessage_TitleMessage& msg);
 
-	private:
 		void ProcessMainStatus(const Messages::IAQMessage_MainStatus& msg);
 		void ProcessAuxStatus(const Messages::IAQMessage_AuxStatus& msg);
 
@@ -211,7 +209,6 @@ namespace AqualinkAutomate::Devices
 		// registry) so it drains one command per poll. Emulated + survey-enabled + not-run only.
 		void MaybeStartPageSurvey();
 
-	private:
 		// Render the live decoded system status into the device's Screen capability
 		// as a fixed "System Status" page so the diagnostics "Actual Devices" card
 		// shows real data instead of Page_Unknown.  The IAQ (iAqualink2 cloud
@@ -226,11 +223,9 @@ namespace AqualinkAutomate::Devices
 		// but the content is the heartbeat liveness, not decoded system status.
 		void RenderCloudLinkScreen();
 
-	private:
-		Utility::ScreenDataPage m_StatusPage;
-		Utility::ScreenDataPage m_TableInfo;
+		Utility::ScreenDataPage m_StatusPage{ IAQ_STATUS_PAGE_LINES };
+		Utility::ScreenDataPage m_TableInfo{ IAQ_MESSAGE_TABLE_LINES };
 
-	private:
 		Utility::ScreenDataPageUpdater<Utility::ScreenDataPage> m_SM_PageUpdate;
 		Utility::ScreenDataPageUpdater<Utility::ScreenDataPage> m_SM_TableUpdate;
 
@@ -242,7 +237,6 @@ namespace AqualinkAutomate::Devices
 		// control-data response ("1" + value).
 		Capabilities::ActuationResult QueueSetpoint(uint8_t select_field_command, uint8_t temperature, const char* body_name);
 
-	private:
 		// The decoded live-page UI state: current page id, title, on-screen PageButton table, and
 		// the schedule / device-picker / spa-switch-picker row accumulators. Written by the IAQ
 		// message slots and read by the actuators + the write state machines. Extracted from this
@@ -270,7 +264,6 @@ namespace AqualinkAutomate::Devices
 		// (as ICommandSink), passing m_PageModel + m_StatusPage (for the time picker's AM/PM line).
 		IAQ::ScheduleWriter m_ScheduleWriter;
 
-	private:
 		// ICommandSink: the write state machines emit their per-poll command through these. IssueCommand
 		// sets the single pending poll-ACK byte (no logging -- it fires every poll); ArmControlValue
 		// primes the control-data handshake (value + awaiting flag); IsBusy reports the command channel
@@ -292,7 +285,6 @@ namespace AqualinkAutomate::Devices
 		// MaybeStartPageSurvey (emulated + home established) consumes it once into the command queue.
 		IAQ::PageSurvey m_PageSurvey;
 
-	private:
 		Types::ProfilingUnitTypePtr m_ProfilingDomain;
 	};
 

--- a/src/jandy/devices/jandy_device.cpp
+++ b/src/jandy/devices/jandy_device.cpp
@@ -6,8 +6,7 @@ namespace AqualinkAutomate::Devices
 
 	JandyDevice::JandyDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id) :
 		IDevice(device_id),
-		IStatusPublisher(DeviceStatus_Unknown{}),
-		m_SlotManager()
+		IStatusPublisher(DeviceStatus_Unknown{})
 	{
 	}
 

--- a/src/jandy/devices/jandy_device.h
+++ b/src/jandy/devices/jandy_device.h
@@ -13,10 +13,9 @@ namespace AqualinkAutomate::Devices
 	class JandyDevice : public Interfaces::IDevice, public Interfaces::IStatusPublisher
 	{
 	public:
-		JandyDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
+		explicit JandyDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id);
 		~JandyDevice() override = default;
 
-	public:
 		const Devices::JandyDeviceType& DeviceId() const;
 
 	protected:

--- a/src/jandy/devices/jandy_device_id.h
+++ b/src/jandy/devices/jandy_device_id.h
@@ -15,10 +15,8 @@ namespace AqualinkAutomate::Devices
 		constexpr JandyDeviceId() : m_DeviceId(0) {}
 		constexpr JandyDeviceId(value_type device_id) : m_DeviceId(device_id) {}
 
-	public:
 		constexpr value_type operator()() const { return m_DeviceId; }
 
-	public:
 		constexpr bool operator==(const JandyDeviceId& other) const { return (m_DeviceId == other.m_DeviceId); }
 		constexpr bool operator!=(const JandyDeviceId& other) const { return !operator==(other); }
 

--- a/src/jandy/devices/jandy_device_types.cpp
+++ b/src/jandy/devices/jandy_device_types.cpp
@@ -6,7 +6,6 @@ namespace AqualinkAutomate::Devices
 {
 
 	JandyDeviceType::JandyDeviceType() :
-		m_DeviceClass(DeviceClasses::Unknown),
 		m_DeviceId(0xFF)
 	{
 	}

--- a/src/jandy/devices/jandy_device_types.h
+++ b/src/jandy/devices/jandy_device_types.h
@@ -75,13 +75,11 @@ namespace AqualinkAutomate::Devices
 		JandyDeviceType();
 		JandyDeviceType(DeviceId device_id);
 
-	public:
 		JandyDeviceType(const JandyDeviceType& other) = default;
 		JandyDeviceType& operator=(const JandyDeviceType& other) = default;
 		JandyDeviceType(JandyDeviceType&& other) noexcept = default;
 		JandyDeviceType& operator=(JandyDeviceType&& other) noexcept = default;
 
-	public:
 		bool operator==(const JandyDeviceType& other) const;
 		bool operator!=(const JandyDeviceType& other) const;
 		using Interfaces::IDeviceIdentifier::operator==;
@@ -93,7 +91,6 @@ namespace AqualinkAutomate::Devices
 	public:
 		DeviceId operator()() const;
 
-	public:
 		DeviceClasses Class() const;
 		DeviceId Id() const;
 
@@ -104,7 +101,7 @@ namespace AqualinkAutomate::Devices
 		static std::vector<std::uint8_t> InstanceAddressesForClass(DeviceClasses device_class);
 
 	private:
-		DeviceClasses m_DeviceClass;
+		DeviceClasses m_DeviceClass{ DeviceClasses::Unknown };
 		DeviceId m_DeviceId;
 	};
 

--- a/src/jandy/devices/jandy_emulated_device_types.cpp
+++ b/src/jandy/devices/jandy_emulated_device_types.cpp
@@ -1,9 +1,1 @@
 #include "devices/jandy_emulated_device_types.h"
-
-namespace AqualinkAutomate::Devices
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Devices

--- a/src/jandy/devices/keypad/keypad_messageprocessors.cpp
+++ b/src/jandy/devices/keypad/keypad_messageprocessors.cpp
@@ -12,7 +12,7 @@ using namespace AqualinkAutomate::Logging;
 
 namespace AqualinkAutomate::Devices
 {
-	void KeypadDevice::Slot_Keypad_Ack(const Messages::JandyMessage_Ack& msg)
+	void KeypadDevice::Slot_Keypad_Ack([[maybe_unused]] const Messages::JandyMessage_Ack& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("KeypadDevice::Slot_Keypad_Ack", std::source_location::current());
 
@@ -24,7 +24,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void KeypadDevice::Slot_Keypad_Probe(const Messages::JandyMessage_Probe& msg)
+	void KeypadDevice::Slot_Keypad_Probe([[maybe_unused]] const Messages::JandyMessage_Probe& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("KeypadDevice::Slot_Keypad_Probe", std::source_location::current());
 
@@ -37,7 +37,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void KeypadDevice::Slot_Keypad_Message(const Messages::JandyMessage_Message& msg)
+	void KeypadDevice::Slot_Keypad_Message([[maybe_unused]] const Messages::JandyMessage_Message& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("KeypadDevice::Slot_Keypad_Message", std::source_location::current());
 
@@ -50,7 +50,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void KeypadDevice::Slot_Keypad_MessageLong(const Messages::JandyMessage_MessageLong& msg)
+	void KeypadDevice::Slot_Keypad_MessageLong([[maybe_unused]] const Messages::JandyMessage_MessageLong& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("KeypadDevice::Slot_Keypad_MessageLong", std::source_location::current());
 
@@ -63,7 +63,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void KeypadDevice::Slot_Keypad_Status(const Messages::JandyMessage_Status& msg)
+	void KeypadDevice::Slot_Keypad_Status([[maybe_unused]] const Messages::JandyMessage_Status& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("KeypadDevice::Slot_Keypad_Status", std::source_location::current());
 

--- a/src/jandy/devices/keypad_device.cpp
+++ b/src/jandy/devices/keypad_device.cpp
@@ -31,10 +31,14 @@ namespace AqualinkAutomate::Devices
 
 	void KeypadDevice::ProcessControllerUpdates()
 	{
+		// Intentionally empty: the RS Keypad is a passive decoder and has no periodic
+		// controller-side state to advance; ACKs are emitted directly from the slot handlers.
 	}
 
 	void KeypadDevice::WatchdogTimeoutOccurred()
 	{
+		// Intentionally empty: loss of communications on the passive RS Keypad requires no
+		// device-side state change.
 	}
 
 	nlohmann::json KeypadDevice::DescribeDiagnostics() const

--- a/src/jandy/devices/keypad_device.h
+++ b/src/jandy/devices/keypad_device.h
@@ -39,10 +39,8 @@ namespace AqualinkAutomate::Devices
 	private:
 		void ProcessControllerUpdates() override;
 
-	private:
 		void WatchdogTimeoutOccurred() override;
 
-	private:
 		void Slot_Keypad_Ack(const Messages::JandyMessage_Ack& msg);
 		void Slot_Keypad_Probe(const Messages::JandyMessage_Probe& msg);
 		void Slot_Keypad_Message(const Messages::JandyMessage_Message& msg);

--- a/src/jandy/devices/onetouch/onetouch_goals.cpp
+++ b/src/jandy/devices/onetouch/onetouch_goals.cpp
@@ -545,6 +545,8 @@ namespace AqualinkAutomate::Devices::OneTouch
 
 	std::optional<GoalStatus> ScheduleWriteGoal::StepHour(KeypadContext& ctx, uint8_t line, int target_hour, Phase next)
 	{
+		using enum Navigation::NavKeyCommand;
+
 		// Step a 12h+meridiem hour wheel (24 positions) toward target_hour closed-loop: read the
 		// echoed value, emit ONE key the shorter way round, Select once matched. Advances to next.
 		if (!OnEditorPage(ctx)) { return std::nullopt; }   // page mid-transition; wait
@@ -552,33 +554,35 @@ namespace AqualinkAutomate::Devices::OneTouch
 		if (!cur.has_value()) { return std::nullopt; }     // value blanked mid-render; wait
 		if (cur->first == target_hour)
 		{
-			ctx.Emit(Navigation::NavKeyCommand::Select);   // commit the hour, advance to the minute
+			ctx.Emit(Select);   // commit the hour, advance to the minute
 			m_Phase = next;
 			m_FieldStep = 0;
 			return std::nullopt;
 		}
 		if (++m_FieldStep > MAX_STEP) { return GoalStatus::Failed; }
 		const int forward = ((target_hour - cur->first) + 24) % 24;   // steps if we go LineUp (+1/step)
-		ctx.Emit((forward <= 12) ? Navigation::NavKeyCommand::LineUp : Navigation::NavKeyCommand::LineDown);
+		ctx.Emit((forward <= 12) ? LineUp : LineDown);
 		return std::nullopt;
 	}
 
 	std::optional<GoalStatus> ScheduleWriteGoal::StepMinute(KeypadContext& ctx, uint8_t line, int target_minute, Phase next)
 	{
+		using enum Navigation::NavKeyCommand;
+
 		// Step a 0-59 minute wheel toward target_minute closed-loop, then Select to advance.
 		if (!OnEditorPage(ctx)) { return std::nullopt; }
 		auto cur = DisplayedTime(ctx, line);
 		if (!cur.has_value()) { return std::nullopt; }
 		if (cur->second == target_minute)
 		{
-			ctx.Emit(Navigation::NavKeyCommand::Select);
+			ctx.Emit(Select);
 			m_Phase = next;
 			m_FieldStep = 0;
 			return std::nullopt;
 		}
 		if (++m_FieldStep > MAX_STEP) { return GoalStatus::Failed; }
 		const int forward = ((target_minute - cur->second) + 60) % 60;
-		ctx.Emit((forward <= 30) ? Navigation::NavKeyCommand::LineUp : Navigation::NavKeyCommand::LineDown);
+		ctx.Emit((forward <= 30) ? LineUp : LineDown);
 		return std::nullopt;
 	}
 

--- a/src/jandy/devices/onetouch/onetouch_keypad.cpp
+++ b/src/jandy/devices/onetouch/onetouch_keypad.cpp
@@ -12,16 +12,18 @@ namespace AqualinkAutomate::Devices::OneTouch
 
 	bool KeypadContext::MoveCursorToward(uint8_t target_line)
 	{
+		using enum Navigation::NavKeyCommand;
+
 		if (highlighted_line == target_line)
 		{
 			return true;
 		}
 		if (highlighted_line == Navigation::Navigator::CURSOR_LINE_NONE)
 		{
-			Emit(Navigation::NavKeyCommand::LineDown);   // establish a cursor first
+			Emit(LineDown);   // establish a cursor first
 			return false;
 		}
-		Emit((highlighted_line < target_line) ? Navigation::NavKeyCommand::LineDown : Navigation::NavKeyCommand::LineUp);
+		Emit((highlighted_line < target_line) ? LineDown : LineUp);
 		return false;
 	}
 

--- a/src/jandy/devices/onetouch/onetouch_message_router.cpp
+++ b/src/jandy/devices/onetouch/onetouch_message_router.cpp
@@ -30,13 +30,11 @@ namespace AqualinkAutomate::Devices
 
 		LogTrace(Channel::Devices, [this, &msg]() { return std::format("OneTouch ({}): Received JandyMessage_Ack: raw_command=0x{:02x}", m_Device.DeviceId(), msg.Command()); });
 
-		OneTouchDevice::KeyCommands key_press = msg.Command<OneTouchDevice::KeyCommands>([](uint8_t command_id)
+		if (OneTouchDevice::KeyCommands key_press = msg.Command<OneTouchDevice::KeyCommands>([](uint8_t command_id)
 			{
 				return magic_enum::enum_cast<OneTouchDevice::KeyCommands>(command_id).value_or(OneTouchDevice::KeyCommands::Unknown);
 			}
-		);
-
-		if (key_press == OneTouchDevice::KeyCommands::Unknown)
+		); key_press == OneTouchDevice::KeyCommands::Unknown)
 		{
 			LogWarning(Channel::Devices, [this, &msg]() { return std::format("OneTouch ({}): Unknown key command received in ACK: 0x{:02x}", m_Device.DeviceId(), msg.Command()); });
 		}
@@ -76,7 +74,7 @@ namespace AqualinkAutomate::Devices
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): Watchdog kicked (MessageLong)", m_Device.DeviceId()); });
 	}
 
-	void OneTouchMessageRouter::Slot_OneTouch_Probe(const Messages::JandyMessage_Probe& msg)
+	void OneTouchMessageRouter::Slot_OneTouch_Probe([[maybe_unused]] const Messages::JandyMessage_Probe& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::Slot_Probe", std::source_location::current(), Profiling::UnitColours::Red);
 
@@ -89,7 +87,7 @@ namespace AqualinkAutomate::Devices
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): Watchdog kicked (Probe)", m_Device.DeviceId()); });
 	}
 
-	void OneTouchMessageRouter::Slot_OneTouch_Status(const Messages::JandyMessage_Status& msg)
+	void OneTouchMessageRouter::Slot_OneTouch_Status([[maybe_unused]] const Messages::JandyMessage_Status& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::Slot_Status", std::source_location::current(), Profiling::UnitColours::Red);
 
@@ -138,7 +136,7 @@ namespace AqualinkAutomate::Devices
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): Watchdog kicked (Status)", m_Device.DeviceId()); });
 	}
 
-	void OneTouchMessageRouter::Slot_OneTouch_Clear(const Messages::PDAMessage_Clear& msg)
+	void OneTouchMessageRouter::Slot_OneTouch_Clear([[maybe_unused]] const Messages::PDAMessage_Clear& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::Slot_Clear", std::source_location::current(), Profiling::UnitColours::Red);
 
@@ -242,7 +240,7 @@ namespace AqualinkAutomate::Devices
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): Watchdog kicked (ShiftLines)", m_Device.DeviceId()); });
 	}
 
-	void OneTouchMessageRouter::Slot_OneTouch_DisplayUpdate(const Messages::JandyMessage_DisplayUpdate& msg)
+	void OneTouchMessageRouter::Slot_OneTouch_DisplayUpdate([[maybe_unused]] const Messages::JandyMessage_DisplayUpdate& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::Slot_DisplayUpdate", std::source_location::current(), Profiling::UnitColours::Red);
 

--- a/src/jandy/devices/onetouch/onetouch_pageprocessors.cpp
+++ b/src/jandy/devices/onetouch/onetouch_pageprocessors.cpp
@@ -91,7 +91,7 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void OneTouchScraper::PageProcessor_Service(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_Service([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_Service", std::source_location::current());
 
@@ -140,7 +140,7 @@ namespace AqualinkAutomate::Devices
 		m_DataHub->TimeoutRemaining = Utility::TimeoutDurationStringConverter(Utility::TrimWhitespace(page[10].Text));
 	}
 
-	void OneTouchScraper::PageProcessor_OneTouch(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_OneTouch([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_OneTouch", std::source_location::current());
 
@@ -301,14 +301,14 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void OneTouchScraper::PageProcessor_SelectSpeed(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_SelectSpeed([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_SelectSpeed", std::source_location::current());
 
 		LogDebug(Channel::Devices, [this]() { return std::format("OneTouch ({}): OneTouch device is processing a PageProcessor_SelectSpeed page.", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_MenuHelp(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_MenuHelp([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_MenuHelp", std::source_location::current());
 
@@ -401,14 +401,14 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void OneTouchScraper::PageProcessor_SetTime(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_SetTime([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_SetTime", std::source_location::current());
 
 		LogDebug(Channel::Devices, [this]() { return std::format("OneTouch ({}): OneTouch device is processing a PageProcessor_SetTime page.", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_SystemSetup(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_SystemSetup([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_SystemSetup", std::source_location::current());
 
@@ -442,7 +442,7 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void OneTouchScraper::PageProcessor_Boost(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_Boost([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_Boost", std::source_location::current());
 
@@ -611,7 +611,7 @@ namespace AqualinkAutomate::Devices
 		LogInfo(Channel::Devices, [&model_number, &panel_type, &fw_revision]() { return std::format("Aqualink Power Center - Model: {}, Type: {}, Rev: {}", model_number, panel_type, fw_revision); });
 	}
 
-	void OneTouchScraper::PageProcessor_DiagnosticsSensors(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_DiagnosticsSensors([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_DiagnosticsSensors", std::source_location::current());
 
@@ -633,7 +633,7 @@ namespace AqualinkAutomate::Devices
 		*/
 	}
 
-	void OneTouchScraper::PageProcessor_DiagnosticsRemotes(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_DiagnosticsRemotes([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_DiagnosticsRemotes", std::source_location::current());
 
@@ -655,7 +655,7 @@ namespace AqualinkAutomate::Devices
 		*/
 	}
 
-	void OneTouchScraper::PageProcessor_DiagnosticsErrors(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_DiagnosticsErrors([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_DiagnosticsErrors", std::source_location::current());
 
@@ -677,7 +677,7 @@ namespace AqualinkAutomate::Devices
 		*/
 	}
 
-	void OneTouchScraper::PageProcessor_LabelAuxList(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_LabelAuxList([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchScraper::PageProcessor_LabelAuxList", std::source_location::current());
 
@@ -784,17 +784,17 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void OneTouchScraper::PageProcessor_MoreOneTouch(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_MoreOneTouch([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_MoreOneTouch invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_SetPoolHeat(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_SetPoolHeat([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_SetPoolHeat invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_SetSpaHeat(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_SetSpaHeat([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_SetSpaHeat invoked", DeviceId()); });
 	}
@@ -877,52 +877,52 @@ namespace AqualinkAutomate::Devices
 		m_ControllerScheduleStore->Replace(Scheduling::ControllerScheduleStatus::Available, std::move(schedules), m_ControllerScheduleGroup);
 	}
 
-	void OneTouchScraper::PageProcessor_DisplayLight(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_DisplayLight([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_DisplayLight invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_Lockouts(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_Lockouts([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_Lockouts invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_PasswordSettings(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_PasswordSettings([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_PasswordSettings invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_ProgramGroup(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_ProgramGroup([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_ProgramGroup invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_GeneralLabels(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_GeneralLabels([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_GeneralLabels invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_LightLabels(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_LightLabels([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_LightLabels invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_WaterfallLabels(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_WaterfallLabels([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_WaterfallLabels invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_CustomLabel(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_CustomLabel([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_CustomLabel invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_EnterPassword(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_EnterPassword([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_EnterPassword invoked", DeviceId()); });
 	}
 
-	void OneTouchScraper::PageProcessor_HelpKeys(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_HelpKeys([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, [this]() { return std::format("OneTouch ({}): PageProcessor_HelpKeys invoked", DeviceId()); });
 	}

--- a/src/jandy/devices/onetouch/onetouch_scraper.cpp
+++ b/src/jandy/devices/onetouch/onetouch_scraper.cpp
@@ -23,56 +23,58 @@ namespace AqualinkAutomate::Devices
 
 	std::list<Utility::ScreenDataPage_Processor> OneTouchScraper::MakeProcessors()
 	{
+		using enum Utility::ScreenDataPageTypes;
+
 		return {
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_System, { 9, "Equipment ON/OFF" }, std::bind(&OneTouchScraper::PageProcessor_System, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Service, { 3, "Service Mode" }, std::bind(&OneTouchScraper::PageProcessor_Service, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_TimeOut, { 3, "Timeout Mode" }, std::bind(&OneTouchScraper::PageProcessor_TimeOut, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_OneTouch, { 11, "System" }, std::bind(&OneTouchScraper::PageProcessor_OneTouch, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_EquipmentOnOff, { 11, "More" }, std::bind(&OneTouchScraper::PageProcessor_EquipmentOnOff, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_EquipmentOnOff, { 0, "Filter Pump" }, std::bind(&OneTouchScraper::PageProcessor_EquipmentOnOff, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_EquipmentStatus, { 0, "EQUIPMENT STATUS" }, std::bind(&OneTouchScraper::PageProcessor_EquipmentStatus, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SelectSpeed, { 0, "Select Speed" }, std::bind(&OneTouchScraper::PageProcessor_SelectSpeed, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_MenuHelp, { 0, "Menu" }, std::bind(&OneTouchScraper::PageProcessor_MenuHelp, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_HelpSubmenu, { 1, "Keys" }, std::bind(&OneTouchScraper::PageProcessor_HelpSubmenu, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetTemperature, { 0, "Set Temp" }, std::bind(&OneTouchScraper::PageProcessor_SetTemperature, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetTime, { 0, "Set Time" }, std::bind(&OneTouchScraper::PageProcessor_SetTime, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SystemSetup, { 0, "System Setup" }, std::bind(&OneTouchScraper::PageProcessor_SystemSetup, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_FreezeProtect, { 0, "Freeze Protect" }, std::bind(&OneTouchScraper::PageProcessor_FreezeProtect, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Boost, { 0, "Boost Pool" }, std::bind(&OneTouchScraper::PageProcessor_Boost, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetAquapure, { 0, "Set AQUAPURE" }, std::bind(&OneTouchScraper::PageProcessor_SetAquapure, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Version, { 7, "REV " }, std::bind(&OneTouchScraper::PageProcessor_Version, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_DiagnosticsSensors, { 6, "Sensors" }, std::bind(&OneTouchScraper::PageProcessor_DiagnosticsSensors, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_DiagnosticsRemotes, { 0, "Remotes" }, std::bind(&OneTouchScraper::PageProcessor_DiagnosticsRemotes, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_DiagnosticsErrors, { 0, "Errors" }, std::bind(&OneTouchScraper::PageProcessor_DiagnosticsErrors, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_LabelAuxList, { 0, "Label Aux" }, std::bind(&OneTouchScraper::PageProcessor_LabelAuxList, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_LabelAux, { 2, "Current Label" }, std::bind(&OneTouchScraper::PageProcessor_LabelAux, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetPoolHeat, { 0, "Pool Heat" }, std::bind(&OneTouchScraper::PageProcessor_SetPoolHeat, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetSpaHeat, { 0, "Spa Heat" }, std::bind(&OneTouchScraper::PageProcessor_SetSpaHeat, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SpaSwitch, { 0, "Spa Switch" }, std::bind_front(&OneTouchScraper::PageProcessor_SpaSwitch, this)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_MoreOneTouch, { 10, "OneTouch ON/OFF" }, std::bind(&OneTouchScraper::PageProcessor_MoreOneTouch, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Program, { 0, "Program" }, std::bind(&OneTouchScraper::PageProcessor_Program, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_System, { 9, "Equipment ON/OFF" }, std::bind(&OneTouchScraper::PageProcessor_System, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_Service, { 3, "Service Mode" }, std::bind(&OneTouchScraper::PageProcessor_Service, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_TimeOut, { 3, "Timeout Mode" }, std::bind(&OneTouchScraper::PageProcessor_TimeOut, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_OneTouch, { 11, "System" }, std::bind(&OneTouchScraper::PageProcessor_OneTouch, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_EquipmentOnOff, { 11, "More" }, std::bind(&OneTouchScraper::PageProcessor_EquipmentOnOff, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_EquipmentOnOff, { 0, "Filter Pump" }, std::bind(&OneTouchScraper::PageProcessor_EquipmentOnOff, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_EquipmentStatus, { 0, "EQUIPMENT STATUS" }, std::bind(&OneTouchScraper::PageProcessor_EquipmentStatus, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SelectSpeed, { 0, "Select Speed" }, std::bind(&OneTouchScraper::PageProcessor_SelectSpeed, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_MenuHelp, { 0, "Menu" }, std::bind(&OneTouchScraper::PageProcessor_MenuHelp, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_HelpSubmenu, { 1, "Keys" }, std::bind(&OneTouchScraper::PageProcessor_HelpSubmenu, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SetTemperature, { 0, "Set Temp" }, std::bind(&OneTouchScraper::PageProcessor_SetTemperature, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SetTime, { 0, "Set Time" }, std::bind(&OneTouchScraper::PageProcessor_SetTime, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SystemSetup, { 0, "System Setup" }, std::bind(&OneTouchScraper::PageProcessor_SystemSetup, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_FreezeProtect, { 0, "Freeze Protect" }, std::bind(&OneTouchScraper::PageProcessor_FreezeProtect, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_Boost, { 0, "Boost Pool" }, std::bind(&OneTouchScraper::PageProcessor_Boost, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SetAquapure, { 0, "Set AQUAPURE" }, std::bind(&OneTouchScraper::PageProcessor_SetAquapure, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_Version, { 7, "REV " }, std::bind(&OneTouchScraper::PageProcessor_Version, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_DiagnosticsSensors, { 6, "Sensors" }, std::bind(&OneTouchScraper::PageProcessor_DiagnosticsSensors, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_DiagnosticsRemotes, { 0, "Remotes" }, std::bind(&OneTouchScraper::PageProcessor_DiagnosticsRemotes, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_DiagnosticsErrors, { 0, "Errors" }, std::bind(&OneTouchScraper::PageProcessor_DiagnosticsErrors, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_LabelAuxList, { 0, "Label Aux" }, std::bind(&OneTouchScraper::PageProcessor_LabelAuxList, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_LabelAux, { 2, "Current Label" }, std::bind(&OneTouchScraper::PageProcessor_LabelAux, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SetPoolHeat, { 0, "Pool Heat" }, std::bind(&OneTouchScraper::PageProcessor_SetPoolHeat, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SetSpaHeat, { 0, "Spa Heat" }, std::bind(&OneTouchScraper::PageProcessor_SetSpaHeat, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_SpaSwitch, { 0, "Spa Switch" }, std::bind_front(&OneTouchScraper::PageProcessor_SpaSwitch, this)),
+			Utility::ScreenDataPage_Processor(Page_MoreOneTouch, { 10, "OneTouch ON/OFF" }, std::bind(&OneTouchScraper::PageProcessor_MoreOneTouch, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_Program, { 0, "Program" }, std::bind(&OneTouchScraper::PageProcessor_Program, this, std::placeholders::_1)),
 			// The per-equipment Program DETAIL page has the EQUIPMENT NAME on line 0 (e.g.
 			// "Filter Pump"), NOT "Program", so the { 0, "Program" } matcher above misses it.
 			// Detect it by a STABLE row instead: line 2 always carries "Pgm N of M". (Its
 			// line-0 name also trips the Page_EquipmentOnOff { 0, "Filter Pump" } matcher, but
 			// that processor rejects every detail-page row - none end in ON/OFF/ENA or *** - so it
 			// is a harmless no-op while THIS processor does the real parse.)
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Program, { 2, "Pgm " }, std::bind_front(&OneTouchScraper::PageProcessor_Program, this)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_DisplayLight, { 0, "Display Light" }, std::bind(&OneTouchScraper::PageProcessor_DisplayLight, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Lockouts, { 0, "Lockout" }, std::bind(&OneTouchScraper::PageProcessor_Lockouts, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_PasswordSettings, { 0, "Password" }, std::bind(&OneTouchScraper::PageProcessor_PasswordSettings, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_ProgramGroup, { 0, "Program Group" }, std::bind(&OneTouchScraper::PageProcessor_ProgramGroup, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_GeneralLabels, { 0, "General" }, std::bind(&OneTouchScraper::PageProcessor_GeneralLabels, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_LightLabels, { 0, "Light" }, std::bind(&OneTouchScraper::PageProcessor_LightLabels, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_WaterfallLabels, { 0, "Wtrfall" }, std::bind(&OneTouchScraper::PageProcessor_WaterfallLabels, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_CustomLabel, { 0, "Custom" }, std::bind(&OneTouchScraper::PageProcessor_CustomLabel, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_EnterPassword, { 0, "Enter Password" }, std::bind(&OneTouchScraper::PageProcessor_EnterPassword, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_HelpKeys, { 0, "Key Help" }, std::bind(&OneTouchScraper::PageProcessor_HelpKeys, this, std::placeholders::_1)),
-			Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_StartUp, { 5, "-" }, std::bind(&OneTouchScraper::PageProcessor_StartUp, this, std::placeholders::_1))
+			Utility::ScreenDataPage_Processor(Page_Program, { 2, "Pgm " }, std::bind_front(&OneTouchScraper::PageProcessor_Program, this)),
+			Utility::ScreenDataPage_Processor(Page_DisplayLight, { 0, "Display Light" }, std::bind(&OneTouchScraper::PageProcessor_DisplayLight, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_Lockouts, { 0, "Lockout" }, std::bind(&OneTouchScraper::PageProcessor_Lockouts, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_PasswordSettings, { 0, "Password" }, std::bind(&OneTouchScraper::PageProcessor_PasswordSettings, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_ProgramGroup, { 0, "Program Group" }, std::bind(&OneTouchScraper::PageProcessor_ProgramGroup, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_GeneralLabels, { 0, "General" }, std::bind(&OneTouchScraper::PageProcessor_GeneralLabels, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_LightLabels, { 0, "Light" }, std::bind(&OneTouchScraper::PageProcessor_LightLabels, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_WaterfallLabels, { 0, "Wtrfall" }, std::bind(&OneTouchScraper::PageProcessor_WaterfallLabels, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_CustomLabel, { 0, "Custom" }, std::bind(&OneTouchScraper::PageProcessor_CustomLabel, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_EnterPassword, { 0, "Enter Password" }, std::bind(&OneTouchScraper::PageProcessor_EnterPassword, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_HelpKeys, { 0, "Key Help" }, std::bind(&OneTouchScraper::PageProcessor_HelpKeys, this, std::placeholders::_1)),
+			Utility::ScreenDataPage_Processor(Page_StartUp, { 5, "-" }, std::bind(&OneTouchScraper::PageProcessor_StartUp, this, std::placeholders::_1))
 		};
 	}
 
-	void OneTouchScraper::PageProcessor_HelpSubmenu(const Utility::ScreenDataPage& page)
+	void OneTouchScraper::PageProcessor_HelpSubmenu([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogTrace(Channel::Devices, std::format("OneTouch ({}): PageProcessor_HelpSubmenu invoked", DeviceId()));
 	}

--- a/src/jandy/devices/onetouch/onetouch_scraper.h
+++ b/src/jandy/devices/onetouch/onetouch_scraper.h
@@ -54,7 +54,6 @@ namespace AqualinkAutomate::Devices
 		// bodies (which log "OneTouch ({})", DeviceId()) read unchanged.
 		const Devices::JandyDeviceType& DeviceId() const { return *m_DeviceId; }
 
-	private:
 		// Page processors (screen -> DataHub). One per navigable page; several are log-only stubs
 		// kept so the page stays registered and therefore detectable/navigable.
 		void PageProcessor_System(const Utility::ScreenDataPage& page);
@@ -95,7 +94,6 @@ namespace AqualinkAutomate::Devices
 		void PageProcessor_SpaSwitch(const Utility::ScreenDataPage& page);
 		void PageProcessor_StartUp(const Utility::ScreenDataPage& page);
 
-	private:
 		static constexpr uint32_t HINT_COUNT{ 2 };
 		using HintArrayType = std::array<unsigned char, HINT_COUNT>;
 
@@ -110,7 +108,6 @@ namespace AqualinkAutomate::Devices
 		void StatusProcessor_SaltLevelPPM(const Utility::ScreenDataPage& page, const uint8_t line_id);
 		void StatusProcessor_CheckAquaPure(const Utility::ScreenDataPage& page, const uint8_t line_id);
 
-	private:
 		// Shared decode for the two pages carrying the panel identity + pool configuration (the
 		// cold-start splash and the REV page); builds the bodies of water via
 		// DataHub::ApplyPoolConfiguration so both call sites stay consistent.

--- a/src/jandy/devices/onetouch_device.cpp
+++ b/src/jandy/devices/onetouch_device.cpp
@@ -118,9 +118,8 @@ namespace AqualinkAutomate::Devices
 		{
 		case OperatingStates::ColdStart:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> cold_start", std::source_location::current());
-			auto detected = m_MenuModel.DetectPage(DisplayedPage());
-			if (detected == Navigation::PageId::StartUp)
+			auto cold_start_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> cold_start", std::source_location::current());
+			if (auto detected = m_MenuModel.DetectPage(DisplayedPage()); detected == Navigation::PageId::StartUp)
 			{
 				// Splash is still showing - stay in ColdStart and wait.
 				// Page processor has already extracted model/type/revision.
@@ -139,7 +138,7 @@ namespace AqualinkAutomate::Devices
 
 		case OperatingStates::StartUp:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> start_up", std::source_location::current());
+			auto start_up_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> start_up", std::source_location::current());
 			LogDebug(Channel::Devices, std::format("OneTouch ({}): Processing StartUp state", DeviceId()));
 			Scraping_ProcessStep_StartUp();
 			break;
@@ -147,7 +146,7 @@ namespace AqualinkAutomate::Devices
 
 		case OperatingStates::Scraping:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> scraping", std::source_location::current());
+			auto scraping_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> scraping", std::source_location::current());
 			LogDebug(Channel::Devices, std::format("OneTouch ({}): Processing Scraping state", DeviceId()));
 			Scraping_ProcessStep();
 			break;
@@ -155,7 +154,7 @@ namespace AqualinkAutomate::Devices
 
 		case OperatingStates::NormalOperation:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> normal_operation", std::source_location::current());
+			auto normal_operation_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> normal_operation", std::source_location::current());
 			LogTrace(Channel::Devices, std::format("OneTouch ({}): Processing NormalOperation state", DeviceId()));
 			ServiceActiveGoal();
 			SetpointRefresh_ProcessStep();
@@ -164,7 +163,7 @@ namespace AqualinkAutomate::Devices
 
 		case OperatingStates::ScrapingFaulted:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> scraping_faulted", std::source_location::current());
+			auto scraping_faulted_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> scraping_faulted", std::source_location::current());
 			LogWarning(Channel::Scraping, std::format("OneTouch ({}): ScrapingFaulted state - device in unknown state, no commands will be sent", DeviceId()));
 			// Do not send any commands - device state is unknown. But if the controller has
 			// resumed coherent comms, this attempts to recover us back to NormalOperation.
@@ -174,7 +173,7 @@ namespace AqualinkAutomate::Devices
 
 		case OperatingStates::FaultHasOccurred:
 		{
-			auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> fault", std::source_location::current());
+			auto fault_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::ProcessControllerUpdates -> fault", std::source_location::current());
 			LogWarning(Channel::Devices, std::format("OneTouch ({}): Processing FaultHasOccurred state", DeviceId()));
 			// As for ScrapingFaulted: try to recover once the controller is talking coherently again.
 			AttemptFaultRecovery(is_status_message);
@@ -205,11 +204,13 @@ namespace AqualinkAutomate::Devices
 
 	void OneTouchDevice::WatchdogTimeoutOccurred()
 	{
+		using enum OperatingStates;
+
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("OneTouchDevice::WatchdogTimeoutOccurred", std::source_location::current());
 
 		LogWarning(Channel::Devices, std::format("OneTouch({}) : Watchdog timeout occurred: state={}, timeout_duration={}s", DeviceId(), magic_enum::enum_name(m_OpState), ONETOUCH_TIMEOUT_DURATION.count()));
 
-		if (m_OpState == OperatingStates::Scraping)
+		if (m_OpState == Scraping)
 		{
 			// Scraping was in progress when the watchdog fired.  Abandon the
 			// scraping sequence and fall through to normal (passive) operation
@@ -220,15 +221,15 @@ namespace AqualinkAutomate::Devices
 			// timer - the timed-out crawl may never have reached Set AquaPure, so let the first
 			// periodic re-scrape happen promptly to recover the configured setpoint.
 			m_RefreshState.MarkStartupComplete();
-			m_OpState = OperatingStates::NormalOperation;
+			m_OpState = NormalOperation;
 			m_ScrapingStallCounter = 0;
 			Status(Devices::DeviceStatus_Normal{});
 		}
-		else if (m_OpState == OperatingStates::StartUp || m_OpState == OperatingStates::ColdStart)
+		else if (m_OpState == StartUp || m_OpState == ColdStart)
 		{
 			// Never received a recognisable page during start-up.
 			LogWarning(Channel::Devices, std::format("OneTouch({}) : No valid page received during startup -> entering FaultHasOccurred", DeviceId()));
-			m_OpState = OperatingStates::FaultHasOccurred;
+			m_OpState = FaultHasOccurred;
 			Status(Devices::DeviceStatus_FaultOccurred{});
 		}
 	}
@@ -726,7 +727,7 @@ namespace AqualinkAutomate::Devices
 
 			// Use FullDiscoveryVisitPolicy for startup - visits all navigable pages
 			auto policy = std::make_unique<Navigation::FullDiscoveryVisitPolicy>(
-				[this](Navigation::PageId page, const Utility::ScreenDataPage& content)
+				[this](Navigation::PageId page, [[maybe_unused]] const Utility::ScreenDataPage& content)
 				{
 					LogDebug(Channel::Scraping, std::format("OneTouch ({}): SpiderEngine visited page {}",
 						DeviceId(), static_cast<uint32_t>(page)));

--- a/src/jandy/devices/onetouch_device.h
+++ b/src/jandy/devices/onetouch_device.h
@@ -278,7 +278,6 @@ namespace AqualinkAutomate::Devices
 	Messages::AckTypes m_AckType_ToSend{ Messages::AckTypes::V2_Normal };
 		KeyCommands m_KeyCommand_ToSend{ KeyCommands::NoKeyCommand };
 
-	private:
 		// The read path: page + status processors, panel-config decode and controller-schedule
 		// accumulation. Created in the constructor with the shared DataHub + schedule store; its
 		// processors are registered into the Screen capability. Destroyed after the Screen base's

--- a/src/jandy/devices/pda/pda_messageprocessors.cpp
+++ b/src/jandy/devices/pda/pda_messageprocessors.cpp
@@ -28,7 +28,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void PDADevice::Slot_PDA_Clear(const Messages::PDAMessage_Clear& msg)
+	void PDADevice::Slot_PDA_Clear([[maybe_unused]] const Messages::PDAMessage_Clear& msg)
 	{
 		LogDebug(Channel::Devices, "PDA device received a JandyMessage_Clear signal.");
 
@@ -95,7 +95,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void PDADevice::Slot_PDA_Probe(const Messages::JandyMessage_Probe& msg)
+	void PDADevice::Slot_PDA_Probe([[maybe_unused]] const Messages::JandyMessage_Probe& msg)
 	{
 		LogDebug(Channel::Devices, "PDA device received a JandyMessage_Probe signal.");
 
@@ -106,7 +106,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void PDADevice::Slot_PDA_Status(const Messages::JandyMessage_Status& msg)
+	void PDADevice::Slot_PDA_Status([[maybe_unused]] const Messages::JandyMessage_Status& msg)
 	{
 		LogDebug(Channel::Devices, "PDA device received a JandyMessage_Status signal.");
 

--- a/src/jandy/devices/pda/pda_pageprocessors.cpp
+++ b/src/jandy/devices/pda/pda_pageprocessors.cpp
@@ -9,7 +9,7 @@ using namespace AqualinkAutomate::Logging;
 namespace AqualinkAutomate::Devices
 {
 
-	void PDADevice::PageProcessor_System(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_System([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
 		LogDebug(Channel::Devices, "PDA device is processing a PageProcessor_System page.");
 
@@ -27,36 +27,44 @@ namespace AqualinkAutomate::Devices
 		*/
 	}
 
-	void PDADevice::PageProcessor_SetTemperature(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_SetTemperature([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_SetTime(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_SetTime([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_PoolHeat(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_PoolHeat([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_SpaHeat(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_SpaHeat([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_AquaPure(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_AquaPure([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_FreezeProtect(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_FreezeProtect([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_EquipmentStatus(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_EquipmentStatus([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 
-	void PDADevice::PageProcessor_Boost(const Utility::ScreenDataPage& page)
+	void PDADevice::PageProcessor_Boost([[maybe_unused]] const Utility::ScreenDataPage& page)
 	{
+		// Placeholder: this PDA page is recognised for navigation but not yet parsed.
 	}
 	
 	void PDADevice::PageProcessor_FirmwareVersion(const Utility::ScreenDataPage& page)

--- a/src/jandy/devices/pda_device.cpp
+++ b/src/jandy/devices/pda_device.cpp
@@ -27,22 +27,24 @@ namespace AqualinkAutomate::Devices
 			JandyMessage_Status{}
 		),
 		Capabilities::Emulated(is_emulated)
-		
+
 	{
+		using enum Utility::ScreenDataPageTypes;
+
 		PageProcessors(
 			{
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_System, {0, "   MAIN MENU    "}, std::bind(&PDADevice::PageProcessor_System, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_EquipmentStatus, { 0, "EQUIPMENT STATUS" }, std::bind(&PDADevice::PageProcessor_EquipmentStatus, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetPoolHeat, { 0, "   POOL HEAT    " }, std::bind(&PDADevice::PageProcessor_PoolHeat, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetSpaHeat, { 0, "    SPA HEAT    " }, std::bind(&PDADevice::PageProcessor_SpaHeat, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetTemperature, { 0, "    SET TEMP    " }, std::bind(&PDADevice::PageProcessor_SetTemperature, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetTime, { 0, "    SET TIME    " }, std::bind(&PDADevice::PageProcessor_SetTime, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_FreezeProtect, { 0, " FREEZE PROTECT " }, std::bind(&PDADevice::PageProcessor_FreezeProtect, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Boost, { 0, "BOOST" }, std::bind(&PDADevice::PageProcessor_Boost, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_SetAquapure, { 0, "  SET AquaPure  " }, std::bind(&PDADevice::PageProcessor_AquaPure, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Version, { 3, "Firmware Version" }, std::bind(&PDADevice::PageProcessor_FirmwareVersion, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Version, { 1, "    AquaPalm" }, std::bind(&PDADevice::PageProcessor_FirmwareVersion, this, std::placeholders::_1)),
-				Utility::ScreenDataPage_Processor(Utility::ScreenDataPageTypes::Page_Version, { 1, " PDA-P" }, std::bind(&PDADevice::PageProcessor_FirmwareVersion, this, std::placeholders::_1))
+				Utility::ScreenDataPage_Processor(Page_System, {0, "   MAIN MENU    "}, std::bind(&PDADevice::PageProcessor_System, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_EquipmentStatus, { 0, "EQUIPMENT STATUS" }, std::bind(&PDADevice::PageProcessor_EquipmentStatus, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_SetPoolHeat, { 0, "   POOL HEAT    " }, std::bind(&PDADevice::PageProcessor_PoolHeat, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_SetSpaHeat, { 0, "    SPA HEAT    " }, std::bind(&PDADevice::PageProcessor_SpaHeat, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_SetTemperature, { 0, "    SET TEMP    " }, std::bind(&PDADevice::PageProcessor_SetTemperature, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_SetTime, { 0, "    SET TIME    " }, std::bind(&PDADevice::PageProcessor_SetTime, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_FreezeProtect, { 0, " FREEZE PROTECT " }, std::bind(&PDADevice::PageProcessor_FreezeProtect, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_Boost, { 0, "BOOST" }, std::bind(&PDADevice::PageProcessor_Boost, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_SetAquapure, { 0, "  SET AquaPure  " }, std::bind(&PDADevice::PageProcessor_AquaPure, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_Version, { 3, "Firmware Version" }, std::bind(&PDADevice::PageProcessor_FirmwareVersion, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_Version, { 1, "    AquaPalm" }, std::bind(&PDADevice::PageProcessor_FirmwareVersion, this, std::placeholders::_1)),
+				Utility::ScreenDataPage_Processor(Page_Version, { 1, " PDA-P" }, std::bind(&PDADevice::PageProcessor_FirmwareVersion, this, std::placeholders::_1))
 			}
 		);
 
@@ -64,10 +66,14 @@ namespace AqualinkAutomate::Devices
 	
 	void PDADevice::ProcessControllerUpdates()
 	{
+		// Intentionally empty: the PDA advances its state directly from the incoming
+		// screen-update message handlers, so there is no periodic controller work to do here.
 	}
 
 	void PDADevice::WatchdogTimeoutOccurred()
 	{
+		// Intentionally empty: loss of communications on the PDA requires no device-side
+		// state change.
 	}
 
 	nlohmann::json PDADevice::DescribeDiagnostics() const

--- a/src/jandy/devices/pda_device.h
+++ b/src/jandy/devices/pda_device.h
@@ -51,10 +51,8 @@ namespace AqualinkAutomate::Devices
 	private:
 		void ProcessControllerUpdates() override;
 
-	private:
 		void WatchdogTimeoutOccurred() override;
 
-	private:
 		void Slot_PDA_Ack(const Messages::JandyMessage_Ack& msg);
 		void Slot_PDA_Clear(const Messages::PDAMessage_Clear& msg);
 		void Slot_PDA_Highlight(const Messages::PDAMessage_Highlight& msg);
@@ -65,7 +63,6 @@ namespace AqualinkAutomate::Devices
 		void Slot_PDA_ShiftLines(const Messages::PDAMessage_ShiftLines& msg);
 		void Slot_PDA_Unknown_PDA_1B(const Messages::JandyMessage_Unknown& msg);
 
-	private:
 		void PageProcessor_System(const Utility::ScreenDataPage& page);
 		void PageProcessor_SetTemperature(const Utility::ScreenDataPage& page);
 		void PageProcessor_SetTime(const Utility::ScreenDataPage& page);

--- a/src/jandy/devices/serial_adapter/serial_adapter_commandprocessors.cpp
+++ b/src/jandy/devices/serial_adapter/serial_adapter_commandprocessors.cpp
@@ -50,12 +50,14 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void SerialAdapterDevice::Command_SerialAdapter_Options(const Messages::SerialAdapter_SCS_Options& options)
+	void SerialAdapterDevice::Command_SerialAdapter_Options([[maybe_unused]] const Messages::SerialAdapter_SCS_Options& options)
 	{
+		// Intentionally empty: the reported system options are not yet consumed by the DataHub.
 	}
 
-	void SerialAdapterDevice::Command_SerialAdapter_BatteryCondition(const Messages::SerialAdapter_SCS_BatteryCondition& battery_condition)
+	void SerialAdapterDevice::Command_SerialAdapter_BatteryCondition([[maybe_unused]] const Messages::SerialAdapter_SCS_BatteryCondition& battery_condition)
 	{
+		// Intentionally empty: the reported battery condition is not yet consumed by the DataHub.
 	}
 
 	void SerialAdapterDevice::Command_SerialAdapter_AirTemperature(const Kernel::Temperature& temperature)
@@ -82,8 +84,10 @@ namespace AqualinkAutomate::Devices
 		}
 	}
 
-	void SerialAdapterDevice::Command_SerialAdapter_SolarTemperature(const Kernel::Temperature& temperature)
+	void SerialAdapterDevice::Command_SerialAdapter_SolarTemperature([[maybe_unused]] const Kernel::Temperature& temperature)
 	{
+		// Intentionally empty: solar temperature is reported by the adapter but not yet
+		// surfaced to the DataHub.
 	}
 
 	void SerialAdapterDevice::Command_SerialAdapter_AuxillaryStatus(const Auxillaries::JandyAuxillaryIds& aux_id, const Auxillaries::JandyAuxillaryStatuses& status)

--- a/src/jandy/devices/serial_adapter/serial_adapter_messageprocessors.cpp
+++ b/src/jandy/devices/serial_adapter/serial_adapter_messageprocessors.cpp
@@ -13,7 +13,7 @@ using namespace AqualinkAutomate::Logging;
 namespace AqualinkAutomate::Devices
 {
 
-	void SerialAdapterDevice::Slot_SerialAdapter_Ack(const Messages::JandyMessage_Ack& msg)
+	void SerialAdapterDevice::Slot_SerialAdapter_Ack([[maybe_unused]] const Messages::JandyMessage_Ack& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::Slot_Ack", std::source_location::current());
 		LogDebug(Channel::Devices, "Serial Adapter device received a JandyMessage_Ack signal.");
@@ -22,7 +22,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void SerialAdapterDevice::Slot_SerialAdapter_DevReady(const Messages::SerialAdapterMessage_DevReady& msg)
+	void SerialAdapterDevice::Slot_SerialAdapter_DevReady([[maybe_unused]] const Messages::SerialAdapterMessage_DevReady& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::Slot_DevReady", std::source_location::current());
 		LogDebug(Channel::Devices, "Serial Adapter device received a SerialAdapterMessage_DevReady signal.");
@@ -219,7 +219,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void SerialAdapterDevice::Slot_SerialAdapter_Probe(const Messages::JandyMessage_Probe& msg)
+	void SerialAdapterDevice::Slot_SerialAdapter_Probe([[maybe_unused]] const Messages::JandyMessage_Probe& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::Slot_Probe", std::source_location::current());
 		LogDebug(Channel::Devices, "Serial Adapter device received a JandyMessage_Probe signal.");
@@ -230,7 +230,7 @@ namespace AqualinkAutomate::Devices
 		Restartable::Kick();
 	}
 
-	void SerialAdapterDevice::Slot_SerialAdapter_Status(const Messages::JandyMessage_Status& msg)
+	void SerialAdapterDevice::Slot_SerialAdapter_Status([[maybe_unused]] const Messages::JandyMessage_Status& msg)
 	{
 		auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::Slot_Status", std::source_location::current());
 		LogDebug(Channel::Devices, "Serial Adapter device received a JandyMessage_Status signal.");

--- a/src/jandy/devices/serial_adapter_device.cpp
+++ b/src/jandy/devices/serial_adapter_device.cpp
@@ -24,9 +24,6 @@ namespace AqualinkAutomate::Devices
 		JandyController(device_id, hub_locator),
 		Capabilities::Restartable(SERIALADAPTER_TIMEOUT_DURATION),
 		Capabilities::Emulated(is_emulated),
-		m_StatusTypesCollection(),
-		m_StatusTypesCollectionIter(),
-		m_StatusMessageReceived(false),
 		m_ProfilingDomain(std::move(Factory::ProfilingUnitFactory::Instance().CreateDomain("SerialAdapterDevice")))
 	{
 		m_ProfilingDomain->Start();
@@ -44,13 +41,12 @@ namespace AqualinkAutomate::Devices
 		// known before any temperature/setpoint values are decoded in the first poll cycle.
 		auto stc_begin = std::find_if(m_StatusTypesCollection.begin(), m_StatusTypesCollection.end(),
 			[](const auto& v) { return std::holds_alternative<SerialAdapter_SystemTemperatureCommands>(v); });
-		auto units_it = std::find_if(stc_begin, m_StatusTypesCollection.end(),
+		if (auto units_it = std::find_if(stc_begin, m_StatusTypesCollection.end(),
 			[](const auto& v)
 			{
 				return std::holds_alternative<SerialAdapter_SystemTemperatureCommands>(v) &&
 					std::get<SerialAdapter_SystemTemperatureCommands>(v) == SerialAdapter_SystemTemperatureCommands::UNITS;
-			});
-		if (units_it != m_StatusTypesCollection.end() && units_it != stc_begin)
+			}); units_it != m_StatusTypesCollection.end() && units_it != stc_begin)
 		{
 			std::rotate(stc_begin, units_it, units_it + 1);
 		}
@@ -87,7 +83,7 @@ namespace AqualinkAutomate::Devices
 		{
 			if (!m_PendingCommands.empty())
 			{
-				auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::ProcessControllerUpdates -> pending_command", std::source_location::current());
+				auto pending_command_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::ProcessControllerUpdates -> pending_command", std::source_location::current());
 
 				const PendingCommand pending = m_PendingCommands.front();
 				m_PendingCommands.pop_front();
@@ -99,7 +95,7 @@ namespace AqualinkAutomate::Devices
 			}
 			else
 			{
-				auto zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::ProcessControllerUpdates -> query_status", std::source_location::current());
+				auto query_status_zone = Factory::ProfilingUnitFactory::Instance().CreateZone("SerialAdapterDevice::ProcessControllerUpdates -> query_status", std::source_location::current());
 
 				LogDebug(Channel::Devices, "ProcessControllerUpdates -> Query for Status");
 
@@ -140,7 +136,7 @@ namespace AqualinkAutomate::Devices
 							ack_type = 0x00;
 							ack_data_value = magic_enum::enum_integer(sa_jai) + SerialAdapterMessage_DevStatus::SERIALADAPTER_AUX_ID_OFFSET;
 						},
-						[](SerialAdapter_UnknownCommands sa_uc)
+						[]([[maybe_unused]] SerialAdapter_UnknownCommands sa_uc)
 						{
 							LogWarning(Channel::Devices, "SerialAdapterDevice: Cannot select next StatusType; unknown command type");
 						}
@@ -590,6 +586,8 @@ namespace AqualinkAutomate::Devices
 
 	void SerialAdapterDevice::WatchdogTimeoutOccurred()
 	{
+		// Intentionally empty: the Serial Adapter is an emulated controller that owns the bus
+		// conversation, so a watchdog timeout requires no device-side state change here.
 	}
 
 	nlohmann::json SerialAdapterDevice::DescribeDiagnostics() const

--- a/src/jandy/devices/serial_adapter_device.h
+++ b/src/jandy/devices/serial_adapter_device.h
@@ -47,7 +47,6 @@ namespace AqualinkAutomate::Devices
 		SerialAdapterDevice(const std::shared_ptr<Devices::JandyDeviceType>& device_id, Kernel::HubLocator& hub_locator, bool is_emulated);
 		~SerialAdapterDevice() override;
 
-	public:
 		nlohmann::json DescribeDiagnostics() const override;
 
 		void QueueCommand(uint8_t ack_type, uint8_t ack_data_value);
@@ -111,10 +110,8 @@ namespace AqualinkAutomate::Devices
 		// serialadapter.c). DEV_READY is sent only as part of that handshake.
 		void DrainPendingCommandForDevReady();
 
-	private:
 		void WatchdogTimeoutOccurred() override;
 
-	private:
 		void Slot_SerialAdapter_Ack(const Messages::JandyMessage_Ack& msg);
 		void Slot_SerialAdapter_DevReady(const Messages::SerialAdapterMessage_DevReady& msg);
 		void Slot_SerialAdapter_DevStatus(const Messages::SerialAdapterMessage_DevStatus& msg);
@@ -122,7 +119,6 @@ namespace AqualinkAutomate::Devices
 		void Slot_SerialAdapter_Status(const Messages::JandyMessage_Status& msg);
 		void Slot_SerialAdapter_Unknown(const Messages::JandyMessage_Unknown& msg);
 
-	private:
 		void Command_SerialAdapter_Model(const uint16_t model_type);
 		void Command_SerialAdapter_OpMode(const Messages::SerialAdapter_SCS_OpModes& op_mode);
 		void Command_SerialAdapter_Options(const Messages::SerialAdapter_SCS_Options& options);
@@ -133,18 +129,15 @@ namespace AqualinkAutomate::Devices
 		void Command_SerialAdapter_SolarTemperature(const Kernel::Temperature& temperature);
 		void Command_SerialAdapter_AuxillaryStatus(const Auxillaries::JandyAuxillaryIds& aux_id, const Auxillaries::JandyAuxillaryStatuses& status);
 
-	private:
 		// Presence gating: called when a real Serial Adapter is observed answering
 		// the master at this device's address. Latches emulation off permanently so
 		// the emulated instance never collides with the real one on the bus.
 		void DetectRealAdapterAndSuppressEmulation(std::string_view observed_message_kind);
 
-	private:
 		std::vector<Messages::SerialAdapter_StatusTypes> m_StatusTypesCollection;
 		std::vector<Messages::SerialAdapter_StatusTypes>::const_iterator m_StatusTypesCollectionIter;
 
-	private:
-		bool m_StatusMessageReceived;
+		bool m_StatusMessageReceived{ false };
 
 		// True once the emulated adapter has actively transmitted (answered a master
 		// poll/probe), i.e. it has "claimed" this bus address. Used by presence-gating:
@@ -160,7 +153,6 @@ namespace AqualinkAutomate::Devices
 		// they are emitted on consecutive master polls in the correct order.
 		std::deque<PendingCommand> m_PendingCommands{};
 
-	private:
 		Types::ProfilingUnitTypePtr m_ProfilingDomain;
 	};
 

--- a/src/jandy/equipment/jandy_equipment.cpp
+++ b/src/jandy/equipment/jandy_equipment.cpp
@@ -70,7 +70,6 @@ namespace AqualinkAutomate::Equipment
 	JandyEquipment::JandyEquipment(Kernel::HubLocator& hub_locator, bool decode_to_master) :
 		IEquipment(),
 		IStatusPublisher(Equipment::EquipmentStatus_Unknown{}),
-		m_MessageConnections(),
 		m_HubLocator(hub_locator),
 		m_DecodeToMaster(decode_to_master)
 	{

--- a/src/jandy/equipment/jandy_equipment.h
+++ b/src/jandy/equipment/jandy_equipment.h
@@ -46,10 +46,8 @@ namespace AqualinkAutomate::Equipment
 				...);
 		}
 
-	private:
 		void DisplayUnknownMessages(const Messages::JandyMessage& message);
 
-	private:
 		std::vector<boost::signals2::connection> m_MessageConnections;
 
 		// Device classes already reported as unsupported, so the per-message
@@ -57,7 +55,6 @@ namespace AqualinkAutomate::Equipment
 		// line on every message addressed to an unsupported class (rate limiting).
 		std::unordered_set<Devices::DeviceClasses> m_ReportedUnsupportedClasses;
 
-	private:
 		Kernel::HubLocator& m_HubLocator;
 		std::shared_ptr<Kernel::DataHub> m_DataHub{ nullptr };
 		// Raw (non-owning) pointer, NOT a shared_ptr: the EquipmentHub OWNS this

--- a/src/jandy/errors/jandy_errors_auxillary_factory.cpp
+++ b/src/jandy/errors/jandy_errors_auxillary_factory.cpp
@@ -10,21 +10,23 @@ namespace AqualinkAutomate::ErrorCodes
 
 	std::string_view Factory_ErrorCategory::Describe(Factory_ErrorCodes e)
 	{
+		using enum Factory_ErrorCodes;
+
 		switch (e)
 		{
-		case Factory_ErrorCodes::Error_UnknownFactoryError:
+		case Error_UnknownFactoryError:
 			return "An unspecified error occurred while creating the auxillary device";
 
-		case Factory_ErrorCodes::Error_UnknownDeviceLabel:
+		case Error_UnknownDeviceLabel:
 			return "The device label is not recognised by the auxillary factory";
 
-		case Factory_ErrorCodes::Error_CannotCastToJandyAuxillaryId:
+		case Error_CannotCastToJandyAuxillaryId:
 			return "The device identifier could not be cast to a Jandy auxillary id";
 
-		case Factory_ErrorCodes::Error_FailedToCreateAuxillaryPtr:
+		case Error_FailedToCreateAuxillaryPtr:
 			return "The auxillary device pointer could not be created";
 
-		case Factory_ErrorCodes::Error_ReceivedInvalidAuxillaryStatus:
+		case Error_ReceivedInvalidAuxillaryStatus:
 			return "An invalid auxillary status was received";
 
 		default:

--- a/src/jandy/errors/jandy_errors_auxillary_factory.h
+++ b/src/jandy/errors/jandy_errors_auxillary_factory.h
@@ -24,7 +24,6 @@ namespace AqualinkAutomate::ErrorCodes
 	public:
 		static const Factory_ErrorCategory& Instance();
 
-	public:
 		static constexpr std::string_view CategoryName{ "AqualinkAutomate::Factory Error Category" };
 		static std::string_view Describe(Factory_ErrorCodes e);
 

--- a/src/jandy/errors/jandy_errors_scrapeable.cpp
+++ b/src/jandy/errors/jandy_errors_scrapeable.cpp
@@ -10,36 +10,38 @@ namespace AqualinkAutomate::ErrorCodes
 
 	std::string_view Scrapeable_ErrorCategory::Describe(Scrapeable_ErrorCodes e)
 	{
+		using enum Scrapeable_ErrorCodes;
+
 		switch (e)
 		{
-		case Scrapeable_ErrorCodes::WaitingForPage:
+		case WaitingForPage:
 			return "Waiting for the expected page to be scraped before continuing";
 
-		case Scrapeable_ErrorCodes::WaitingForMessage:
+		case WaitingForMessage:
 			return "Waiting for one or more status messages before continuing";
 
-		case Scrapeable_ErrorCodes::NoStepPossible:
+		case NoStepPossible:
 			return "No further navigation step is possible from the current page";
 
-		case Scrapeable_ErrorCodes::NoGraphBeingScraped:
+		case NoGraphBeingScraped:
 			return "No menu graph is currently being scraped";
 
-		case Scrapeable_ErrorCodes::UnknownScrapeError:
+		case UnknownScrapeError:
 			return "An unspecified error occurred during scraping";
 
-		case Scrapeable_ErrorCodes::PreCommandValidationFailed:
+		case PreCommandValidationFailed:
 			return "Validation of the page state before issuing the command failed";
 
-		case Scrapeable_ErrorCodes::PostCommandValidationFailed:
+		case PostCommandValidationFailed:
 			return "Validation of the page state after issuing the command failed";
 
-		case Scrapeable_ErrorCodes::RecoveryInProgress:
+		case RecoveryInProgress:
 			return "Navigation recovery is in progress (pressing Back to reach a known page)";
 
-		case Scrapeable_ErrorCodes::RecoveryComplete:
+		case RecoveryComplete:
 			return "Navigation recovery completed and a known page was reached";
 
-		case Scrapeable_ErrorCodes::MaxRecoveryAttemptsExceeded:
+		case MaxRecoveryAttemptsExceeded:
 			return "The maximum number of navigation recovery attempts was exceeded";
 
 		default:

--- a/src/jandy/errors/jandy_errors_scrapeable.h
+++ b/src/jandy/errors/jandy_errors_scrapeable.h
@@ -29,7 +29,6 @@ namespace AqualinkAutomate::ErrorCodes
 	public:
 		static const Scrapeable_ErrorCategory& Instance();
 
-	public:
 		static constexpr std::string_view CategoryName{ "AqualinkAutomate::Scrapeable Error Category" };
 		static std::string_view Describe(Scrapeable_ErrorCodes e);
 

--- a/src/jandy/errors/string_conversion_errors.h
+++ b/src/jandy/errors/string_conversion_errors.h
@@ -20,7 +20,6 @@ namespace AqualinkAutomate::ErrorCodes
 	public:
 		static const StringConversion_ErrorCategory& Instance();
 
-	public:
 		static constexpr std::string_view CategoryName{ "AqualinkAutomate::String Conversion Error Category" };
 		static std::string_view Describe(StringConversion_ErrorCodes e);
 

--- a/src/jandy/factories/jandy_auxillary_factory.cpp
+++ b/src/jandy/factories/jandy_auxillary_factory.cpp
@@ -151,7 +151,7 @@ namespace AqualinkAutomate::Factory
 		return (SPILLOVER == label);
 	}
 
-	bool JandyAuxillaryFactory::IsSprinklerDevice(const std::string& label) const
+	bool JandyAuxillaryFactory::IsSprinklerDevice(const std::string& /*label*/) const
 	{
 		return false;
 	}
@@ -202,6 +202,8 @@ namespace AqualinkAutomate::Factory
 					},
 					[&aux_ptr](const HeaterDevice_Data& data)
 					{
+						using enum Kernel::BodyOfWaterIds;
+
 						aux_ptr->AuxillaryTraits.Set(AuxillaryTraitsTypes::AuxillaryTypeTrait{}, AuxillaryTraitsTypes::AuxillaryTypes::Heater);
 						aux_ptr->AuxillaryTraits.Set(Kernel::AuxillaryTraitsTypes::LabelTrait{}, data.Label.value_or(HEATER));
 
@@ -211,17 +213,19 @@ namespace AqualinkAutomate::Factory
 						}
 
 						auto label = data.Label.value_or(HEATER);
-						auto body_id = Kernel::BodyOfWaterIds::Unknown;
+						auto body_id = Unknown;
 						if (label.find("Pool") != std::string::npos)
-							body_id = Kernel::BodyOfWaterIds::Pool;
+							body_id = Pool;
 						else if (label.find("Spa") != std::string::npos)
-							body_id = Kernel::BodyOfWaterIds::Spa;
+							body_id = Spa;
 						else if (label.find("Solar") != std::string::npos)
-							body_id = Kernel::BodyOfWaterIds::Shared;
+							body_id = Shared;
 						aux_ptr->AuxillaryTraits.Set(Kernel::AuxillaryTraitsTypes::BodyOfWaterTrait{}, body_id);
 					},
 					[&aux_ptr](const PumpDevice_Data& data)
 					{
+						using enum Kernel::BodyOfWaterIds;
+
 						aux_ptr->AuxillaryTraits.Set(AuxillaryTraitsTypes::AuxillaryTypeTrait{}, AuxillaryTraitsTypes::AuxillaryTypes::Pump);
 						aux_ptr->AuxillaryTraits.Set(Kernel::AuxillaryTraitsTypes::LabelTrait{}, data.Label.value_or(PUMP));
 
@@ -231,13 +235,13 @@ namespace AqualinkAutomate::Factory
 						}
 
 						auto label = data.Label.value_or(PUMP);
-						auto body_id = Kernel::BodyOfWaterIds::Unknown;
+						auto body_id = Unknown;
 						if (label.find("Filter") != std::string::npos)
-							body_id = Kernel::BodyOfWaterIds::Shared;
+							body_id = Shared;
 						else if (label.find("Pool") != std::string::npos)
-							body_id = Kernel::BodyOfWaterIds::Pool;
+							body_id = Pool;
 						else if (label.find("Spa") != std::string::npos)
-							body_id = Kernel::BodyOfWaterIds::Spa;
+							body_id = Spa;
 						aux_ptr->AuxillaryTraits.Set(Kernel::AuxillaryTraitsTypes::BodyOfWaterTrait{}, body_id);
 					},
 					[&aux_ptr](const SpilloverDevice_Data& data)

--- a/src/jandy/factories/jandy_auxillary_factory.h
+++ b/src/jandy/factories/jandy_auxillary_factory.h
@@ -81,10 +81,8 @@ namespace AqualinkAutomate::Factory
 		JandyAuxillaryFactory(JandyAuxillaryFactory&&) = delete;
 		JandyAuxillaryFactory& operator=(JandyAuxillaryFactory&&) = delete;
 
-	public:
 		static JandyAuxillaryFactory& Instance();
 
-	public:
 		std::expected<std::shared_ptr<Kernel::AuxillaryDevice>, boost::system::error_code> SerialAdapterDevice_CreateDevice(const Auxillaries::JandyAuxillaryIds aux_id);
 		std::expected<std::shared_ptr<Kernel::AuxillaryDevice>, boost::system::error_code> SerialAdapterDevice_CreateDevice(const Auxillaries::JandyAuxillaryIds aux_id, const Auxillaries::JandyAuxillaryStatuses status);
 		std::expected<std::shared_ptr<Kernel::AuxillaryDevice>, boost::system::error_code> OneTouchDevice_CreateDevice(const Utility::AuxillaryStateStringConverter& aux_state);
@@ -98,7 +96,6 @@ namespace AqualinkAutomate::Factory
 		bool IsSpilloverDevice(const std::string& label) const;
 		bool IsSprinklerDevice(const std::string& label) const;
 
-	private:
 		std::expected<std::shared_ptr<Kernel::AuxillaryDevice>, boost::system::error_code> CreateDevice_Impl(DeviceData& device_data);
 	};
 

--- a/src/jandy/factories/jandy_message_factory.h
+++ b/src/jandy/factories/jandy_message_factory.h
@@ -67,7 +67,7 @@ namespace AqualinkAutomate::Factory
 		}
 
 		template<Concepts::JandyMessageType T>
-		constexpr HashTableEntry(Messages::JandyMessageIds msg_id) noexcept :
+		explicit constexpr HashTableEntry(Messages::JandyMessageIds msg_id) noexcept :
 			id(msg_id),
 			creator(&MessageCreator<T>::Create)
 		{
@@ -107,8 +107,7 @@ namespace AqualinkAutomate::Factory
 		{
 			LogDebug(Channel::Messages, [id]{ return std::format("Creating message type from message id; id -> {}", id); });
 
-			const auto& entry = cold_table[static_cast<std::size_t>(magic_enum::enum_integer(id))];
-			if (entry.id.has_value())
+			if (const auto& entry = cold_table[static_cast<std::size_t>(magic_enum::enum_integer(id))]; entry.id.has_value())
 			{
 				LogTrace(Channel::Messages, [id]{ return std::format("Message type (id: {}) creator located in message table", id); });
 				return entry.creator();

--- a/src/jandy/formatters/chemistry_formatter.cpp
+++ b/src/jandy/formatters/chemistry_formatter.cpp
@@ -1,13 +1,5 @@
 #include "formatters/chemistry_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/formatters/chemistry_formatter.h
+++ b/src/jandy/formatters/chemistry_formatter.h
@@ -9,14 +9,6 @@
 #include "formatters/ph_formatter.h"
 #include "utility/string_conversion/chemistry_string_converter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/formatters/jandy_device_formatters.cpp
+++ b/src/jandy/formatters/jandy_device_formatters.cpp
@@ -1,13 +1,5 @@
 #include "formatters/jandy_device_formatters.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/formatters/jandy_device_formatters.h
+++ b/src/jandy/formatters/jandy_device_formatters.h
@@ -7,14 +7,6 @@
 #include "devices/jandy_device_id.h"
 #include "devices/jandy_device_types.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/formatters/screen_data_page_formatter.cpp
+++ b/src/jandy/formatters/screen_data_page_formatter.cpp
@@ -1,9 +1,1 @@
 #include "formatters/screen_data_page_formatter.h"
-
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters

--- a/src/jandy/formatters/screen_data_page_formatter.h
+++ b/src/jandy/formatters/screen_data_page_formatter.h
@@ -6,14 +6,6 @@
 
 #include "utility/screen_data_page.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 template<>
 struct std::formatter<AqualinkAutomate::Utility::ScreenDataPage>
 {

--- a/src/jandy/formatters/stats_counter_formatter.cpp
+++ b/src/jandy/formatters/stats_counter_formatter.cpp
@@ -1,13 +1,5 @@
 #include "formatters/stats_counter_formatter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/formatters/stats_counter_formatter.h
+++ b/src/jandy/formatters/stats_counter_formatter.h
@@ -6,14 +6,6 @@
 
 #include "utility/signalling_stats_counter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/formatters/temperature_formatter.h
+++ b/src/jandy/formatters/temperature_formatter.h
@@ -8,14 +8,6 @@
 #include "core/formatters/temperature_formatter.h"
 #include "utility/string_conversion/temperature_string_converter.h"
 
-namespace AqualinkAutomate::Formatters
-{
-
-	// NOTHING HERE
-
-}
-// AqualinkAutomate::Formatters
-
 namespace std
 {
 

--- a/src/jandy/jandy.cpp
+++ b/src/jandy/jandy.cpp
@@ -22,8 +22,11 @@ using namespace AqualinkAutomate::Profiling;
 namespace AqualinkAutomate::Jandy
 {
 
-	void Initialise(Kernel::HubLocator& hub_locator)
+	void Initialise(Kernel::HubLocator& /*hub_locator*/)
 	{
+		// Intentionally empty: the Jandy subsystem performs no work at the
+		// Initialise phase; all setup happens in Configure() once settings
+		// are available.
 	}
 
 	void Configure(Kernel::HubLocator& hub_locator, const AqualinkAutomate::Options::Settings& settings)
@@ -100,9 +103,11 @@ namespace AqualinkAutomate::Jandy
 
 				auto device_id = std::make_shared<Devices::JandyDeviceType>(device_type);
 
+				using enum Devices::JandyEmulatedDeviceTypes;
+
 				switch (controller_type)
 				{
-				case Devices::JandyEmulatedDeviceTypes::OneTouch:
+				case OneTouch:
 					{
 						auto onetouch = std::make_unique<Devices::OneTouchDevice>(device_id, hub_locator, true);
 						onetouch->EnableChlorinatorSetpointRefresh(std::chrono::seconds{ jandy_settings.chlorinator_setpoint_refresh_interval });
@@ -110,27 +115,27 @@ namespace AqualinkAutomate::Jandy
 					}
 					break;
 
-				case Devices::JandyEmulatedDeviceTypes::RS_Keypad:
+				case RS_Keypad:
 					equipment_hub->AddDevice(std::make_unique<Devices::KeypadDevice>(device_id, hub_locator, true));
 					break;
 
-				case Devices::JandyEmulatedDeviceTypes::IAQ:
+				case IAQ:
 					equipment_hub->AddDevice(std::make_unique<Devices::IAQDevice>(device_id, hub_locator, true));
 					break;
 
-				case Devices::JandyEmulatedDeviceTypes::PDA:
+				case PDA:
 					equipment_hub->AddDevice(std::make_unique<Devices::PDADevice>(device_id, hub_locator, true));
 					break;
 
-				case Devices::JandyEmulatedDeviceTypes::SerialAdapter:
+				case SerialAdapter:
 					equipment_hub->AddDevice(std::make_unique<Devices::SerialAdapterDevice>(device_id, hub_locator, true));
 					break;
 
-				case Devices::JandyEmulatedDeviceTypes::SpasideRemote:
+				case SpasideRemote:
 					equipment_hub->AddDevice(std::make_unique<Devices::SpasideRemoteDevice>(device_id, hub_locator, true));
 					break;
 
-				case Devices::JandyEmulatedDeviceTypes::Unknown:
+				case Unknown:
 				default:
 					LogWarning(Channel::Main, "Unknown emulated device type; cannot create controller device");
 				}

--- a/src/jandy/messages/aquarite/aquarite_message.h
+++ b/src/jandy/messages/aquarite/aquarite_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class AquariteMessage : public JandyMessage
 	{
 	public:
-		AquariteMessage(const JandyMessageIds& msg_id);
+		explicit AquariteMessage(const JandyMessageIds& msg_id);
 		~AquariteMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/aquarite/aquarite_message_getid.h
+++ b/src/jandy/messages/aquarite/aquarite_message_getid.h
@@ -25,16 +25,13 @@ namespace AqualinkAutomate::Messages
 
 	public:
 		AquariteMessage_GetId() noexcept;
-		AquariteMessage_GetId(PanelDataTypes requested_panel_data);
+		explicit AquariteMessage_GetId(PanelDataTypes requested_panel_data);
 		~AquariteMessage_GetId() override = default;
 
-	public:
 		PanelDataTypes RequestedPanelData() const;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/aquarite/aquarite_message_percent.cpp
+++ b/src/jandy/messages/aquarite/aquarite_message_percent.cpp
@@ -10,8 +10,7 @@ namespace AqualinkAutomate::Messages
 
 	AquariteMessage_Percent::AquariteMessage_Percent() noexcept :
 		AquariteMessage(JandyMessageIds::AQUARITE_Percent),
-		Interfaces::IMessageSignalRecv<AquariteMessage_Percent>(),
-		m_Percent(0)
+		Interfaces::IMessageSignalRecv<AquariteMessage_Percent>()
 	{
 	}
 

--- a/src/jandy/messages/aquarite/aquarite_message_percent.h
+++ b/src/jandy/messages/aquarite/aquarite_message_percent.h
@@ -23,20 +23,17 @@ namespace AqualinkAutomate::Messages
 		AquariteMessage_Percent() noexcept;
 		~AquariteMessage_Percent() override = default;
 
-	public:
 		uint8_t GeneratingPercentage() const;
 		bool IsBoostMode() const;
 		bool IsServiceMode() const;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_Percent;
+		uint8_t m_Percent{ 0 };
 	};
 
 }

--- a/src/jandy/messages/aquarite/aquarite_message_ppm.cpp
+++ b/src/jandy/messages/aquarite/aquarite_message_ppm.cpp
@@ -13,9 +13,7 @@ namespace AqualinkAutomate::Messages
 
 	AquariteMessage_PPM::AquariteMessage_PPM() noexcept :
 		AquariteMessage(JandyMessageIds::AQUARITE_PPM),
-		Interfaces::IMessageSignalRecv<AquariteMessage_PPM>(),
-		m_PPM(0),
-		m_Status(AquariteStatuses::Unknown)
+		Interfaces::IMessageSignalRecv<AquariteMessage_PPM>()
 	{
 	}
 

--- a/src/jandy/messages/aquarite/aquarite_message_ppm.h
+++ b/src/jandy/messages/aquarite/aquarite_message_ppm.h
@@ -39,20 +39,17 @@ namespace AqualinkAutomate::Messages
 		AquariteMessage_PPM() noexcept;
 		~AquariteMessage_PPM() override = default;
 
-	public:
 		uint16_t SaltConcentrationPPM() const;
 		AquariteStatuses Status() const;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint16_t m_PPM;
-		AquariteStatuses m_Status;
+		uint16_t m_PPM{ 0 };
+		AquariteStatuses m_Status{ AquariteStatuses::Unknown };
 	};
 
 }

--- a/src/jandy/messages/chemlink/chemlink_message.h
+++ b/src/jandy/messages/chemlink/chemlink_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class ChemlinkMessage : public JandyMessage
 	{
 	public:
-		ChemlinkMessage(const JandyMessageIds& msg_id);
+		explicit ChemlinkMessage(const JandyMessageIds& msg_id);
 		~ChemlinkMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/chemlink/chemlink_message_response.cpp
+++ b/src/jandy/messages/chemlink/chemlink_message_response.cpp
@@ -14,9 +14,7 @@ namespace AqualinkAutomate::Messages
 
 	ChemlinkMessage_Response::ChemlinkMessage_Response() noexcept :
 		ChemlinkMessage(JandyMessageIds::Chemlink_Response),
-		Interfaces::IMessageSignalRecv<ChemlinkMessage_Response>(),
-		m_DataTag(ChemlinkDataTag::Unknown),
-		m_RawValue(0)
+		Interfaces::IMessageSignalRecv<ChemlinkMessage_Response>()
 	{
 	}
 

--- a/src/jandy/messages/chemlink/chemlink_message_response.h
+++ b/src/jandy/messages/chemlink/chemlink_message_response.h
@@ -31,21 +31,15 @@ namespace AqualinkAutomate::Messages
 	public:
 		ChemlinkMessage_Response() noexcept;
 		~ChemlinkMessage_Response() override = default;
-
-	public:
 		ChemlinkDataTag DataTag() const;
 		uint16_t RawValue() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		ChemlinkDataTag m_DataTag;
-		uint16_t m_RawValue;
+		ChemlinkDataTag m_DataTag{ ChemlinkDataTag::Unknown };
+		uint16_t m_RawValue{ 0 };
 	};
 
 }

--- a/src/jandy/messages/epump/epump_message.h
+++ b/src/jandy/messages/epump/epump_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class EPumpMessage : public JandyMessage
 	{
 	public:
-		EPumpMessage(const JandyMessageIds& msg_id);
+		explicit EPumpMessage(const JandyMessageIds& msg_id);
 		~EPumpMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/epump/epump_message_rpm.cpp
+++ b/src/jandy/messages/epump/epump_message_rpm.cpp
@@ -12,8 +12,7 @@ namespace AqualinkAutomate::Messages
 
 	EPumpMessage_RPM::EPumpMessage_RPM() noexcept :
 		EPumpMessage(JandyMessageIds::EPUMP_RPM),
-		Interfaces::IMessageSignalRecv<EPumpMessage_RPM>(),
-		m_RPM(0)
+		Interfaces::IMessageSignalRecv<EPumpMessage_RPM>()
 	{
 	}
 

--- a/src/jandy/messages/epump/epump_message_rpm.h
+++ b/src/jandy/messages/epump/epump_message_rpm.h
@@ -31,19 +31,13 @@ namespace AqualinkAutomate::Messages
 	public:
 		EPumpMessage_RPM() noexcept;
 		~EPumpMessage_RPM() override = default;
-
-	public:
 		uint16_t RPM() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint16_t m_RPM;
+		uint16_t m_RPM{ 0 };
 	};
 
 }

--- a/src/jandy/messages/epump/epump_message_status.cpp
+++ b/src/jandy/messages/epump/epump_message_status.cpp
@@ -11,8 +11,7 @@ namespace AqualinkAutomate::Messages
 
 	EPumpMessage_Status::EPumpMessage_Status() noexcept :
 		EPumpMessage(JandyMessageIds::EPUMP_Status),
-		Interfaces::IMessageSignalRecv<EPumpMessage_Status>(),
-		m_SubCommand(0)
+		Interfaces::IMessageSignalRecv<EPumpMessage_Status>()
 	{
 	}
 

--- a/src/jandy/messages/epump/epump_message_status.h
+++ b/src/jandy/messages/epump/epump_message_status.h
@@ -20,19 +20,13 @@ namespace AqualinkAutomate::Messages
 	public:
 		EPumpMessage_Status() noexcept;
 		~EPumpMessage_Status() override = default;
-
-	public:
 		uint8_t SubCommand() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_SubCommand;
+		uint8_t m_SubCommand{ 0 };
 	};
 
 }

--- a/src/jandy/messages/epump/epump_message_watts.cpp
+++ b/src/jandy/messages/epump/epump_message_watts.cpp
@@ -12,8 +12,7 @@ namespace AqualinkAutomate::Messages
 
 	EPumpMessage_Watts::EPumpMessage_Watts() noexcept :
 		EPumpMessage(JandyMessageIds::EPUMP_Watts),
-		Interfaces::IMessageSignalRecv<EPumpMessage_Watts>(),
-		m_Watts(0)
+		Interfaces::IMessageSignalRecv<EPumpMessage_Watts>()
 	{
 	}
 

--- a/src/jandy/messages/epump/epump_message_watts.h
+++ b/src/jandy/messages/epump/epump_message_watts.h
@@ -21,19 +21,13 @@ namespace AqualinkAutomate::Messages
 	public:
 		EPumpMessage_Watts() noexcept;
 		~EPumpMessage_Watts() override = default;
-
-	public:
 		uint16_t Watts() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint16_t m_Watts;
+		uint16_t m_Watts{ 0 };
 	};
 
 }

--- a/src/jandy/messages/heater/heater_message.h
+++ b/src/jandy/messages/heater/heater_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class HeaterMessage : public JandyMessage
 	{
 	public:
-		HeaterMessage(const JandyMessageIds& msg_id);
+		explicit HeaterMessage(const JandyMessageIds& msg_id);
 		~HeaterMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/heater/heater_message_request.cpp
+++ b/src/jandy/messages/heater/heater_message_request.cpp
@@ -12,11 +12,7 @@ namespace AqualinkAutomate::Messages
 
 	HeaterMessage_Request::HeaterMessage_Request() noexcept :
 		HeaterMessage(JandyMessageIds::Heater_Request),
-		Interfaces::IMessageSignalRecv<HeaterMessage_Request>(),
-		m_OperatingMode(HeaterOperatingModes::Unknown),
-		m_PoolSetpoint(0),
-		m_SpaSetpoint(0),
-		m_WaterTemperature(0)
+		Interfaces::IMessageSignalRecv<HeaterMessage_Request>()
 	{
 	}
 

--- a/src/jandy/messages/heater/heater_message_request.h
+++ b/src/jandy/messages/heater/heater_message_request.h
@@ -38,25 +38,19 @@ namespace AqualinkAutomate::Messages
 	public:
 		HeaterMessage_Request() noexcept;
 		~HeaterMessage_Request() override = default;
-
-	public:
 		HeaterOperatingModes OperatingMode() const;
 		uint8_t PoolSetpoint() const;
 		uint8_t SpaSetpoint() const;
 		uint8_t WaterTemperature() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		HeaterOperatingModes m_OperatingMode;
-		uint8_t m_PoolSetpoint;
-		uint8_t m_SpaSetpoint;
-		uint8_t m_WaterTemperature;
+		HeaterOperatingModes m_OperatingMode{ HeaterOperatingModes::Unknown };
+		uint8_t m_PoolSetpoint{ 0 };
+		uint8_t m_SpaSetpoint{ 0 };
+		uint8_t m_WaterTemperature{ 0 };
 	};
 
 }

--- a/src/jandy/messages/heater/heater_message_status.cpp
+++ b/src/jandy/messages/heater/heater_message_status.cpp
@@ -13,9 +13,7 @@ namespace AqualinkAutomate::Messages
 
 	HeaterMessage_Status::HeaterMessage_Status() noexcept :
 		HeaterMessage(JandyMessageIds::Heater_Status),
-		Interfaces::IMessageSignalRecv<HeaterMessage_Status>(),
-		m_HeaterState(HeaterStates::Unknown),
-		m_ErrorCode(HeaterErrors::Unknown)
+		Interfaces::IMessageSignalRecv<HeaterMessage_Status>()
 	{
 	}
 

--- a/src/jandy/messages/heater/heater_message_status.h
+++ b/src/jandy/messages/heater/heater_message_status.h
@@ -40,21 +40,15 @@ namespace AqualinkAutomate::Messages
 	public:
 		HeaterMessage_Status() noexcept;
 		~HeaterMessage_Status() override = default;
-
-	public:
 		HeaterStates HeaterState() const;
 		HeaterErrors ErrorCode() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		HeaterStates m_HeaterState;
-		HeaterErrors m_ErrorCode;
+		HeaterStates m_HeaterState{ HeaterStates::Unknown };
+		HeaterErrors m_ErrorCode{ HeaterErrors::Unknown };
 	};
 
 }

--- a/src/jandy/messages/iaq/iaq_message.h
+++ b/src/jandy/messages/iaq/iaq_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class IAQMessage : public JandyMessage
 	{
 	public:
-		IAQMessage(const JandyMessageIds& msg_id);
+		explicit IAQMessage(const JandyMessageIds& msg_id);
 		~IAQMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/iaq/iaq_message_aux_status.h
+++ b/src/jandy/messages/iaq/iaq_message_aux_status.h
@@ -25,16 +25,10 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_AuxStatus() noexcept;
 		~IAQMessage_AuxStatus() override = default;
-
-	public:
 		const std::vector<uint8_t>& RawPayload() const;
 		const std::vector<AuxDeviceInfo>& Devices() const;
 		uint8_t DeviceCount() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/iaq/iaq_message_command_ready.h
+++ b/src/jandy/messages/iaq/iaq_message_command_ready.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_CommandReady() noexcept;
 		~IAQMessage_CommandReady() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_control_data_response.h
+++ b/src/jandy/messages/iaq/iaq_message_control_data_response.h
@@ -19,11 +19,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		explicit IAQMessage_ControlDataResponse(const std::string& ascii_data);
 		~IAQMessage_ControlDataResponse() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/iaq/iaq_message_control_ready.h
+++ b/src/jandy/messages/iaq/iaq_message_control_ready.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_ControlReady() noexcept;
 		~IAQMessage_ControlReady() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_heartbeat.h
+++ b/src/jandy/messages/iaq/iaq_message_heartbeat.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_Heartbeat() noexcept;
 		~IAQMessage_Heartbeat() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_main_status.cpp
+++ b/src/jandy/messages/iaq/iaq_message_main_status.cpp
@@ -28,12 +28,14 @@ namespace AqualinkAutomate::Messages
 		// Protocol values: 0x00=off, 0x01=heating, 0x03=enabled (standby).
 		constexpr Kernel::HeaterStatuses RawToHeaterStatus(uint8_t raw)
 		{
+			using enum Kernel::HeaterStatuses;
+
 			switch (raw)
 			{
-			case 0x00: return Kernel::HeaterStatuses::Off;
-			case 0x01: return Kernel::HeaterStatuses::Heating;
-			case 0x03: return Kernel::HeaterStatuses::Enabled;
-			default:   return Kernel::HeaterStatuses::Unknown;
+			case 0x00: return Off;
+			case 0x01: return Heating;
+			case 0x03: return Enabled;
+			default:   return Unknown;
 			}
 		}
 	}

--- a/src/jandy/messages/iaq/iaq_message_main_status.h
+++ b/src/jandy/messages/iaq/iaq_message_main_status.h
@@ -20,8 +20,6 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_MainStatus() noexcept;
 		~IAQMessage_MainStatus() override = default;
-
-	public:
 		const std::vector<uint8_t>& RawPayload() const;
 		bool PumpOn() const;
 		bool SpaMode() const;
@@ -44,11 +42,7 @@ namespace AqualinkAutomate::Messages
 		Kernel::HeaterStatuses SpaHeaterStatus() const;
 		Kernel::HeaterStatuses SolarHeaterStatus() const;
 		const std::vector<uint8_t>& DeviceIds() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/iaq/iaq_message_message_long.h
+++ b/src/jandy/messages/iaq/iaq_message_message_long.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_MessageLong() noexcept;
 		~IAQMessage_MessageLong() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_onetouch_status.h
+++ b/src/jandy/messages/iaq/iaq_message_onetouch_status.h
@@ -17,14 +17,8 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_OneTouchStatus() noexcept;
 		~IAQMessage_OneTouchStatus() override = default;
-
-	public:
 		const std::vector<uint8_t>& RawPayload() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/iaq/iaq_message_page_button.cpp
+++ b/src/jandy/messages/iaq/iaq_message_page_button.cpp
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 
 	IAQMessage_PageButton::IAQMessage_PageButton() noexcept :
 		IAQMessage(JandyMessageIds::IAQ_PageButton),
-		Interfaces::IMessageSignalRecv<IAQMessage_PageButton>(),
-		m_ButtonIndex(0),
-		m_ButtonStatus(ButtonStatuses::Unknown),
-		m_ButtonType(ButtonTypes::Unknown),
-		m_ButtonName()
+		Interfaces::IMessageSignalRecv<IAQMessage_PageButton>()
 	{
 	}
 

--- a/src/jandy/messages/iaq/iaq_message_page_button.h
+++ b/src/jandy/messages/iaq/iaq_message_page_button.h
@@ -49,24 +49,18 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_PageButton() noexcept;
 		~IAQMessage_PageButton() override = default;
-
-	public:
 		uint8_t ButtonIndex() const;
 		ButtonStatuses ButtonStatus() const;
 		ButtonTypes ButtonType() const;
 		std::string ButtonName() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_ButtonIndex;
-		ButtonStatuses m_ButtonStatus;
-		ButtonTypes m_ButtonType;
+		uint8_t m_ButtonIndex{ 0 };
+		ButtonStatuses m_ButtonStatus{ ButtonStatuses::Unknown };
+		ButtonTypes m_ButtonType{ ButtonTypes::Unknown };
 		std::string m_ButtonName;
 	};
 

--- a/src/jandy/messages/iaq/iaq_message_page_continue.h
+++ b/src/jandy/messages/iaq/iaq_message_page_continue.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_PageContinue() noexcept;
 		~IAQMessage_PageContinue() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_page_end.h
+++ b/src/jandy/messages/iaq/iaq_message_page_end.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_PageEnd() noexcept;
 		~IAQMessage_PageEnd() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_page_message.cpp
+++ b/src/jandy/messages/iaq/iaq_message_page_message.cpp
@@ -13,9 +13,7 @@ namespace AqualinkAutomate::Messages
 
 	IAQMessage_PageMessage::IAQMessage_PageMessage() noexcept :
 		IAQMessage(JandyMessageIds::IAQ_PageMessage),
-		Interfaces::IMessageSignalRecv<IAQMessage_PageMessage>(),
-		m_LineId(0),
-		m_Line()
+		Interfaces::IMessageSignalRecv<IAQMessage_PageMessage>()
 	{
 	}
 

--- a/src/jandy/messages/iaq/iaq_message_page_message.h
+++ b/src/jandy/messages/iaq/iaq_message_page_message.h
@@ -21,20 +21,14 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_PageMessage() noexcept;
 		~IAQMessage_PageMessage() override = default;
-
-	public:
 		uint8_t LineId() const;
 		std::string Line() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_LineId;
+		uint8_t m_LineId{ 0 };
 		std::string m_Line;
 	};
 

--- a/src/jandy/messages/iaq/iaq_message_page_start.h
+++ b/src/jandy/messages/iaq/iaq_message_page_start.h
@@ -21,14 +21,8 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_PageStart() noexcept;
 		~IAQMessage_PageStart() override = default;
-
-	public:
 		uint8_t PageId() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/iaq/iaq_message_poll.h
+++ b/src/jandy/messages/iaq/iaq_message_poll.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_Poll() noexcept;
 		~IAQMessage_Poll() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_startup.h
+++ b/src/jandy/messages/iaq/iaq_message_startup.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_StartUp() noexcept;
 		~IAQMessage_StartUp() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/iaq/iaq_message_table_message.cpp
+++ b/src/jandy/messages/iaq/iaq_message_table_message.cpp
@@ -13,9 +13,7 @@ namespace AqualinkAutomate::Messages
 
 	IAQMessage_TableMessage::IAQMessage_TableMessage() noexcept :
 		IAQMessage(JandyMessageIds::IAQ_TableMessage),
-		Interfaces::IMessageSignalRecv<IAQMessage_TableMessage>(),
-		m_LineId(0),
-		m_Line()
+		Interfaces::IMessageSignalRecv<IAQMessage_TableMessage>()
 	{
 	}
 

--- a/src/jandy/messages/iaq/iaq_message_table_message.h
+++ b/src/jandy/messages/iaq/iaq_message_table_message.h
@@ -28,21 +28,15 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_TableMessage() noexcept;
 		~IAQMessage_TableMessage() override = default;
-
-	public:
 		uint8_t LineId() const;
 		uint8_t Attribute() const;
 		std::string Line() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_LineId;
+		uint8_t m_LineId{ 0 };
 		uint8_t m_Attribute{ 0 };
 		std::string m_Line;
 	};

--- a/src/jandy/messages/iaq/iaq_message_title_message.cpp
+++ b/src/jandy/messages/iaq/iaq_message_title_message.cpp
@@ -13,8 +13,7 @@ namespace AqualinkAutomate::Messages
 
 	IAQMessage_TitleMessage::IAQMessage_TitleMessage() noexcept :
 		IAQMessage(JandyMessageIds::IAQ_TitleMessage),
-		Interfaces::IMessageSignalRecv<IAQMessage_TitleMessage>(),
-		m_Title()
+		Interfaces::IMessageSignalRecv<IAQMessage_TitleMessage>()
 	{
 	}
 

--- a/src/jandy/messages/iaq/iaq_message_title_message.h
+++ b/src/jandy/messages/iaq/iaq_message_title_message.h
@@ -20,14 +20,8 @@ namespace AqualinkAutomate::Messages
 	public:
 		IAQMessage_TitleMessage() noexcept;
 		~IAQMessage_TitleMessage() override = default;
-
-	public:
 		std::string Title() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/jandy_message.cpp
+++ b/src/jandy/messages/jandy_message.cpp
@@ -2,6 +2,7 @@
 #include <format>
 #include <span>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <magic_enum/magic_enum.hpp>
@@ -20,11 +21,7 @@ namespace AqualinkAutomate::Messages
 {
 JandyMessage::JandyMessage(const JandyMessageIds& msg_id) :
 		Interfaces::IMessage<JandyMessageIds>(msg_id),
-		Interfaces::ISerializable(),
-		m_Destination(0x00), 
-		m_RawId(0),
-		m_MessageLength(0),
-		m_ChecksumValue(0)
+		Interfaces::ISerializable()
 	{
 	}
 
@@ -122,7 +119,7 @@ JandyMessage::JandyMessage(const JandyMessageIds& msg_id) :
 		std::transform(message_bytes.begin(), message_bytes.end(), byte_buffer.begin(),
 			[](std::byte b)
 			{
-				return static_cast<uint8_t>(b);
+				return std::to_underlying(b);
 			}
 		);
 

--- a/src/jandy/messages/jandy_message.h
+++ b/src/jandy/messages/jandy_message.h
@@ -38,22 +38,18 @@ namespace AqualinkAutomate::Messages
 		static constexpr uint8_t MAXIMUM_PACKET_LENGTH{ 128 };
 		static constexpr uint8_t MINIMUM_PACKET_LENGTH{ PACKET_HEADER_LENGTH + PACKET_FOOTER_LENGTH };
 
-	public:
-		JandyMessage(const JandyMessageIds& msg_id);
+		explicit JandyMessage(const JandyMessageIds& msg_id);
 		~JandyMessage() override = default;
 
-	public:
 		const Devices::JandyDeviceType Destination() const;
 		uint8_t RawId() const;
 		uint8_t MessageLength() const;
 		uint8_t ChecksumValue() const;
 
-	public:
 		uint8_t MaxPermittedPacketLength() const override;
 		uint8_t MinPermittedPacketLength() const override;
 		std::string ToString() const override;
 
-	public:
 		// Two Deserialize overloads coexist on this type.  They are NOT competing
 		// generic overloads — they form a single logical entry point split by an
 		// unambiguous, disjoint parameter domain, both forwarding into the one
@@ -76,7 +72,6 @@ namespace AqualinkAutomate::Messages
 		bool Deserialize(const std::span<const std::byte>& message_bytes) final;
 		virtual bool DeserializeContents(std::span<const uint8_t> message_bytes) = 0;
 
-	public:
 		template <MutableJandyRawMessageRange RAW_MESSAGE_RANGE>
 		[[nodiscard]] bool Serialize(RAW_MESSAGE_RANGE& raw_message) const
 		{
@@ -138,10 +133,10 @@ namespace AqualinkAutomate::Messages
 		bool PacketChecksumIsValid(std::span<const uint8_t> message_bytes) const;
 
 	protected:
-		Devices::JandyDeviceType m_Destination;
-		uint8_t m_RawId;
-		uint8_t m_MessageLength;
-		uint8_t m_ChecksumValue;
+		Devices::JandyDeviceType m_Destination{ 0x00 };
+		uint8_t m_RawId{ 0 };
+		uint8_t m_MessageLength{ 0 };
+		uint8_t m_ChecksumValue{ 0 };
 	};
 
 }

--- a/src/jandy/messages/jandy_message_ack.h
+++ b/src/jandy/messages/jandy_message_ack.h
@@ -50,22 +50,14 @@ namespace AqualinkAutomate::Messages
 		JandyMessage_Ack(AckTypes ack_type, uint8_t command);
 		explicit JandyMessage_Ack(uint8_t ack_value, uint8_t command);
 		~JandyMessage_Ack() override = default;
-
-	public:
 		AckTypes AckType() const;
 		uint8_t Command() const;
-
-	public:
 		template<typename COMMAND_TYPE>
 		COMMAND_TYPE Command(std::function<COMMAND_TYPE(uint8_t)> command_decoder) const
 		{
 			return command_decoder(Command());
 		}
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/jandy_message_display_update.h
+++ b/src/jandy/messages/jandy_message_display_update.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		JandyMessage_DisplayUpdate() noexcept;
 		~JandyMessage_DisplayUpdate() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/jandy_message_message.h
+++ b/src/jandy/messages/jandy_message_message.h
@@ -20,16 +20,13 @@ namespace AqualinkAutomate::Messages
 
 	public:
 		JandyMessage_Message() noexcept;
-		JandyMessage_Message(const std::string& line);
+		explicit JandyMessage_Message(const std::string& line);
 		~JandyMessage_Message() override = default;
 
-	public:
 		std::string Line() const;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/jandy_message_message_long.cpp
+++ b/src/jandy/messages/jandy_message_message_long.cpp
@@ -18,10 +18,10 @@ namespace AqualinkAutomate::Messages
 		m_Line.reserve(MAXIMUM_MESSAGE_LENGTH);
 	}
 
-	JandyMessage_MessageLong::JandyMessage_MessageLong(const uint8_t line_id, const std::string& line) :
+	JandyMessage_MessageLong::JandyMessage_MessageLong(const uint8_t line_id_value, const std::string& line) :
 		JandyMessage(JandyMessageIds::MessageLong),
 		Interfaces::IMessageSignalRecv<JandyMessage_MessageLong>(),
-		m_LineId(line_id),
+		m_LineId(line_id_value),
 		m_Line(line)
 	{
 		m_Line.reserve(MAXIMUM_MESSAGE_LENGTH);

--- a/src/jandy/messages/jandy_message_message_long.h
+++ b/src/jandy/messages/jandy_message_message_long.h
@@ -25,15 +25,9 @@ namespace AqualinkAutomate::Messages
 		JandyMessage_MessageLong() noexcept;
 		JandyMessage_MessageLong(const uint8_t line_id, const std::string& line);
 		~JandyMessage_MessageLong() override = default;
-
-	public:
 		uint8_t LineId() const;
 		std::string Line() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/jandy_message_probe.h
+++ b/src/jandy/messages/jandy_message_probe.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		JandyMessage_Probe() noexcept;
 		~JandyMessage_Probe() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/jandy_message_status.cpp
+++ b/src/jandy/messages/jandy_message_status.cpp
@@ -14,19 +14,7 @@ namespace AqualinkAutomate::Messages
 
 	JandyMessage_Status::JandyMessage_Status() noexcept :
 		JandyMessage(JandyMessageIds::Status),
-		Interfaces::IMessageSignalRecv<JandyMessage_Status>(), 
-		m_Mode(ComboModes::Unknown),
-		m_FilterPump(Kernel::PumpStatuses::Unknown),
-		m_Aux1(Kernel::AuxillaryStatuses::Unknown),
-		m_Aux2(Kernel::AuxillaryStatuses::Unknown),
-		m_Aux3(Kernel::AuxillaryStatuses::Unknown),
-		m_Aux4(Kernel::AuxillaryStatuses::Unknown),
-		m_Aux5(Kernel::AuxillaryStatuses::Unknown),
-		m_Aux6(Kernel::AuxillaryStatuses::Unknown),
-		m_Aux7(Kernel::AuxillaryStatuses::Unknown),
-		m_PoolHeater(Kernel::HeaterStatuses::Unknown),
-		m_SolarHeater(Kernel::HeaterStatuses::Unknown),
-		m_SpaHeater(Kernel::HeaterStatuses::Unknown)
+		Interfaces::IMessageSignalRecv<JandyMessage_Status>() 
 	{
 	}
 

--- a/src/jandy/messages/jandy_message_status.h
+++ b/src/jandy/messages/jandy_message_status.h
@@ -29,8 +29,6 @@ namespace AqualinkAutomate::Messages
 	public:
 		JandyMessage_Status() noexcept;
 		~JandyMessage_Status() override = default;
-
-	public:
 		ComboModes Mode() const;
 		Kernel::PumpStatuses FilterPump() const;
 		Kernel::AuxillaryStatuses Aux1() const;
@@ -43,8 +41,6 @@ namespace AqualinkAutomate::Messages
 		Kernel::HeaterStatuses PoolHeater() const;
 		Kernel::HeaterStatuses SpaHeater() const;
 		Kernel::HeaterStatuses SolarHeater() const;
-
-	public:
 		// Raw payload bytes retained verbatim from the wire (between the 4-byte header and
 		// 3-byte footer). Empty until DeserializeContents runs. The structured Aux*/Heater
 		// accessors above decode payload bytes [1..] (wire indices 5..9); payload byte [0]
@@ -54,25 +50,23 @@ namespace AqualinkAutomate::Messages
 		const std::vector<uint8_t>& RawPayload() const;
 
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
 		std::vector<uint8_t> m_RawPayload;
-		ComboModes m_Mode;
-		Kernel::PumpStatuses m_FilterPump;
-		Kernel::AuxillaryStatuses m_Aux1;
-		Kernel::AuxillaryStatuses m_Aux2;
-		Kernel::AuxillaryStatuses m_Aux3;
-		Kernel::AuxillaryStatuses m_Aux4;
-		Kernel::AuxillaryStatuses m_Aux5;
-		Kernel::AuxillaryStatuses m_Aux6;
-		Kernel::AuxillaryStatuses m_Aux7;
-		Kernel::HeaterStatuses m_PoolHeater;
-		Kernel::HeaterStatuses m_SolarHeater;
-		Kernel::HeaterStatuses m_SpaHeater;
+		ComboModes m_Mode{ ComboModes::Unknown };
+		Kernel::PumpStatuses m_FilterPump{ Kernel::PumpStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux1{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux2{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux3{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux4{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux5{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux6{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::AuxillaryStatuses m_Aux7{ Kernel::AuxillaryStatuses::Unknown };
+		Kernel::HeaterStatuses m_PoolHeater{ Kernel::HeaterStatuses::Unknown };
+		Kernel::HeaterStatuses m_SolarHeater{ Kernel::HeaterStatuses::Unknown };
+		Kernel::HeaterStatuses m_SpaHeater{ Kernel::HeaterStatuses::Unknown };
 	};
 
 }

--- a/src/jandy/messages/jandy_message_unknown.h
+++ b/src/jandy/messages/jandy_message_unknown.h
@@ -17,11 +17,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		JandyMessage_Unknown() noexcept;
 		~JandyMessage_Unknown() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/light/light_message.h
+++ b/src/jandy/messages/light/light_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class LightMessage : public JandyMessage
 	{
 	public:
-		LightMessage(const JandyMessageIds& msg_id);
+		explicit LightMessage(const JandyMessageIds& msg_id);
 		~LightMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/pda/pda_message.h
+++ b/src/jandy/messages/pda/pda_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class PDAMessage : public JandyMessage
 	{
 	public:
-		PDAMessage(const JandyMessageIds& msg_id);
+		explicit PDAMessage(const JandyMessageIds& msg_id);
 		~PDAMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/pda/pda_message_clear.h
+++ b/src/jandy/messages/pda/pda_message_clear.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		PDAMessage_Clear() noexcept;
 		~PDAMessage_Clear() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/pda/pda_message_highlight.cpp
+++ b/src/jandy/messages/pda/pda_message_highlight.cpp
@@ -14,10 +14,10 @@ namespace AqualinkAutomate::Messages
 	{
 	}
 
-	PDAMessage_Highlight::PDAMessage_Highlight(const uint8_t line_id) :
+	PDAMessage_Highlight::PDAMessage_Highlight(const uint8_t line_id_value) :
 		PDAMessage(JandyMessageIds::PDA_Highlight),
 		Interfaces::IMessageSignalRecv<PDAMessage_Highlight>(),
-		m_LineId(line_id)
+		m_LineId(line_id_value)
 	{
 	}
 

--- a/src/jandy/messages/pda/pda_message_highlight.h
+++ b/src/jandy/messages/pda/pda_message_highlight.h
@@ -18,16 +18,13 @@ namespace AqualinkAutomate::Messages
 
 	public:
 		PDAMessage_Highlight() noexcept;
-		PDAMessage_Highlight(const uint8_t line_id);
+		explicit PDAMessage_Highlight(const uint8_t line_id);
 		~PDAMessage_Highlight() override = default;
 
-	public:
 		uint8_t LineId() const;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 

--- a/src/jandy/messages/pda/pda_message_highlight_chars.cpp
+++ b/src/jandy/messages/pda/pda_message_highlight_chars.cpp
@@ -11,10 +11,7 @@ namespace AqualinkAutomate::Messages
 
 	PDAMessage_HighlightChars::PDAMessage_HighlightChars() noexcept :
 		PDAMessage(JandyMessageIds::PDA_HighlightChars),
-		Interfaces::IMessageSignalRecv<PDAMessage_HighlightChars>(),
-		m_LineId(0),
-		m_StartIndex(0),
-		m_StopIndex(0)
+		Interfaces::IMessageSignalRecv<PDAMessage_HighlightChars>()
 	{
 	}
 

--- a/src/jandy/messages/pda/pda_message_highlight_chars.h
+++ b/src/jandy/messages/pda/pda_message_highlight_chars.h
@@ -21,23 +21,17 @@ namespace AqualinkAutomate::Messages
 	public:
 		PDAMessage_HighlightChars() noexcept;
 		~PDAMessage_HighlightChars() override = default;
-
-	public:
 		uint8_t LineId() const;
 		uint8_t StartIndex() const;
 		uint8_t StopIndex() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_LineId;
-		uint8_t m_StartIndex;
-		uint8_t m_StopIndex;
+		uint8_t m_LineId{ 0 };
+		uint8_t m_StartIndex{ 0 };
+		uint8_t m_StopIndex{ 0 };
 	};
 
 }

--- a/src/jandy/messages/pda/pda_message_shiftlines.cpp
+++ b/src/jandy/messages/pda/pda_message_shiftlines.cpp
@@ -11,10 +11,7 @@ namespace AqualinkAutomate::Messages
 
 	PDAMessage_ShiftLines::PDAMessage_ShiftLines() noexcept :
 		PDAMessage(JandyMessageIds::PDA_ShiftLines),
-		Interfaces::IMessageSignalRecv<PDAMessage_ShiftLines>(),
-		m_FirstLineId(0),
-		m_LastLineId(0),
-		m_LineShift(0)
+		Interfaces::IMessageSignalRecv<PDAMessage_ShiftLines>()
 	{
 	}
 

--- a/src/jandy/messages/pda/pda_message_shiftlines.h
+++ b/src/jandy/messages/pda/pda_message_shiftlines.h
@@ -21,23 +21,17 @@ namespace AqualinkAutomate::Messages
 	public:
 		PDAMessage_ShiftLines() noexcept;
 		~PDAMessage_ShiftLines() override = default;
-
-	public:
 		uint8_t FirstLineId() const;
 		uint8_t LastLineId() const;
 		int8_t LineShift() const;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
-		uint8_t m_FirstLineId;
-		uint8_t m_LastLineId;
-		int8_t m_LineShift;
+		uint8_t m_FirstLineId{ 0 };
+		uint8_t m_LastLineId{ 0 };
+		int8_t m_LineShift{ 0 };
 	};
 
 }

--- a/src/jandy/messages/serial_adapter/serial_adapter_message.h
+++ b/src/jandy/messages/serial_adapter/serial_adapter_message.h
@@ -13,13 +13,11 @@ namespace AqualinkAutomate::Messages
 	class SerialAdapterMessage : public JandyMessage
 	{
 	public:
-		SerialAdapterMessage(const JandyMessageIds& msg_id);
+		explicit SerialAdapterMessage(const JandyMessageIds& msg_id);
 		~SerialAdapterMessage() override = default;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override = 0;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override = 0;
 	};

--- a/src/jandy/messages/serial_adapter/serial_adapter_message_dev_ready.h
+++ b/src/jandy/messages/serial_adapter/serial_adapter_message_dev_ready.h
@@ -16,11 +16,7 @@ namespace AqualinkAutomate::Messages
 	public:
 		SerialAdapterMessage_DevReady() noexcept;
 		~SerialAdapterMessage_DevReady() override = default;
-
-	public:
 		std::string ToString() const override;
-
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 	};

--- a/src/jandy/messages/serial_adapter/serial_adapter_message_dev_status.cpp
+++ b/src/jandy/messages/serial_adapter/serial_adapter_message_dev_status.cpp
@@ -151,6 +151,7 @@ namespace AqualinkAutomate::Messages
 			{ 
 				[](std::monostate)
 				{
+					// Intentionally empty: an unset status variant serialises nothing.
 				},
 				[&message_bytes](SerialAdapter_ConfigControlCommands sa_ccc)
 				{
@@ -211,10 +212,10 @@ namespace AqualinkAutomate::Messages
 				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> SerialAdapter_SystemPumpCommands: {}", magic_enum::enum_name(status_type.value())));
 				return status_type.value();
 			}
-			else if (auto status_type = magic_enum::enum_cast<Auxillaries::JandyAuxillaryIds>(static_cast<uint8_t>(message_bytes[Index_DeviceId]) - SERIALADAPTER_AUX_ID_OFFSET); status_type.has_value())
+			else if (auto aux_status_type = magic_enum::enum_cast<Auxillaries::JandyAuxillaryIds>(static_cast<uint8_t>(message_bytes[Index_DeviceId]) - SERIALADAPTER_AUX_ID_OFFSET); aux_status_type.has_value())
 			{
-				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> Auxillaries::JandyAuxillaryIds: {}", magic_enum::enum_name(status_type.value())));
-				return status_type.value();
+				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> Auxillaries::JandyAuxillaryIds: {}", magic_enum::enum_name(aux_status_type.value())));
+				return aux_status_type.value();
 			}
 
 			return SerialAdapter_StatusTypes();
@@ -240,15 +241,15 @@ namespace AqualinkAutomate::Messages
 				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> SerialAdapter_ConfigControlCommands: {}", magic_enum::enum_name(status_type.value())));
 				m_StatusType = status_type.value();
 			}
-			else if (auto status_type = magic_enum::enum_cast<SerialAdapter_SystemConfigurationStatuses>(static_cast<uint8_t>(message_bytes[Index_StatusType])); status_type.has_value())
+			else if (auto config_status_type = magic_enum::enum_cast<SerialAdapter_SystemConfigurationStatuses>(static_cast<uint8_t>(message_bytes[Index_StatusType])); config_status_type.has_value())
 			{
-				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> SerialAdapter_SystemConfigurationStatuses: {}", magic_enum::enum_name(status_type.value())));
-				m_StatusType = status_type.value();
+				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> SerialAdapter_SystemConfigurationStatuses: {}", magic_enum::enum_name(config_status_type.value())));
+				m_StatusType = config_status_type.value();
 			}
-			else if (auto status_type = magic_enum::enum_cast<SerialAdapter_SystemTemperatureCommands>(static_cast<uint8_t>(message_bytes[Index_StatusType])); status_type.has_value())
+			else if (auto temp_status_type = magic_enum::enum_cast<SerialAdapter_SystemTemperatureCommands>(static_cast<uint8_t>(message_bytes[Index_StatusType])); temp_status_type.has_value())
 			{
-				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> SerialAdapter_SystemTemperatureCommands: {}", magic_enum::enum_name(status_type.value())));
-				m_StatusType = status_type.value();
+				LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: StatusType -> SerialAdapter_SystemTemperatureCommands: {}", magic_enum::enum_name(temp_status_type.value())));
+				m_StatusType = temp_status_type.value();
 			}
 			else
 			{
@@ -269,8 +270,9 @@ namespace AqualinkAutomate::Messages
 				{
 					LogWarning(Channel::Messages, "SerialAdapterMessage_DevStatus: Invalid Status Type");
 				},
-				[this, &message_bytes](SerialAdapter_ConfigControlCommands sa_ccc)
+				[this, &message_bytes](SerialAdapter_ConfigControlCommands)
 				{
+					// Intentionally empty: config-control command responses carry no decodable payload here.
 				},
 				[this, &message_bytes](SerialAdapter_SystemConfigurationStatuses sa_scs)
 				{
@@ -319,25 +321,27 @@ namespace AqualinkAutomate::Messages
 				},
 				[this, &message_bytes](SerialAdapter_SystemPumpCommands sa_spc)
 				{
+					using enum SerialAdapter_SystemPumpCommands;
+
 					switch (sa_spc)
 					{
-					case SerialAdapter_SystemPumpCommands::CLEANR:
+					case CLEANR:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: Cleaner -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 
-					case SerialAdapter_SystemPumpCommands::SPILLOVER:
+					case SPILLOVER:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: Spillover -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 
-					case SerialAdapter_SystemPumpCommands::PUMP:
+					case PUMP:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: Pump -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 
-					case SerialAdapter_SystemPumpCommands::PUMPLO:
+					case PUMPLO:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: PumpLowSpeed -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 
-					case SerialAdapter_SystemPumpCommands::SPA:
+					case SPA:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: Spa -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 					}
@@ -349,18 +353,20 @@ namespace AqualinkAutomate::Messages
 					// Unit-aware conversion to Temperature objects happens in the message processor
 					// which has access to DataHub's SystemTemperatureUnits().
 
+					using enum SerialAdapter_SystemTemperatureCommands;
+
 					switch (sa_stc)
 					{
-					case SerialAdapter_SystemTemperatureCommands::UNITS:
+					case UNITS:
 						m_TemperatureUnits = (0x00 == message_bytes[Index_TemperatureUnits]) ? Kernel::TemperatureUnits::Fahrenheit : Kernel::TemperatureUnits::Celsius;
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: TemperatureUnits -> {}", magic_enum::enum_name(m_TemperatureUnits.value())));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::POOLHT:
+					case POOLHT:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: PoolHeat -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break; 
 
-					case SerialAdapter_SystemTemperatureCommands::POOLHT2:
+					case POOLHT2:
 						// CAPTURE-GATED: documented as a boolean enable (st); decode the STC value
 						// byte (Index_PoolTemperature_SetPoint == 6, the shared value slot for every
 						// STC command -- byte[4] is the command selector) as "TEMP2 maintenance
@@ -370,45 +376,45 @@ namespace AqualinkAutomate::Messages
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: PoolHeat2 -> {:02x} {:02x} {:02x} {:02x} (TEMP2 enabled={})", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7], m_PoolHeater_Two_Enabled.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::SPAHT:
+					case SPAHT:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: SpaHeat -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::SOLHT:
+					case SOLHT:
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: SolarHeat -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::POOLSP:
+					case POOLSP:
 						m_PoolTemperature_SetPoint_One = message_bytes[Index_PoolTemperature_SetPoint];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: PoolTemp SetPoint 1 -> {}", m_PoolTemperature_SetPoint_One.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::POOLSP2:
+					case POOLSP2:
 						m_PoolTemperature_SetPoint_Two = message_bytes[Index_PoolTemperature_SetPoint];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: PoolTemp SetPoint 2 -> {}", m_PoolTemperature_SetPoint_Two.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::SPASP:
+					case SPASP:
 						m_SpaTemperature_SetPoint = message_bytes[Index_SpaTemperature_SetPoint];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: SpaTemp SetPoint -> {}", m_SpaTemperature_SetPoint.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::POOLTMP:
+					case POOLTMP:
 						m_PoolTemperature = message_bytes[Index_PoolTemperature];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: PoolTemp -> {}", m_PoolTemperature.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::SPATMP:
+					case SPATMP:
 						m_SpaTemperature = message_bytes[Index_SpaTemperature];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: SpaTemp -> {}", m_SpaTemperature.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::AIRTMP:
+					case AIRTMP:
 						m_AirTemperature = message_bytes[Index_AirTemperature];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: AirTemp -> {}", m_AirTemperature.value()));
 						break;
 
-					case SerialAdapter_SystemTemperatureCommands::SOLTMP:
+					case SOLTMP:
 						m_SolarTemperature = message_bytes[Index_SolarTemperature];
 						LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: SolarTemp -> {}", m_SolarTemperature.value()));
 						break;
@@ -422,7 +428,7 @@ namespace AqualinkAutomate::Messages
 
 					LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: {} Status -> {}", magic_enum::enum_name(sa_jai), magic_enum::enum_name(status)));
 				},
-				[this, &message_bytes](SerialAdapter_UnknownCommands sa_uc)
+				[this, &message_bytes](SerialAdapter_UnknownCommands)
 				{
 					LogDebug(Channel::Messages, "SerialAdapterMessage_DevStatus: Unknown, error, and/or unhandled status type");
 					LogDebug(Channel::Messages, std::format("SerialAdapterMessage_DevStatus: Unknown/Error -> {:02x} {:02x} {:02x} {:02x}", message_bytes[4], message_bytes[5], message_bytes[6], message_bytes[7]));

--- a/src/jandy/messages/serial_adapter/serial_adapter_message_dev_status.h
+++ b/src/jandy/messages/serial_adapter/serial_adapter_message_dev_status.h
@@ -168,20 +168,18 @@ namespace AqualinkAutomate::Messages
 
 	public:
 		SerialAdapterMessage_DevStatus() noexcept;
-		SerialAdapterMessage_DevStatus(const SerialAdapter_ConfigControlCommands  sa_ccc);
-		SerialAdapterMessage_DevStatus(const SerialAdapter_SystemConfigurationStatuses sa_scs);
-		SerialAdapterMessage_DevStatus(const SerialAdapter_SystemPumpCommands sa_spc);
-		SerialAdapterMessage_DevStatus(const SerialAdapter_SystemTemperatureCommands sa_stc);
-		SerialAdapterMessage_DevStatus(const Auxillaries::JandyAuxillaryIds sa_jai);
+		explicit SerialAdapterMessage_DevStatus(const SerialAdapter_ConfigControlCommands  sa_ccc);
+		explicit SerialAdapterMessage_DevStatus(const SerialAdapter_SystemConfigurationStatuses sa_scs);
+		explicit SerialAdapterMessage_DevStatus(const SerialAdapter_SystemPumpCommands sa_spc);
+		explicit SerialAdapterMessage_DevStatus(const SerialAdapter_SystemTemperatureCommands sa_stc);
+		explicit SerialAdapterMessage_DevStatus(const Auxillaries::JandyAuxillaryIds sa_jai);
 		~SerialAdapterMessage_DevStatus() override = default;
 
-	public:
 		std::optional<uint16_t> ModelType() const;
 		std::optional<SerialAdapter_SCS_OpModes> OpMode() const;
 		std::optional<SerialAdapter_SCS_Options> Options() const;
 		std::optional<SerialAdapter_SCS_BatteryCondition> BatteryCondition() const;
 
-	public:
 		std::optional<Kernel::TemperatureUnits> TemperatureUnits() const;
 		std::optional<uint8_t> Pool_SetPoint_One() const;
 		std::optional<uint8_t> Pool_SetPoint_Two() const;
@@ -192,28 +190,22 @@ namespace AqualinkAutomate::Messages
 		std::optional<uint8_t> SolarTemperature() const;
 		std::optional<uint8_t> SpaTemperature() const;
 
-	public:
 		std::optional<std::tuple<Auxillaries::JandyAuxillaryIds, std::optional<Auxillaries::JandyAuxillaryStatuses>>> AuxilliaryState() const;
 
-	public:
 		std::string ToString() const override;
 
-	public:
 		bool SerializeContents(std::vector<uint8_t>& message_bytes) const override;
 		bool DeserializeContents(std::span<const uint8_t> message_bytes) override;
 
 	private:
 		SerialAdapter_StatusTypes m_StatusType;
 
-	private:
 		std::optional<uint16_t> m_ModelType{ std::nullopt };
 
-	private:
 		std::optional<SerialAdapter_SCS_OpModes> m_OpMode{ std::nullopt };
 		std::optional<SerialAdapter_SCS_Options> m_Options{ std::nullopt };
 		std::optional<SerialAdapter_SCS_BatteryCondition> m_BatteryCondition{ std::nullopt };
 
-	private:
 		std::optional<Kernel::TemperatureUnits> m_TemperatureUnits{ std::nullopt };
 		std::optional<uint8_t> m_PoolTemperature_SetPoint_One{ std::nullopt };
 		std::optional<uint8_t> m_PoolTemperature_SetPoint_Two{ std::nullopt };
@@ -230,10 +222,8 @@ namespace AqualinkAutomate::Messages
 		std::optional<uint8_t> m_SolarTemperature{ std::nullopt };
 		std::optional<uint8_t> m_SpaTemperature{ std::nullopt };
 
-	private:
 		std::optional<std::tuple<Auxillaries::JandyAuxillaryIds, std::optional<Auxillaries::JandyAuxillaryStatuses>>> m_Aux_State{ std::nullopt };
 
-	private:
 		std::optional<Auxillaries::JandyAuxillaryStatuses> m_Cleaner_State;
 		std::optional<Auxillaries::JandyAuxillaryStatuses> m_Spillover_State;
 	};

--- a/src/jandy/navigation/navigator.cpp
+++ b/src/jandy/navigation/navigator.cpp
@@ -302,17 +302,19 @@ namespace AqualinkAutomate::Navigation
 
 	void Navigator::Reset()
 	{
+		using enum PageId;
+
 		LogDebug(Channel::Navigation, "Navigator: Resetting to idle state");
 		m_State = State::Idle;
-		m_CurrentPage = PageId::Unknown;
-		m_TargetPage = PageId::Unknown;
+		m_CurrentPage = Unknown;
+		m_TargetPage = Unknown;
 		m_Path.clear();
 		m_PathIndex = 0;
 		m_PendingStatusMessages = 0;
 		m_RecoveryAttempts = 0;
 		m_RecoveryBackPresses = 0;
 		m_NavigatingToItem = false;
-		m_SelectTarget = PageId::Unknown;
+		m_SelectTarget = Unknown;
 		m_CursorStuckCount = 0;
 		m_PreviousCursorLine = 0;
 		m_SkipCursorCheck = false;
@@ -320,10 +322,10 @@ namespace AqualinkAutomate::Navigation
 		m_WaitCycleCount = 0;
 		m_RecomputeCount = 0;
 		m_StuckRecomputeCount = 0;
-		m_LastRecomputeActual = PageId::Unknown;
-		m_LastRecomputeTarget = PageId::Unknown;
+		m_LastRecomputeActual = Unknown;
+		m_LastRecomputeTarget = Unknown;
 		m_TransientWaitCount = 0;
-		m_SyncDetectedPage = PageId::Unknown;
+		m_SyncDetectedPage = Unknown;
 		m_SyncConsistentCount = 0;
 		m_pCurrentContent = nullptr;
 		m_CurrentEdge = nullptr;
@@ -910,8 +912,7 @@ namespace AqualinkAutomate::Navigation
 		}
 
 		// Check for system events (timeout, service mode)
-		auto system_event = m_Model.FindSystemEvent(actual);
-		if (system_event.has_value())
+		if (auto system_event = m_Model.FindSystemEvent(actual); system_event.has_value())
 		{
 			LogWarning(Channel::Navigation, [&system_event] { return std::format("Navigator: System event detected: '{}'",
 				system_event->label); });
@@ -989,8 +990,7 @@ namespace AqualinkAutomate::Navigation
 		}
 
 		// Check for pages that don't support Back (OneTouch-style pages)
-		const MenuPage* current_page = m_Model.GetPage(m_CurrentPage);
-		if (current_page && !current_page->SupportsKey(EdgeTrigger::Back))
+		if (const MenuPage* current_page = m_Model.GetPage(m_CurrentPage); current_page && !current_page->SupportsKey(EdgeTrigger::Back))
 		{
 			// This page doesn't support Back - try to navigate to System via selection
 			LogDebug(Channel::Navigation, [this, &current_page] { return std::format("Navigator: Page {}({}) doesn't support Back - looking for System navigation",

--- a/src/jandy/navigation/spider_engine.cpp
+++ b/src/jandy/navigation/spider_engine.cpp
@@ -39,7 +39,7 @@ namespace AqualinkAutomate::Navigation
 		else
 		{
 			LogInfo(Channel::Scraping, std::format("SpiderEngine: Starting crawl from page {}",
-				static_cast<uint32_t>(m_Navigator.GetCurrentPage())));
+				std::to_underlying(m_Navigator.GetCurrentPage())));
 			m_State = State::NavigatingToNext;
 			NavigateToNextTarget();
 		}
@@ -66,7 +66,7 @@ namespace AqualinkAutomate::Navigation
 			if (m_Navigator.IsSynced())
 			{
 				LogInfo(Channel::Scraping, std::format("SpiderEngine: Navigator synced to page {} - beginning crawl",
-					static_cast<uint32_t>(m_Navigator.GetCurrentPage())));
+					std::to_underlying(m_Navigator.GetCurrentPage())));
 				m_State = State::NavigatingToNext;
 				NavigateToNextTarget();
 
@@ -91,7 +91,7 @@ namespace AqualinkAutomate::Navigation
 				{
 					// Arrived at target page
 					LogInfo(Channel::Scraping, std::format("SpiderEngine: Arrived at target page {}",
-						static_cast<uint32_t>(m_CurrentTarget)));
+						std::to_underlying(m_CurrentTarget)));
 					m_State = State::CapturingPage;
 					m_NavigationFailures = 0;
 
@@ -133,7 +133,7 @@ namespace AqualinkAutomate::Navigation
 					{
 						m_NavigationFailures++;
 						LogWarning(Channel::Scraping, std::format("SpiderEngine: Navigation to page {} failed ({}/{})",
-							static_cast<uint32_t>(m_CurrentTarget), m_NavigationFailures, MAX_NAVIGATION_FAILURES));
+							std::to_underlying(m_CurrentTarget), m_NavigationFailures, MAX_NAVIGATION_FAILURES));
 
 						if (m_NavigationFailures >= MAX_NAVIGATION_FAILURES)
 						{
@@ -169,8 +169,7 @@ namespace AqualinkAutomate::Navigation
 			}
 
 			// Track visit for multi-instance vs normal pages
-			const MenuPage* page_info = m_Model.GetPage(m_CurrentTarget);
-			if (page_info && page_info->multi_instance && m_CurrentMultiEdge.has_value())
+			if (const MenuPage* page_info = m_Model.GetPage(m_CurrentTarget); page_info && page_info->multi_instance && m_CurrentMultiEdge.has_value())
 			{
 				// Mark the specific edge as visited (not the page itself)
 				auto edge = m_CurrentMultiEdge.value();
@@ -178,8 +177,8 @@ namespace AqualinkAutomate::Navigation
 				m_CurrentMultiEdge = std::nullopt;
 
 				LogDebug(Channel::Scraping, std::format("SpiderEngine: Captured multi-instance page {} via edge (source={}, line={}) ({} edges visited)",
-					static_cast<uint32_t>(m_CurrentTarget),
-					static_cast<uint32_t>(edge->source), edge->trigger_line,
+					std::to_underlying(m_CurrentTarget),
+					std::to_underlying(edge->source), edge->trigger_line,
 					m_VisitedMultiEdges[m_CurrentTarget].size()));
 
 				// Only mark the page as fully visited when ALL incoming edges are done
@@ -187,7 +186,7 @@ namespace AqualinkAutomate::Navigation
 				{
 					m_Visited.insert(m_CurrentTarget);
 					LogInfo(Channel::Scraping, std::format("SpiderEngine: All instances of multi-instance page {} visited",
-						static_cast<uint32_t>(m_CurrentTarget)));
+						std::to_underlying(m_CurrentTarget)));
 				}
 			}
 			else
@@ -195,7 +194,7 @@ namespace AqualinkAutomate::Navigation
 				m_Visited.insert(m_CurrentTarget);
 
 				LogDebug(Channel::Scraping, std::format("SpiderEngine: Captured page {} ({} pages visited so far)",
-					static_cast<uint32_t>(m_CurrentTarget), m_Visited.size()));
+					std::to_underlying(m_CurrentTarget), m_Visited.size()));
 			}
 
 			// Choose next target
@@ -274,13 +273,10 @@ namespace AqualinkAutomate::Navigation
 
 		for (PageId candidate : candidates)
 		{
-			const MenuPage* page = m_Model.GetPage(candidate);
-
 			// For multi-instance pages, compute path to the parent page (via specific edge)
-			if (page && page->multi_instance)
+			if (const MenuPage* page = m_Model.GetPage(candidate); page && page->multi_instance)
 			{
-				auto next_edge = GetNextUnvisitedMultiEdge(candidate);
-				if (next_edge.has_value())
+				if (auto next_edge = GetNextUnvisitedMultiEdge(candidate); next_edge.has_value())
 				{
 					auto path = m_Model.FindPath(current, next_edge.value()->source);
 					// Path to parent + 1 step to select item
@@ -310,7 +306,7 @@ namespace AqualinkAutomate::Navigation
 		if (nearest != PageId::Unknown)
 		{
 			LogTrace(Channel::Scraping, std::format("SpiderEngine: Nearest unvisited target is page {} ({} steps away)",
-				static_cast<uint32_t>(nearest), shortest_path));
+				std::to_underlying(nearest), shortest_path));
 		}
 
 		return (nearest != PageId::Unknown) ? std::optional<PageId>(nearest) : std::nullopt;
@@ -337,7 +333,7 @@ namespace AqualinkAutomate::Navigation
 		const MenuPage* target_page = m_Model.GetPage(m_CurrentTarget);
 
 		LogDebug(Channel::Scraping, std::format("SpiderEngine: Next target -> {}({})",
-			static_cast<uint32_t>(m_CurrentTarget), target_page ? target_page->name : "Unknown"));
+			std::to_underlying(m_CurrentTarget), target_page ? target_page->name : "Unknown"));
 
 		// Multi-instance pages: navigate to parent page and select specific menu item
 		if (target_page && target_page->multi_instance)
@@ -349,7 +345,7 @@ namespace AqualinkAutomate::Navigation
 				m_CurrentMultiEdge = edge;
 
 				LogDebug(Channel::Scraping, std::format("SpiderEngine: Multi-instance navigation via parent {}({}) line {} '{}'",
-					static_cast<uint32_t>(edge->source), edge->trigger_line,
+					std::to_underlying(edge->source), edge->trigger_line,
 					edge->trigger_line, edge->label));
 
 				// Navigate to the parent page, position cursor on the item, and select it

--- a/src/jandy/navigation/visit_policies.cpp
+++ b/src/jandy/navigation/visit_policies.cpp
@@ -1,5 +1,7 @@
 #include "navigation/visit_policies.h"
 
+#include <utility>
+
 #include <magic_enum/magic_enum.hpp>
 
 #include "logging/logging.h"
@@ -46,13 +48,15 @@ namespace AqualinkAutomate::Navigation
 	bool FullDiscoveryVisitPolicy::ShouldVisit(PageId page, const MenuPage& info) const
 	{
 		// Visit all pages except special system pages
+		using enum PageId;
+
 		switch (page)
 		{
-		case PageId::Unknown:
-		case PageId::StartUp:
-		case PageId::Service:
-		case PageId::TimeOut:
-		case PageId::EnterPassword:
+		case Unknown:
+		case StartUp:
+		case Service:
+		case TimeOut:
+		case EnterPassword:
 			return false;
 
 		default:
@@ -67,7 +71,7 @@ namespace AqualinkAutomate::Navigation
 	void FullDiscoveryVisitPolicy::OnPageReached(PageId page, const Utility::ScreenDataPage& content)
 	{
 		LogDebug(Channel::Scraping, std::format("FullDiscoveryVisitPolicy: Visited page {}",
-			static_cast<uint32_t>(page)));
+			std::to_underlying(page)));
 
 		if (m_OnPage)
 		{
@@ -107,7 +111,7 @@ namespace AqualinkAutomate::Navigation
 	void TargetedVisitPolicy::OnPageReached(PageId page, const Utility::ScreenDataPage& content)
 	{
 		LogDebug(Channel::Scraping, std::format("TargetedVisitPolicy: Visited target page {}",
-			static_cast<uint32_t>(page)));
+			std::to_underlying(page)));
 
 		if (m_OnPage)
 		{

--- a/src/jandy/navigation/visit_policies.h
+++ b/src/jandy/navigation/visit_policies.h
@@ -25,7 +25,7 @@ namespace AqualinkAutomate::Navigation
 	class FullDiscoveryVisitPolicy : public VisitPolicy
 	{
 	public:
-		FullDiscoveryVisitPolicy(
+		explicit FullDiscoveryVisitPolicy(
 			PageVisitCallback on_page = nullptr,
 			CrawlCompleteCallback on_complete = nullptr,
 			bool skip_label_pages = false);
@@ -50,7 +50,7 @@ namespace AqualinkAutomate::Navigation
 	class TargetedVisitPolicy : public VisitPolicy
 	{
 	public:
-		TargetedVisitPolicy(
+		explicit TargetedVisitPolicy(
 			std::set<PageId> target_pages,
 			PageVisitCallback on_page = nullptr,
 			CrawlCompleteCallback on_complete = nullptr);

--- a/src/jandy/options/options_jandy.cpp
+++ b/src/jandy/options/options_jandy.cpp
@@ -31,14 +31,15 @@ namespace AqualinkAutomate::Jandy::Options
 		// Uses secondary IDs to avoid conflicting with real (primary) devices on the RS-485 bus.
 		JandyDeviceId DefaultDeviceId(JandyEmulatedDeviceTypes device_type)
 		{
+			using enum JandyEmulatedDeviceTypes;
 			switch (device_type)
 			{
-			case JandyEmulatedDeviceTypes::OneTouch:		return JandyDeviceId{ 0x41 };
-			case JandyEmulatedDeviceTypes::IAQ:				return JandyDeviceId{ 0xA1 };
-			case JandyEmulatedDeviceTypes::RS_Keypad:		return JandyDeviceId{ 0x09 };
-			case JandyEmulatedDeviceTypes::PDA:				return JandyDeviceId{ 0x61 };
-			case JandyEmulatedDeviceTypes::SerialAdapter:	return JandyDeviceId{ 0x48 };
-			default:										return JandyDeviceId{ 0xFF };
+			case OneTouch:			return JandyDeviceId{ 0x41 };
+			case IAQ:				return JandyDeviceId{ 0xA1 };
+			case RS_Keypad:			return JandyDeviceId{ 0x09 };
+			case PDA:				return JandyDeviceId{ 0x61 };
+			case SerialAdapter:		return JandyDeviceId{ 0x48 };
+			default:				return JandyDeviceId{ 0xFF };
 			}
 		}
 
@@ -185,11 +186,12 @@ namespace AqualinkAutomate::Jandy::Options
 		{
 			// No explicit device types specified — use default set.
 			// OneTouch for menu scraping, IAQ for status data, SerialAdapter for commands.
+			using enum JandyEmulatedDeviceTypes;
 			static const std::vector<JandyEmulatedDeviceTypes> DEFAULT_DEVICE_TYPES
 			{
-				JandyEmulatedDeviceTypes::OneTouch,
-				JandyEmulatedDeviceTypes::IAQ,
-				JandyEmulatedDeviceTypes::SerialAdapter
+				OneTouch,
+				IAQ,
+				SerialAdapter
 			};
 
 			for (auto type : DEFAULT_DEVICE_TYPES)

--- a/src/jandy/options/options_jandy.h
+++ b/src/jandy/options/options_jandy.h
@@ -33,16 +33,10 @@ namespace AqualinkAutomate::Jandy::Options
 			return AREA_NAME;
 		}
 
-		JandySettings() :
-			disable_emulation{ false },
-			emulated_devices{}
-		{
-		}
-
-		bool disable_emulation;
+		bool disable_emulation{ false };
 		bool disable_presence_gating{ false };     // disable RSSA presence-gating (auto-suppress emulation on a detected real adapter)
 		bool auto_startup{ false };                // detect the controller from the bus and choose what to emulate
-		JandyEmulatedDeviceCollection emulated_devices;
+		JandyEmulatedDeviceCollection emulated_devices{};
 		std::string navigation_password{};  // 4-digit password for menu navigation
 		std::uint32_t chlorinator_setpoint_refresh_interval{ 300 };  // seconds between Set-AquaPure menu re-scrapes of the configured chlorinator % (0 = disabled)
 	};
@@ -76,7 +70,6 @@ namespace AqualinkAutomate::Jandy::Options
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/src/jandy/options/validators/jandy_device_id_validator.cpp
+++ b/src/jandy/options/validators/jandy_device_id_validator.cpp
@@ -11,18 +11,10 @@
 
 using namespace AqualinkAutomate::Logging;
 
-namespace AqualinkAutomate::Jandy::Options::Validators
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Jandy::Options::Validators
-
 namespace AqualinkAutomate::Devices
 {
 
-	void validate(boost::any& v, std::vector<std::string> const& values, JandyDeviceId* target_type, int)
+	void validate(boost::any& v, std::vector<std::string> const& values, JandyDeviceId* /*target_type*/, int)
 	{
 		static const uint8_t MINIMUM_DEVICE_ID_LENGTH = 3;
 		static const uint8_t MAXIMUM_DEVICE_ID_LENGTH = 4;

--- a/src/jandy/options/validators/jandy_device_id_validator.h
+++ b/src/jandy/options/validators/jandy_device_id_validator.h
@@ -8,14 +8,6 @@
 
 #include "devices/jandy_device_id.h"
 
-namespace AqualinkAutomate::Jandy::Options::Validators
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Jandy::Options::Validators
-
 //=============================================================================
 //
 // BOOST Program Options requires validators to be in the namespace of the

--- a/src/jandy/options/validators/jandy_emulated_device_type_validator.cpp
+++ b/src/jandy/options/validators/jandy_emulated_device_type_validator.cpp
@@ -9,18 +9,10 @@
 
 using namespace AqualinkAutomate::Logging;
 
-namespace AqualinkAutomate::Jandy::Options::Validators
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Jandy::Options::Validators
-
 namespace AqualinkAutomate::Devices
 {
 
-	void validate(boost::any& v, std::vector<std::string> const& values, JandyEmulatedDeviceTypes* target_type, int)
+	void validate(boost::any& v, std::vector<std::string> const& values, JandyEmulatedDeviceTypes* /*target_type*/, int)
 	{
 		std::string device_type_string;
 

--- a/src/jandy/options/validators/jandy_emulated_device_type_validator.h
+++ b/src/jandy/options/validators/jandy_emulated_device_type_validator.h
@@ -7,14 +7,6 @@
 
 #include "devices/jandy_emulated_device_types.h"
 
-namespace AqualinkAutomate::Jandy::Options::Validators
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Jandy::Options::Validators
-
 //=============================================================================
 //
 // BOOST Program Options requires validators to be in the namespace of the

--- a/src/jandy/types/jandy_types.cpp
+++ b/src/jandy/types/jandy_types.cpp
@@ -1,9 +1,1 @@
 #include "types/jandy_types.h"
-
-namespace AqualinkAutomate::Types
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Types

--- a/src/jandy/utility/filtered_slot.cpp
+++ b/src/jandy/utility/filtered_slot.cpp
@@ -1,9 +1,1 @@
 #include "utility/filtered_slot.h"
-
-namespace AqualinkAutomate::Utility
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Utility

--- a/src/jandy/utility/jandy_checksum.cpp
+++ b/src/jandy/utility/jandy_checksum.cpp
@@ -1,9 +1,1 @@
 #include "utility/jandy_checksum.h"
-
-namespace AqualinkAutomate::Utility
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Utility

--- a/src/jandy/utility/jandy_pool_configuration_decoder.h
+++ b/src/jandy/utility/jandy_pool_configuration_decoder.h
@@ -21,9 +21,8 @@ namespace AqualinkAutomate::Utility
 		static const ConfigMap JANDY_EQUIPMENT_CONFIGURATIONS;
 
 	public:
-		PoolConfigurationDecoder(const std::string& panel_type);
+		explicit PoolConfigurationDecoder(const std::string& panel_type);
 
-	public:
 		Kernel::PoolConfigurations Configuration() const;
 		Kernel::SystemBoards SystemBoard() const;
 		uint8_t AuxillaryCount() const;

--- a/src/jandy/utility/screen_data_page.cpp
+++ b/src/jandy/utility/screen_data_page.cpp
@@ -6,8 +6,7 @@ using namespace AqualinkAutomate::Logging;
 namespace AqualinkAutomate::Utility
 {
 
-	ScreenDataPage::ScreenDataPage(std::size_t row_count) :
-		m_Rows()
+	ScreenDataPage::ScreenDataPage(std::size_t row_count)
 	{
 		m_Rows.reserve(row_count);
 
@@ -35,9 +34,9 @@ namespace AqualinkAutomate::Utility
 		}
 	}
 
-	void ScreenDataPage::Highlight(uint8_t line_id)
+	void ScreenDataPage::Highlight(uint8_t line_index)
 	{
-		if (CLEAR_HIGHLIGHTS == line_id)
+		if (CLEAR_HIGHLIGHTS == line_index)
 		{
 			LogTrace(Channel::Devices, "ScreenDataPage: Clearing all previously set highlighted lines");
 
@@ -47,9 +46,9 @@ namespace AqualinkAutomate::Utility
 				row.HighlightRange = std::nullopt;
 			}
 		}
-		else if (m_Rows.size() <= line_id)
+		else if (m_Rows.size() <= line_index)
 		{
-			LogDebug(Channel::Devices, std::format("ScreenDataPage: Cannot toggle highlight, line id is out of range; requested line id -> {}, max line id -> {}", line_id, m_Rows.size()));
+			LogDebug(Channel::Devices, std::format("ScreenDataPage: Cannot toggle highlight, line id is out of range; requested line id -> {}, max line id -> {}", line_index, m_Rows.size()));
 		}
 		else
 		{
@@ -61,21 +60,21 @@ namespace AqualinkAutomate::Utility
 				row.HighlightRange = std::nullopt;
 			}
 
-			m_Rows[line_id].HighlightState = HighlightStates::Highlighted;
-			m_Rows[line_id].HighlightRange = std::nullopt;
+			m_Rows[line_index].HighlightState = HighlightStates::Highlighted;
+			m_Rows[line_index].HighlightRange = std::nullopt;
 		}
 	}
 
-	void ScreenDataPage::HighlightChars(uint8_t line_id, uint8_t start_index, uint8_t stop_index)
+	void ScreenDataPage::HighlightChars(uint8_t line_index, uint8_t start_index, uint8_t stop_index)
 	{
-		if (m_Rows.size() <= line_id)
+		if (m_Rows.size() <= line_index)
 		{
-			LogDebug(Channel::Devices, std::format("ScreenDataPage: Cannot toggle highlight, line id is out of range; requested line id -> {}, max line id -> {}", line_id, m_Rows.size()));
+			LogDebug(Channel::Devices, std::format("ScreenDataPage: Cannot toggle highlight, line id is out of range; requested line id -> {}, max line id -> {}", line_index, m_Rows.size()));
 		}
 		else
 		{
-			m_Rows[line_id].HighlightState = HighlightStates::PartiallyHighlighted;
-			m_Rows[line_id].HighlightRange = { start_index, stop_index };
+			m_Rows[line_index].HighlightState = HighlightStates::PartiallyHighlighted;
+			m_Rows[line_index].HighlightRange = { start_index, stop_index };
 		}
 	}
 

--- a/src/jandy/utility/screen_data_page.h
+++ b/src/jandy/utility/screen_data_page.h
@@ -41,13 +41,11 @@ namespace AqualinkAutomate::Utility
 		inline static const uint8_t CLEAR_HIGHLIGHTS = 0xFF;
 
 	public:
-		ScreenDataPage(std::size_t row_count);
+		explicit ScreenDataPage(std::size_t row_count);
 
-	public:
 		RowType& operator[](std::size_t index);
 		const RowType& operator[](std::size_t index) const;
 
-	public:
 		enum class ShiftDirections
 		{
 			Up, Down

--- a/src/jandy/utility/screen_data_page_graph.h
+++ b/src/jandy/utility/screen_data_page_graph.h
@@ -52,13 +52,11 @@ namespace AqualinkAutomate::Utility
 			}
 		}
 
-	public:
 		void AddVertex(ScreenDataPageGraphImpl::Vertex new_vertex)
 		{
 			m_VertexMap[new_vertex.id] = boost::add_vertex(new_vertex, m_Graph);
 		}
 
-	public:
 		void AddEdge(ScreenDataPageGraphImpl::VertexId source_id, ScreenDataPageGraphImpl::VertexId destination_id, ScreenDataPageGraphImpl::Edge new_edge)
 		{
 			boost::add_edge(m_VertexMap[source_id], m_VertexMap[destination_id], new_edge, m_Graph);

--- a/src/jandy/utility/screen_data_page_graph/screen_data_page_graph_traverse.h
+++ b/src/jandy/utility/screen_data_page_graph/screen_data_page_graph_traverse.h
@@ -28,23 +28,18 @@ namespace AqualinkAutomate::Utility::ScreenDataPageGraphImpl
         ForwardIterator(const ForwardIterator& other);
         ForwardIterator(ForwardIterator&& other) noexcept;
 
-    public:
         ForwardIterator& operator=(const ForwardIterator& other) = delete;
         ForwardIterator& operator=(ForwardIterator&& other) noexcept = delete;
 
-    public:
         ForwardIterator& operator++();
         ForwardIterator operator++(int);
 
-    public:
         ForwardIterator::reference operator*() const;
         ForwardIterator::pointer operator->() const;
 
-    public:
         bool operator==(const ForwardIterator& other) const;
         bool operator!=(const ForwardIterator& other) const;
 
-    public:
         static ForwardIterator begin(ScreenDataPageGraph& graph, VertexId start_id);
         static ForwardIterator end(ScreenDataPageGraph& graph);
 

--- a/src/jandy/utility/screen_data_page_processor.h
+++ b/src/jandy/utility/screen_data_page_processor.h
@@ -64,10 +64,8 @@ namespace AqualinkAutomate::Utility
 	public:
 		ScreenDataPage_Processor(ScreenDataPageTypes page_type, const MenuMatcherDetails& menu_matcher, MenuMatcherProcessor menu_processor);
 
-	public:
 		ScreenDataPageTypes PageType() const;
 
-	public:
 		bool CanProcess(const ScreenDataPage& page) const;
 		void Process(const ScreenDataPage& page) const;
 

--- a/src/jandy/utility/screen_data_page_updater.cpp
+++ b/src/jandy/utility/screen_data_page_updater.cpp
@@ -1,9 +1,1 @@
 #include "utility/screen_data_page_updater.h"
-
-namespace AqualinkAutomate::Utility
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Utility

--- a/src/jandy/utility/screen_data_page_updater.h
+++ b/src/jandy/utility/screen_data_page_updater.h
@@ -36,7 +36,7 @@ namespace AqualinkAutomate::Utility
 		template<typename PAGE_TYPE>
 		struct StateMachine : boost::statechart::state_machine<StateMachine<PAGE_TYPE>, Tracking<PAGE_TYPE>>, Context<PAGE_TYPE>
 		{
-			StateMachine(PAGE_TYPE& page) :
+			explicit StateMachine(PAGE_TYPE& page) :
 				Context<PAGE_TYPE>(page)
 			{
 			}
@@ -109,10 +109,8 @@ namespace AqualinkAutomate::Utility
 
 			boost::statechart::result react(const evUpdate& ev)
 			{
-				auto& ctx = this->template context<StateMachine<PAGE_TYPE>>();
-
 				// Validate that the line id is within the size permitted.
-				if (ev.Id() >= ctx().Size())
+				if (auto& ctx = this->template context<StateMachine<PAGE_TYPE>>(); ev.Id() >= ctx().Size())
 				{
 					LogDebug(Channel::Devices, "Attempted to update a page line that is does not exist in the page.");
 				}

--- a/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_context.cpp
+++ b/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_context.cpp
@@ -1,9 +1,1 @@
 #include "utility/screen_data_page_updater/screen_data_page_updater_context.h"
-
-namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl
-{
-
-	// NOTHING HERE
-
-}
-// namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl

--- a/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_context.h
+++ b/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_context.h
@@ -7,12 +7,11 @@ namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl
 	class Context
 	{
 	public:
-		Context(PAGE_TYPE& page) :
+		explicit Context(PAGE_TYPE& page) :
 			m_Page(page)
 		{
 		};
 
-	public:
 		PAGE_TYPE& operator()()
 		{
 			return m_Page;

--- a/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evhighlight.h
+++ b/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evhighlight.h
@@ -12,7 +12,6 @@ namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl
 	public:
 		evHighlight(uint8_t line_id);
 
-	public:
 		uint8_t LineId() const;
 
 	private:

--- a/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evhighlightchars.h
+++ b/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evhighlightchars.h
@@ -12,7 +12,6 @@ namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl
 	public:
 		evHighlightChars(uint8_t line_id, uint8_t start_index, uint8_t stop_index);
 
-	public:
 		uint8_t LineId() const;
 		uint8_t StartIndex() const;
 		uint8_t StopIndex() const;

--- a/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evshift.h
+++ b/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evshift.h
@@ -15,7 +15,6 @@ namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl
 	public:
 		evShift(ScreenDataPage::ShiftDirections direction, uint8_t first_line, uint8_t last_line, uint8_t number_of_shifts);
 
-	public:
 		ScreenDataPage::ShiftDirections Direction() const;
 		uint8_t FirstLineId() const;
 		uint8_t LastLineId() const;

--- a/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evupdate.h
+++ b/src/jandy/utility/screen_data_page_updater/screen_data_page_updater_evupdate.h
@@ -17,7 +17,6 @@ namespace AqualinkAutomate::Utility::ScreenDataPageUpdaterImpl
 	public:
 		evUpdate(uint8_t line_id, const std::string& line_text);
 
-	public:
 		ScreenDataPageLine::first_type Id() const;
 		const ScreenDataPageLine::second_type& Text() const;
 

--- a/src/jandy/utility/string_conversion/auxillary_state_string_converter.cpp
+++ b/src/jandy/utility/string_conversion/auxillary_state_string_converter.cpp
@@ -14,14 +14,11 @@ namespace AqualinkAutomate::Utility
 	const boost::regex AuxillaryStateStringConverter::REGEX_PARSER{ REGEX_PATTERN };
 
 	AuxillaryStateStringConverter::AuxillaryStateStringConverter() noexcept :
-		m_Label(),
-		m_State(Kernel::AuxillaryStatuses::Unknown),
 		m_ErrorOccurred(ErrorCodes::StringConversion_ErrorCodes::MalformedInput)
 	{
 	}
 
 	AuxillaryStateStringConverter::AuxillaryStateStringConverter(const std::string& auxillary_status_string) noexcept :
-		m_Label(),
 		m_State(Kernel::AuxillaryStatuses::Unknown),
 		m_ErrorOccurred(std::nullopt)
 	{

--- a/src/jandy/utility/string_conversion/auxillary_state_string_converter.h
+++ b/src/jandy/utility/string_conversion/auxillary_state_string_converter.h
@@ -27,16 +27,14 @@ namespace AqualinkAutomate::Utility
 
 	public:
 		AuxillaryStateStringConverter() noexcept;
-		AuxillaryStateStringConverter(const std::string& auxillary_status_string) noexcept;
+		explicit AuxillaryStateStringConverter(const std::string& auxillary_status_string) noexcept;
 		AuxillaryStateStringConverter(const AuxillaryStateStringConverter& other) noexcept;
 		AuxillaryStateStringConverter(AuxillaryStateStringConverter&& other) noexcept;
 
-	public:
 		AuxillaryStateStringConverter& operator=(const AuxillaryStateStringConverter& other) noexcept;
 		AuxillaryStateStringConverter& operator=(AuxillaryStateStringConverter&& other) noexcept;
 		AuxillaryStateStringConverter& operator=(const std::string& auxillary_status_string) noexcept;
 
-	public:
 		std::expected<std::string, boost::system::error_code> Label() const noexcept;
 		std::expected<Kernel::AuxillaryStatuses, boost::system::error_code> State() const noexcept;
 
@@ -44,9 +42,8 @@ namespace AqualinkAutomate::Utility
 		void ConvertStringToStatus(const std::string& auxillary_status_string) noexcept;
 		std::tuple<std::optional<std::string>, std::optional<std::string>> ValidateAndExtractData(const std::string& auxillary_status_string) noexcept;
 
-	private:
 		std::string m_Label;
-		Kernel::AuxillaryStatuses m_State;
+		Kernel::AuxillaryStatuses m_State{ Kernel::AuxillaryStatuses::Unknown };
 
 	private:
 		std::optional<ErrorCodes::StringConversion_ErrorCodes> m_ErrorOccurred;

--- a/src/jandy/utility/string_conversion/chemistry_string_converter.cpp
+++ b/src/jandy/utility/string_conversion/chemistry_string_converter.cpp
@@ -17,8 +17,6 @@ namespace AqualinkAutomate::Utility
 	const boost::regex ChemistryStringConverter::REGEX_PARSER{ REGEX_PATTERN };
 
 	ChemistryStringConverter::ChemistryStringConverter() noexcept :
-		m_ORP(0),
-		m_PH(0.0f),
 		m_ErrorOccurred(ErrorCodes::StringConversion_ErrorCodes::MalformedInput)
 	{
 	}
@@ -109,9 +107,9 @@ namespace AqualinkAutomate::Utility
 				LogDebug(Channel::Devices, std::format("Failed to convert ORP; could not convert to number: error -> {}", magic_enum::enum_name(ec)));
 				m_ErrorOccurred = ErrorCodes::StringConversion_ErrorCodes::MalformedInput;
 			}
-			else if (auto [_, ec] = std::from_chars((*ph).data(), (*ph).data() + (*ph).size(), converted_ph); std::errc() != ec)
+			else if (auto [_ph, ec_ph] = std::from_chars((*ph).data(), (*ph).data() + (*ph).size(), converted_ph); std::errc() != ec_ph)
 			{
-				LogDebug(Channel::Devices, std::format("Failed to convert pH; could not convert to number: error -> {}", magic_enum::enum_name(ec)));
+				LogDebug(Channel::Devices, std::format("Failed to convert pH; could not convert to number: error -> {}", magic_enum::enum_name(ec_ph)));
 				m_ErrorOccurred = ErrorCodes::StringConversion_ErrorCodes::MalformedInput;
 			}
 			else

--- a/src/jandy/utility/string_conversion/chemistry_string_converter.h
+++ b/src/jandy/utility/string_conversion/chemistry_string_converter.h
@@ -28,16 +28,14 @@ namespace AqualinkAutomate::Utility
 
 	public:
 		ChemistryStringConverter() noexcept;
-		ChemistryStringConverter(const std::string& chemistry_string) noexcept;
+		explicit ChemistryStringConverter(const std::string& chemistry_string) noexcept;
 		ChemistryStringConverter(const ChemistryStringConverter& other) noexcept;
 		ChemistryStringConverter(ChemistryStringConverter&& other) noexcept;
 
-	public:
 		ChemistryStringConverter& operator=(const ChemistryStringConverter& other) noexcept;
 		ChemistryStringConverter& operator=(ChemistryStringConverter&& other) noexcept;
 		ChemistryStringConverter& operator=(const std::string& chemistry_string) noexcept;
 
-	public:
 		std::expected<Kernel::ORP, boost::system::error_code> ORP() const noexcept;
 		std::expected<Kernel::pH, boost::system::error_code> PH() const noexcept;
 
@@ -46,8 +44,8 @@ namespace AqualinkAutomate::Utility
 		std::tuple<std::optional<std::string>, std::optional<std::string>> ValidateAndExtractData(const std::string& chemistry_string) noexcept;
 
 	private:
-		Kernel::ORP m_ORP;
-		Kernel::pH m_PH;
+		Kernel::ORP m_ORP{ 0 };
+		Kernel::pH m_PH{ 0.0f };
 
 	private:
 		std::optional<ErrorCodes::StringConversion_ErrorCodes> m_ErrorOccurred;

--- a/src/jandy/utility/string_conversion/temperature_string_converter.cpp
+++ b/src/jandy/utility/string_conversion/temperature_string_converter.cpp
@@ -21,16 +21,12 @@ namespace AqualinkAutomate::Utility
 	const std::string TemperatureStringConverter::REGEX_PATTERN{ R"(^([A-Za-z0-9][A-Za-z0-9 ]{0,14}?)\s{1,10}(-?\d{1,3})`([CF])$)" };
 	const boost::regex TemperatureStringConverter::REGEX_PARSER{ REGEX_PATTERN };
 
-	TemperatureStringConverter::TemperatureStringConverter() noexcept :
-		m_Temperature(Kernel::Temperature::ConvertToTemperatureInCelsius(0)),
-		m_TemperatureArea(),
-		m_ErrorOccurred(std::nullopt)
+	TemperatureStringConverter::TemperatureStringConverter() noexcept
 	{
 	}
 
 	TemperatureStringConverter::TemperatureStringConverter(const std::string& temperature_string) noexcept :
 		m_Temperature(Kernel::Temperature::ConvertToTemperatureInCelsius(0)),
-		m_TemperatureArea(),
 		m_ErrorOccurred(std::nullopt)
 	{
 		ConvertStringToTemperature(TrimWhitespace(temperature_string));

--- a/src/jandy/utility/string_conversion/temperature_string_converter.h
+++ b/src/jandy/utility/string_conversion/temperature_string_converter.h
@@ -27,12 +27,10 @@ namespace AqualinkAutomate::Utility
 
 	public:
 		TemperatureStringConverter() noexcept;
-		TemperatureStringConverter(const std::string& temperature_string) noexcept;
+		explicit TemperatureStringConverter(const std::string& temperature_string) noexcept;
 
-	public:
 		TemperatureStringConverter& operator=(const std::string& temperature_string) noexcept;
 
-	public:
 		std::expected<Kernel::Temperature, boost::system::error_code> operator()() const noexcept;
 		std::expected<std::string, boost::system::error_code> TemperatureArea() const noexcept;
 
@@ -41,11 +39,10 @@ namespace AqualinkAutomate::Utility
 		std::tuple<std::optional<std::string>, std::optional<std::string>, std::optional<std::string>> ValidateAndExtractData(const std::string& temperature_string) noexcept;
 
 	private:
-		Kernel::Temperature m_Temperature;
+		Kernel::Temperature m_Temperature{ Kernel::Temperature::ConvertToTemperatureInCelsius(0) };
 		std::string m_TemperatureArea;
 
-	private:
-		std::optional<ErrorCodes::StringConversion_ErrorCodes> m_ErrorOccurred;
+		std::optional<ErrorCodes::StringConversion_ErrorCodes> m_ErrorOccurred{ std::nullopt };
 	};
 
 }

--- a/src/pentair/options/options_pentair.cpp
+++ b/src/pentair/options/options_pentair.cpp
@@ -22,11 +22,12 @@ namespace AqualinkAutomate::Pentair::Options
 		return options;
 	}
 
-	void OptionsProcessor::Validate(const boost::program_options::variables_map& vm) const
+	void OptionsProcessor::Validate(const boost::program_options::variables_map& /*vm*/) const
 	{
+		// Intentionally empty: Pentair options carry no cross-option constraints to validate.
 	}
 
-	std::expected<OptionsProcessor::SettingsType, ErrorCodes::Options_ErrorCodes> OptionsProcessor::Process(boost::program_options::variables_map& vm) const
+	std::expected<OptionsProcessor::SettingsType, ErrorCodes::Options_ErrorCodes> OptionsProcessor::Process(boost::program_options::variables_map& /*vm*/) const
 	{
 		SettingsType settings;
 

--- a/src/pentair/options/options_pentair.h
+++ b/src/pentair/options/options_pentair.h
@@ -43,7 +43,6 @@ namespace AqualinkAutomate::Pentair::Options
 		std::string Name() const { return SettingsType::AreaName(); }
 		boost::program_options::options_description Options() const;
 
-	public:
 		void Validate(const boost::program_options::variables_map& vm) const;
 		std::expected<SettingsType, ErrorCodes::Options_ErrorCodes> Process(boost::program_options::variables_map& vm) const;
 	};

--- a/test/unit/alerting/test_alert_monitor.cpp
+++ b/test/unit/alerting/test_alert_monitor.cpp
@@ -14,6 +14,7 @@
 #include "kernel/auxillary_devices/chlorinator_status.h"
 #include "kernel/auxillary_traits/auxillary_traits_types.h"
 #include "kernel/data_hub.h"
+#include "kernel/equipment_hub.h"
 #include "kernel/preferences_hub.h"
 #include "kernel/statistics_hub.h"
 #include "options/options_alerting_options.h"
@@ -601,6 +602,80 @@ BOOST_AUTO_TEST_CASE(BuildStateJson_ReflectsLatchedState)
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::ChlorinatorWarning }], "false");
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::SerialCommsLoss }], "false");
 	BOOST_CHECK_EQUAL(state[std::string{ ConditionKeys::TemperatureStale }], "false");
+}
+
+// AddSink ignores a null sink: the guard drops it, so a subsequent transition is
+// delivered only to the real sinks (no crash from invoking an empty std::function).
+BOOST_AUTO_TEST_CASE(AddSink_NullSink_IsIgnored)
+{
+	boost::asio::io_context io;
+	Options::Alerting::AlertingSettings settings;
+
+	AlertMonitor monitor(io, *this, settings);
+
+	// A default-constructed (empty) Sink is dropped by the guard in AddSink.
+	monitor.AddSink(AlertMonitor::Sink{});
+
+	// A real sink added afterwards still receives transitions, proving the null one
+	// was skipped rather than stored-and-invoked (which would have crashed).
+	SinkRecorder rec;
+	monitor.AddSink(rec.AsSink());
+
+	Find<Kernel::DataHub>()->Mode = Kernel::EquipmentMode::Service;
+	monitor.EvaluateServiceMode();
+
+	BOOST_CHECK(monitor.IsRaised(ConditionKeys::ServiceMode));
+	BOOST_CHECK_EQUAL(rec.CountFor(ConditionKeys::ServiceMode), 1u);
+}
+
+// IsRaised returns false for a condition key that is not in the latch map at all
+// (an unknown key never seeded by the catalogue) — the map-miss branch.
+BOOST_AUTO_TEST_CASE(IsRaised_UnknownKey_ReturnsFalse)
+{
+	boost::asio::io_context io;
+	Options::Alerting::AlertingSettings settings;
+
+	AlertMonitor monitor(io, *this, settings);
+
+	BOOST_CHECK(!monitor.IsRaised("not_a_real_condition_key"));
+}
+
+// Start() wires the DataHub and EquipmentHub signals to EvaluateAll: firing either
+// signal after Start() re-evaluates every condition (proven here by observing the
+// service_mode edge that a fired signal produces).
+BOOST_AUTO_TEST_CASE(Start_SubscribesHubSignals_EvaluateOnFire)
+{
+	boost::asio::io_context io;
+	Options::Alerting::AlertingSettings settings;
+
+	AlertMonitor monitor(io, *this, settings);
+	SinkRecorder rec;
+	monitor.AddSink(rec.AsSink());
+
+	std::int64_t now = 5000;
+	monitor.SetClock([&now] { return now; });
+
+	auto data_hub = Find<Kernel::DataHub>();
+	auto equipment_hub = Find<Kernel::EquipmentHub>();
+
+	monitor.Start();
+
+	// Put the controller into Service mode, then fire the DataHub config signal; the
+	// subscription lambda installed by Start() calls EvaluateAll(), raising service_mode.
+	// The AlertMonitor lambda ignores the event payload, so a null shared_ptr is fine.
+	data_hub->Mode = Kernel::EquipmentMode::Service;
+	data_hub->ConfigUpdateSignal(nullptr);
+	BOOST_CHECK(monitor.IsRaised(ConditionKeys::ServiceMode));
+	BOOST_REQUIRE_EQUAL(rec.CountFor(ConditionKeys::ServiceMode), 1u);
+
+	// Leaving Service mode and firing the EquipmentHub signal re-evaluates and clears it,
+	// proving the second subscription lambda is likewise wired.
+	data_hub->Mode = Kernel::EquipmentMode::Normal;
+	equipment_hub->EquipmentStatusChangeSignal(nullptr);
+	BOOST_CHECK(!monitor.IsRaised(ConditionKeys::ServiceMode));
+	BOOST_CHECK_EQUAL(rec.CountFor(ConditionKeys::ServiceMode), 2u);
+
+	monitor.Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/auxillaries/test_jandy_auxillary_id.cpp
+++ b/test/unit/auxillaries/test_jandy_auxillary_id.cpp
@@ -1,7 +1,11 @@
 #include <memory>
 #include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <boost/uuid/uuid.hpp>
 
 #include "jandy/auxillaries/jandy_auxillary_id.h"
@@ -230,6 +234,63 @@ BOOST_AUTO_TEST_CASE(PlaceholderForADifferentAuxIsNotPruned)
 
 	BOOST_CHECK_EQUAL(devices.CountByLabel("Aux6"), 1u);   // different aux: untouched
 	BOOST_CHECK_EQUAL(devices.CountByLabel("Aux5"), 1u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// enum_name customization + native-key / stable-id across EVERY aux value.
+// Exercises all 32 arms of the magic_enum enum_name<JandyAuxillaryIds> switch
+// (display names) and the per-id native key + stable UUID, and proves the
+// display name round-trips back through ParseAuxId to the same enum.
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(JandyAuxillaryId_AllValues_TestSuite)
+
+BOOST_AUTO_TEST_CASE(EnumName_RoundTrips_And_KeysAreConsistent_ForEveryAux)
+{
+	using Auxillaries::JandyAuxillaryIds;
+
+	// {enum value, expected display name, expected native-key integer}.
+	const std::vector<std::tuple<JandyAuxillaryIds, std::string_view, int>> all = {
+		{ JandyAuxillaryIds::Aux_1, "Aux1", 1 },   { JandyAuxillaryIds::Aux_2, "Aux2", 2 },
+		{ JandyAuxillaryIds::Aux_3, "Aux3", 3 },   { JandyAuxillaryIds::Aux_4, "Aux4", 4 },
+		{ JandyAuxillaryIds::Aux_5, "Aux5", 5 },   { JandyAuxillaryIds::Aux_6, "Aux6", 6 },
+		{ JandyAuxillaryIds::Aux_7, "Aux7", 7 },
+		{ JandyAuxillaryIds::Aux_B1, "Aux B1", 8 },  { JandyAuxillaryIds::Aux_B2, "Aux B2", 9 },
+		{ JandyAuxillaryIds::Aux_B3, "Aux B3", 10 }, { JandyAuxillaryIds::Aux_B4, "Aux B4", 11 },
+		{ JandyAuxillaryIds::Aux_B5, "Aux B5", 12 }, { JandyAuxillaryIds::Aux_B6, "Aux B6", 13 },
+		{ JandyAuxillaryIds::Aux_B7, "Aux B7", 14 }, { JandyAuxillaryIds::Aux_B8, "Aux B8", 15 },
+		{ JandyAuxillaryIds::Aux_C1, "Aux C1", 16 }, { JandyAuxillaryIds::Aux_C2, "Aux C2", 17 },
+		{ JandyAuxillaryIds::Aux_C3, "Aux C3", 18 }, { JandyAuxillaryIds::Aux_C4, "Aux C4", 19 },
+		{ JandyAuxillaryIds::Aux_C5, "Aux C5", 20 }, { JandyAuxillaryIds::Aux_C6, "Aux C6", 21 },
+		{ JandyAuxillaryIds::Aux_C7, "Aux C7", 22 }, { JandyAuxillaryIds::Aux_C8, "Aux C8", 23 },
+		{ JandyAuxillaryIds::Aux_D1, "Aux D1", 24 }, { JandyAuxillaryIds::Aux_D2, "Aux D2", 25 },
+		{ JandyAuxillaryIds::Aux_D3, "Aux D3", 26 }, { JandyAuxillaryIds::Aux_D4, "Aux D4", 27 },
+		{ JandyAuxillaryIds::Aux_D5, "Aux D5", 28 }, { JandyAuxillaryIds::Aux_D6, "Aux D6", 29 },
+		{ JandyAuxillaryIds::Aux_D7, "Aux D7", 30 }, { JandyAuxillaryIds::Aux_D8, "Aux D8", 31 },
+		{ JandyAuxillaryIds::ExtraAux, "Extra Aux", 0 },
+	};
+
+	BOOST_REQUIRE_EQUAL(all.size(), 32u);   // every enumerator is exercised
+
+	for (const auto& [id, expected_name, key_int] : all)
+	{
+		// enum_name customization (runtime lookup drives the switch arm for this value).
+		const std::string name{ magic_enum::enum_name(id) };
+		BOOST_CHECK_EQUAL(name, std::string(expected_name));
+
+		// Native key is the integer-keyed protocol identity.
+		BOOST_CHECK_EQUAL(Auxillaries::AuxNativeKey(id), "jandy:aux:" + std::to_string(key_int));
+
+		// Stable UUID is deterministic and non-nil for every aux.
+		const auto uuid = Auxillaries::AuxStableId(id);
+		BOOST_CHECK(!uuid.is_nil());
+		BOOST_CHECK(uuid == Auxillaries::AuxStableId(id));
+
+		// The display name parses back to the same enum (the label contract).
+		BOOST_CHECK(Auxillaries::ParseAuxId(expected_name) == id);
+	}
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/certificates/test_certificate_generation.cpp
+++ b/test/unit/certificates/test_certificate_generation.cpp
@@ -325,6 +325,30 @@ BOOST_AUTO_TEST_CASE(LoadSslCertificates_InvalidPem_ThrowsInvalidFormat)
 	fs::remove_all(dir, rm);
 }
 
+BOOST_AUTO_TEST_CASE(LoadSslCertificates_PresentValidCaChain_LoadsSuccessfully)
+{
+	// The other CA-chain cases cover "not provided" (ignored) and "provided but
+	// absent" (throws NotFound). This drives the remaining arm: a CA chain that is
+	// both configured AND present AND a valid PEM, so use_certificate_chain_file
+	// succeeds and LoadSslCertificates completes without throwing. A self-signed
+	// certificate is itself a valid single-entry PEM chain, so reuse it as the chain.
+	const fs::path dir = fs::temp_directory_path() / "aqualink_loadssl_cachain_ok";
+	std::error_code rm;
+	fs::remove_all(dir, rm);
+
+	const fs::path cert = dir / "cert.pem";
+	const fs::path key = dir / "key.pem";
+	BOOST_REQUIRE(Certificates::GenerateSelfSignedCertificate(cert, key));
+
+	auto cfg = EnabledHttpsSettings(cert, key);
+	cfg.ca_chain_certificate = cert;   // configured, present, and a valid PEM chain
+
+	boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_server);
+	BOOST_CHECK_NO_THROW(Certificates::LoadSslCertificates(cfg, ctx));
+
+	fs::remove_all(dir, rm);
+}
+
 BOOST_AUTO_TEST_CASE(LoadSslCertificates_MissingCaChain_ThrowsNotFound)
 {
 	const fs::path dir = fs::temp_directory_path() / "aqualink_loadssl_cachain";

--- a/test/unit/devices/test_devices_aquarite.cpp
+++ b/test/unit/devices/test_devices_aquarite.cpp
@@ -469,4 +469,164 @@ BOOST_AUTO_TEST_CASE(WarningRaisesQuickly)
 	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_LowSalt);
 }
 
+// =============================================================================
+// ConvertToChlorinatorHealthStatus: every decodable wire status maps to its
+// kernel health enumerator.  The first decodable reading is surfaced
+// immediately (the dwell governs only subsequent changes), so a single PPM
+// frame carrying a given status byte writes the corresponding health trait.
+// These drive the individual switch arms in ConvertToChlorinatorHealthStatus.
+// =============================================================================
+
+BOOST_AUTO_TEST_CASE(Status_TurningOff_MapsToTurningOffHealthAndOffOperating)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x09 == AquariteStatuses::TurningOff.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x09));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::TurningOff);
+
+	// TurningOff drives the operating status Off.
+	auto chlorinators = harness.DataHub()->Chlorinators();
+	BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+	auto status = chlorinators.front()->AuxillaryTraits.TryGet(AuxillaryTraitsTypes::ChlorinatorStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::ChlorinatorStatuses::Off);
+}
+
+BOOST_AUTO_TEST_CASE(Status_WarningNoFlow_MapsToNoFlowHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x01 == AquariteStatuses::Warning_NoFlow.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x01));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_NoFlow);
+}
+
+BOOST_AUTO_TEST_CASE(Status_WarningHighSalt_MapsToHighSaltHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x04 == AquariteStatuses::Warning_HighSalt.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x04));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_HighSalt);
+}
+
+BOOST_AUTO_TEST_CASE(Status_WarningHighCurrent_MapsToHighCurrentHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x10 == AquariteStatuses::Warning_HighCurrent.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x10));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_HighCurrent);
+}
+
+BOOST_AUTO_TEST_CASE(Status_WarningCleanCell_MapsToCleanCellHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x08 == AquariteStatuses::Warning_CleanCell.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x08));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_CleanCell);
+}
+
+BOOST_AUTO_TEST_CASE(Status_WarningLowVoltage_MapsToLowVoltageHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x20 == AquariteStatuses::Warning_LowVoltage.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x20));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_LowVoltage);
+}
+
+BOOST_AUTO_TEST_CASE(Status_WarningLowTemperature_MapsToLowTemperatureHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x40 == AquariteStatuses::Warning_LowTemperature.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x40));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Warning_LowTemperature);
+}
+
+BOOST_AUTO_TEST_CASE(Status_ErrorCheckPCB_MapsToCheckPCBHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x80 == AquariteStatuses::Error_CheckPCB.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x80));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::Error_CheckPCB);
+}
+
+BOOST_AUTO_TEST_CASE(Status_GeneralFault_MapsToGeneralFaultHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0xFD == AquariteStatuses::GeneralFault.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0xFD));
+
+	BOOST_CHECK_EQUAL(HealthOf(harness), Kernel::ChlorinatorHealth::GeneralFault);
+}
+
+// An undecodable status byte (e.g. 0x03 == LowSalt|HighSalt bit-flags combined)
+// deserialises to AquariteStatuses::Unknown, which ConvertToChlorinatorHealthStatus
+// maps via its default arm to ChlorinatorHealth::Unknown, and DwellChlorinatorHealth
+// then swallows (returns nullopt) so the health trait is never written.  Operating
+// status still follows the raw wire status (On, since it is neither Off nor TurningOff).
+BOOST_AUTO_TEST_CASE(Status_UndecodableByte_YieldsUnknownAndDwellHoldsHealth)
+{
+	Test::MockReplayHarness harness;
+
+	auto device_id = std::make_shared<JandyDeviceType>(JandyDeviceId(AQUARITE_DEVICE_ID));
+	harness.AddDevice<AquariteDevice>(device_id);
+
+	// 0x03 is not a single AquariteStatuses enumerator -> decodes to Unknown.
+	harness.Replay(MakePpmFrame(SALT_BYTE_OK, 0x03));
+
+	auto chlorinators = harness.DataHub()->Chlorinators();
+	BOOST_REQUIRE_EQUAL(chlorinators.size(), 1u);
+
+	// The dwell returned nullopt for the Unknown reading -> no health trait written.
+	auto health = chlorinators.front()->AuxillaryTraits.TryGet(AuxillaryTraitsTypes::ChlorinatorHealthTrait{});
+	BOOST_CHECK(!health.has_value());
+
+	// Operating status is still published and reflects On for a non-Off/non-TurningOff status.
+	auto status = chlorinators.front()->AuxillaryTraits.TryGet(AuxillaryTraitsTypes::ChlorinatorStatusTrait{});
+	BOOST_REQUIRE(status.has_value());
+	BOOST_CHECK(status.value() == Kernel::ChlorinatorStatuses::On);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/equipment_cache/test_equipment_cache_service.cpp
+++ b/test/unit/equipment_cache/test_equipment_cache_service.cpp
@@ -439,6 +439,54 @@ BOOST_AUTO_TEST_CASE(Start_NoConfiguredFile_IsNoOp)
 	BOOST_CHECK_NO_THROW(service.Stop());
 }
 
+// SaveNow() writing to a path whose parent directory does not exist: the .tmp
+// ofstream silently fails to create the file, so std::filesystem::rename(tmp, target)
+// throws std::filesystem_error, which is caught and swallowed (SaveNow must not
+// propagate it). Covers the filesystem_error catch arm.
+BOOST_AUTO_TEST_CASE(SaveNow_UnwritablePath_FilesystemErrorIsCaught)
+{
+	boost::asio::io_context io;
+	Options::Equipment::EquipmentSettings settings;
+	// A parent directory that does not exist -> the .tmp cannot be created and the
+	// subsequent rename throws filesystem_error.
+	settings.equipment_cache_file =
+		(std::filesystem::temp_directory_path() / "aqualink_eqcache_no_such_dir" / "cache.json").string();
+
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+	Find<Kernel::DataHub>()->Devices.Add(MakeDevice("Filter Pump", Traits::AuxillaryTypes::Pump));
+
+	// The filesystem_error from rename is caught and logged; SaveNow must not throw
+	// and must not leave the target behind.
+	BOOST_CHECK_NO_THROW(service.SaveNow());
+	BOOST_CHECK(!std::filesystem::exists(settings.equipment_cache_file));
+}
+
+// After Start() schedules the save timer, Stop() cancels it. Pumping the io_context
+// then runs the pending completion handler with error_code == operation_aborted, so
+// it returns immediately without re-scheduling. Covers the operation_aborted guard.
+BOOST_AUTO_TEST_CASE(ScheduleSave_TimerCancelled_HandlerReturnsOnAbort)
+{
+	boost::asio::io_context io;
+	const auto path = (std::filesystem::temp_directory_path() / "aqualink_eqcache_abort.json").string();
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+
+	Options::Equipment::EquipmentSettings settings;
+	settings.equipment_cache_file = path;
+
+	EquipmentCache::EquipmentCacheService service(io, *this, settings);
+
+	service.Start();   // schedules the async_wait on m_Timer
+	service.Stop();    // sets m_Stopped, cancels the timer (handler pends w/ aborted ec)
+
+	// Pump the io_context: the cancelled handler runs and returns at the guard,
+	// without rescheduling, so run() drains to completion and does not hang.
+	BOOST_CHECK_NO_THROW(io.run());
+
+	std::filesystem::remove(path, ec);
+	std::filesystem::remove(path + ".tmp", ec);
+}
+
 BOOST_AUTO_TEST_CASE(Snapshot_FreshHub_HasUnknownConfigAndNoDevices)
 {
 	boost::asio::io_context io;

--- a/test/unit/history/test_history_service.cpp
+++ b/test/unit/history/test_history_service.cpp
@@ -1,4 +1,7 @@
+#include <chrono>
 #include <cstdint>
+#include <filesystem>
+#include <format>
 #include <memory>
 #include <string>
 
@@ -605,6 +608,67 @@ BOOST_AUTO_TEST_CASE(Heartbeat_SamplesChlorinatorDutyCycle)
 		}
 	}
 	BOOST_CHECK(saw_swg);
+}
+
+//=============================================================================
+// Schema migration: Start() opening a pre-existing on-disk database created
+// before the `label` column existed runs MigrateSchema, which probes
+// table_info(series) and ALTERs in the missing column. An in-memory database
+// cannot exercise this (it is recreated fresh each connection), so use a real
+// temp file: seed the legacy schema through a raw SqliteDb, close it, then let
+// the service reopen and migrate it.
+//=============================================================================
+
+BOOST_AUTO_TEST_CASE(Start_MigratesLegacyDbWithoutLabelColumn)
+{
+	// Unique temp path so the test never collides with a stale file.
+	const auto db_path = (std::filesystem::temp_directory_path() /
+		std::filesystem::path{ std::format("aqualink_history_migrate_{}.db",
+			static_cast<std::uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count())) }).string();
+
+	std::filesystem::remove(db_path);   // ensure a clean start
+
+	// Seed the pre-`label` schema through a raw connection, then close it so the
+	// service can reopen the same file.
+	{
+		History::SqliteDb legacy(db_path);
+		legacy.Exec(
+			"CREATE TABLE series ("
+			"  id INTEGER PRIMARY KEY,"
+			"  key TEXT UNIQUE NOT NULL,"
+			"  unit TEXT);"
+			"CREATE TABLE samples ("
+			"  series_id INTEGER NOT NULL REFERENCES series(id),"
+			"  ts INTEGER NOT NULL,"
+			"  value REAL NOT NULL);");
+	}
+
+	{
+		boost::asio::io_context io;
+		auto settings = MemorySettings();
+		settings.db_path = db_path;
+		History::HistoryService service(io, *this, settings);
+
+		std::int64_t now = 100;
+		service.SetClock([&now] { return now; });
+
+		// Start() -> MigrateSchema() finds no `label` column and ALTERs it in.
+		BOOST_CHECK_NO_THROW(service.Start());
+
+		// Proof the column now exists: a labelled device series records and the
+		// label round-trips through the migrated table.
+		service.RecordDeviceState("device/uuid-migrated", "Pool Light", 1.0);
+
+		auto series = service.ListSeries();
+		BOOST_REQUIRE_EQUAL(series.size(), 1u);
+		BOOST_CHECK_EQUAL(series.front().key, "device/uuid-migrated");
+		BOOST_CHECK_EQUAL(series.front().label, "Pool Light");
+		BOOST_CHECK_EQUAL(series.front().count, 1);
+
+		service.Stop();
+	}
+
+	std::filesystem::remove(db_path);   // cleanup
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mqtt/test_mqtt_ha_discovery.cpp
+++ b/test/unit/mqtt/test_mqtt_ha_discovery.cpp
@@ -1413,3 +1413,84 @@ BOOST_AUTO_TEST_CASE(Test_AdoptRetained_InvalidJson_IsHarmless)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+//=============================================================================
+// AddChlorinatorComponents rich entities: a LABELLED chlorinator drives the full
+// chlorinator-component builder (generating %/boost/health sensors + a generating
+// setpoint number entity with min/max/step + a boost switch). The existing dynamic
+// tests only add an UNLABELLED chlorinator, which returns early, so these value
+// entities were never exercised.
+//=============================================================================
+
+BOOST_AUTO_TEST_SUITE(TestSuite_HaDiscovery_ChlorinatorComponents)
+
+BOOST_AUTO_TEST_CASE(Test_ChlorinatorComponents_LabelledChlorinator_EmitsRichEntities)
+{
+	namespace Traits = Kernel::AuxillaryTraitsTypes;
+
+	boost::asio::io_context ioc;
+	auto settings = MakeTestSettings();
+	auto client = std::make_shared<Mqtt::MqttClient>(ioc, settings);
+	Mqtt::HomeAssistantDiscovery ha(client, settings);
+
+	auto data_hub = std::make_shared<Kernel::DataHub>();
+	ha.ConnectDataHub(data_hub);
+
+	// A labelled chlorinator drives AddChlorinatorComponents in full.
+	data_hub->Devices.Add(MakeTypedDevice(Traits::AuxillaryTypes::Chlorinator, "AquaPure"));
+
+	ha.PublishDiscoveryConfigs();
+
+	auto& queue = Test::MqttClientPacketTest::GetPublishQueue(*client);
+	BOOST_REQUIRE_EQUAL(queue.size(), 1);
+	auto cmps = nlohmann::json::parse(queue[0].payload)["cmps"];
+
+	// The three read-only sensors (generating %, boost, health).
+	BOOST_REQUIRE(cmps.contains("chlorinator_aquapure_generating"));
+	{
+		auto& gen = cmps["chlorinator_aquapure_generating"];
+		BOOST_CHECK_EQUAL(gen["p"], "sensor");
+		BOOST_CHECK_EQUAL(gen["unit_of_measurement"], "%");
+		BOOST_CHECK_EQUAL(gen["state_class"], "measurement");
+		BOOST_CHECK_EQUAL(gen["value_template"], "{{ value_json.generating_percentage }}");
+	}
+
+	BOOST_REQUIRE(cmps.contains("chlorinator_aquapure_boost"));
+	{
+		auto& boost_sensor = cmps["chlorinator_aquapure_boost"];
+		BOOST_CHECK_EQUAL(boost_sensor["p"], "sensor");
+		// The boost/health sensors carry no unit_of_measurement / state_class.
+		BOOST_CHECK(!boost_sensor.contains("unit_of_measurement"));
+		BOOST_CHECK(!boost_sensor.contains("state_class"));
+	}
+
+	BOOST_REQUIRE(cmps.contains("chlorinator_aquapure_health"));
+	BOOST_CHECK_EQUAL(cmps["chlorinator_aquapure_health"]["p"], "sensor");
+
+	// The generating-percentage setpoint number entity: min/max/step (uncovered lines).
+	BOOST_REQUIRE(cmps.contains("chlorinator_aquapure_pct_cmd"));
+	{
+		auto& pct = cmps["chlorinator_aquapure_pct_cmd"];
+		BOOST_CHECK_EQUAL(pct["p"], "number");
+		BOOST_CHECK(pct.contains("command_topic"));
+		BOOST_CHECK_EQUAL(pct["min"].get<int>(), 0);
+		BOOST_CHECK_EQUAL(pct["max"].get<int>(), 100);
+		BOOST_CHECK_EQUAL(pct["step"].get<int>(), 1);
+		BOOST_CHECK_EQUAL(pct["unit_of_measurement"], "%");
+		BOOST_CHECK_EQUAL(pct["mode"], "slider");
+	}
+
+	// The boost switch (command topic + on/off state mapping).
+	BOOST_REQUIRE(cmps.contains("chlorinator_aquapure_boost_cmd"));
+	{
+		auto& boost_cmd = cmps["chlorinator_aquapure_boost_cmd"];
+		BOOST_CHECK_EQUAL(boost_cmd["p"], "switch");
+		BOOST_CHECK(boost_cmd.contains("command_topic"));
+		BOOST_CHECK_EQUAL(boost_cmd["payload_on"], "ON");
+		BOOST_CHECK_EQUAL(boost_cmd["payload_off"], "OFF");
+		BOOST_CHECK_EQUAL(boost_cmd["state_on"], "Boost");
+		BOOST_CHECK_EQUAL(boost_cmd["state_off"], "Off");
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/scheduling/test_controller_schedule.cpp
+++ b/test/unit/scheduling/test_controller_schedule.cpp
@@ -65,4 +65,230 @@ BOOST_AUTO_TEST_CASE(ControllerScheduleStore_ReplaceSwapsSnapshot)
 	BOOST_CHECK_EQUAL(store.List().front().target, "Filter Pump");
 }
 
+BOOST_AUTO_TEST_CASE(ControllerScheduleStatusToString_UnknownFallsBackToPendingCapture)
+{
+	// An out-of-range enum value hits the switch fall-through default.
+	const auto bogus = static_cast<ControllerScheduleStatus>(0xff);
+	BOOST_CHECK_EQUAL(ControllerScheduleStatusToString(bogus), "pending_capture");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_ValidBodyParses)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x7f },
+		{ "on_local", "08:05" },
+		{ "off_local", "12:30" },
+		{ "name", "Morning run" },
+		{ "group", "A" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_REQUIRE(result.has_value());
+	BOOST_CHECK(error.empty());
+	BOOST_CHECK_EQUAL(result->target, "Filter Pump");
+	BOOST_CHECK_EQUAL(static_cast<int>(result->days_of_week), 0x7f);
+	BOOST_CHECK_EQUAL(result->on_hour, 8);
+	BOOST_CHECK_EQUAL(result->on_minute, 5);
+	BOOST_CHECK_EQUAL(result->off_hour, 12);
+	BOOST_CHECK_EQUAL(result->off_minute, 30);
+	BOOST_CHECK_EQUAL(result->name, "Morning run");
+	BOOST_CHECK_EQUAL(result->group, "A");
+	BOOST_CHECK(result->enabled);
+	BOOST_CHECK(result->id.empty());
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_ValidBodyWithoutOptionalFields)
+{
+	nlohmann::json body{
+		{ "target", "Spa" },
+		{ "days_of_week", 0 },
+		{ "on_local", "00:00" },
+		{ "off_local", "23:59" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_REQUIRE(result.has_value());
+	BOOST_CHECK(error.empty());
+	BOOST_CHECK_EQUAL(result->target, "Spa");
+	BOOST_CHECK_EQUAL(static_cast<int>(result->days_of_week), 0);
+	BOOST_CHECK_EQUAL(result->on_hour, 0);
+	BOOST_CHECK_EQUAL(result->on_minute, 0);
+	BOOST_CHECK_EQUAL(result->off_hour, 23);
+	BOOST_CHECK_EQUAL(result->off_minute, 59);
+	BOOST_CHECK(result->name.empty());
+	BOOST_CHECK(result->group.empty());
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_NonObjectBodyRejected)
+{
+	std::string error;
+	auto result = ControllerScheduleFromJson(nlohmann::json::array(), error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "body must be a JSON object");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_MissingTargetRejected)
+{
+	nlohmann::json body{
+		{ "days_of_week", 0x7f },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "target is required and must be a non-empty string");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_EmptyTargetRejected)
+{
+	nlohmann::json body{
+		{ "target", "" },
+		{ "days_of_week", 0x7f },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "target is required and must be a non-empty string");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_MissingDaysOfWeekRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "days_of_week is required and must be an integer bitmask");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_NonIntegerDaysOfWeekRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", "seven" },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "days_of_week is required and must be an integer bitmask");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_DaysOfWeekOutOfRangeRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x80 },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "days_of_week must be in the range 0..127");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_NegativeDaysOfWeekRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", -1 },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "days_of_week must be in the range 0..127");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_MissingOnLocalRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x7f },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "on_local is required and must be a valid \"HH:MM\" time");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_MalformedOnLocalRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x7f },
+		{ "on_local", "8-00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "on_local is required and must be a valid \"HH:MM\" time");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_OutOfRangeOnLocalRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x7f },
+		{ "on_local", "24:00" },
+		{ "off_local", "12:30" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "on_local is required and must be a valid \"HH:MM\" time");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_MissingOffLocalRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x7f },
+		{ "on_local", "08:00" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "off_local is required and must be a valid \"HH:MM\" time");
+}
+
+BOOST_AUTO_TEST_CASE(ControllerScheduleFromJson_MalformedOffLocalRejected)
+{
+	nlohmann::json body{
+		{ "target", "Filter Pump" },
+		{ "days_of_week", 0x7f },
+		{ "on_local", "08:00" },
+		{ "off_local", "12:60" },
+	};
+
+	std::string error;
+	auto result = ControllerScheduleFromJson(body, error);
+	BOOST_CHECK(!result.has_value());
+	BOOST_CHECK_EQUAL(error, "off_local is required and must be a valid \"HH:MM\" time");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
SonarCloud cleanup pass (branch off develop).

### Reliability (the 2 open bugs)
- **cpp:S1048** — `AlertMonitor` / `SchedulerService` destructors already swallow a throwing `Stop()`, but the diagnostic log call inside the catch handler could itself throw (`std::format`/sink write) and escape. Guarded both so the destructors are genuinely no-throw.

### CI fixes (both workflows currently red on main)
- **docs (`Publish docs site`)** — `mkdocs build --strict` aborted because `docs/fuzzing.md` linked to repo files outside the docs tree; point them at GitHub blob URLs.
- **Fuzzing** — harnesses failed to link (`libclang_rt.fuzzer.a` / `libclang_rt.asan*.a` missing); install `libclang-rt-<ver>-dev` for the clang that `aminya/setup-cpp` selects.

### Maintainability — 966 safe mechanical fixes (83 skipped)
File-partitioned sweep across the safe rules: redundant access specifiers (S3539), empty namespaces (S3261), default member initializers (S3230), `explicit` ctors (S1709), `using enum` (S6177), `std::to_underlying` (S7035), if-init-statements (S6004), shadowing renames (S1117), empty-method comments (S1186), unused params (S1172). Judgment-heavy/behaviour-affecting instances were skipped; one over-eager `explicit` on the `ORP`/`pH` value-wrappers was reverted (implicit numeric conversion is part of their contract).

Local MSVC build + full unit/integration suite green. This PR exercises the same change across Linux GCC / arm64 / macOS Clang and validates the Fuzzing fix on its PR run.