### PR TITLE
test(e2e): MQTT mock-broker + persistence launch modes for coverage

### DIFF
--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -427,6 +427,40 @@ jobs:
         AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc-coverage/src/aqualink-automate
         AQUALINK_OPEN_BIND: ack
 
+    # MQTT: the ONLY e2e mode that exercises the MQTT layer. Playwright starts a
+    # loopback MQTT broker (e2e/support/mqtt-broker.mjs, via the aedes dev-dep) as
+    # a webServer and boots the app with --mqtt + --home-assistant against it, so
+    # MqttClient (connect/CONNACK/recv-loop/flush), MqttIntegration state
+    # publishing, MqttHub, and Home-Assistant auto-discovery all run under the
+    # coverage build — none of which the broker-less runs above reach.
+    - name: E2E — MQTT (broker + HA discovery)
+      continue-on-error: true
+      shell: bash
+      run: npx playwright test e2e/mqtt.spec.ts
+      env:
+        AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc-coverage/src/aqualink-automate
+        AQUALINK_MQTT: enabled
+
+    # Equipment-cache persistence: boot with --equipment-cache-file so the cache
+    # load-or-init + write-scheduling paths run (skipped in the in-memory default).
+    - name: E2E — equipment cache persisted
+      continue-on-error: true
+      shell: bash
+      run: npx playwright test
+      env:
+        AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc-coverage/src/aqualink-automate
+        AQUALINK_EQUIPMENT_CACHE: ${{ runner.temp }}/e2e-equipment-cache.json
+
+    # Preferences persistence: boot with --preferences-file so the preferences
+    # load/persist path runs against a real file rather than in-memory only.
+    - name: E2E — preferences persisted
+      continue-on-error: true
+      shell: bash
+      run: npx playwright test
+      env:
+        AQUALINK_EXE: ${{ github.workspace }}/build/config-linux-gcc-coverage/src/aqualink-automate
+        AQUALINK_PREFERENCES_FILE: ${{ runner.temp }}/e2e-preferences.json
+
     # gcovr may already be baked into the self-hosted image (the unit-coverage
     # CMake target needs it); install it as a fallback for a stock runner.
     - name: Ensure gcovr is available

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,7 @@ RUN DESTDIR=/src/install/config-linux-gcc cmake --install build/config-linux-gcc
 # the glibc Node installed in the runtime stage. @matter/main and ws are pure JS, so
 # this is belt-and-braces, but it keeps the door open for any future native dep.
 
-FROM node:24-bookworm-slim@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc AS matter-builder
+FROM node:26-bookworm-slim@sha256:b16ca7b4dcfb20184e1c70f9ee30c6a75ed1da669cfafd6d2add4761b123d79f AS matter-builder
 
 WORKDIR /opt/matter-bridge
 

--- a/e2e/mqtt.spec.ts
+++ b/e2e/mqtt.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * MQTT integration e2e — runs ONLY under AQUALINK_MQTT=enabled (see
+ * playwright.config.ts). In that mode Playwright starts a loopback MQTT broker
+ * (e2e/support/mqtt-broker.mjs) and boots the app with --mqtt + --home-assistant
+ * pointed at it. This is the only e2e launch mode that actually exercises the
+ * MQTT layer — MqttClient connect/CONNACK/recv-loop/flush, MqttIntegration state
+ * publishing, MqttHub, and Home-Assistant auto-discovery — so it drives that
+ * code under the gcov-instrumented coverage build.
+ *
+ * The assertions double as a guard: a silent broker / protocol / auth failure
+ * surfaces as a red spec instead of merely producing no coverage.
+ */
+
+test('MQTT client connects to the broker and publishes with HA discovery', async ({ request }) => {
+  const read = async () => (await request.get('/api/diagnostics/mqtt')).json();
+
+  // Poll up to ~12s for the client to connect and complete its initial burst.
+  let diag = await read();
+  for (let i = 0; i < 24 && !(diag.connected && diag.published > 0); i++) {
+    await new Promise((r) => setTimeout(r, 500));
+    diag = await read();
+  }
+
+  expect(diag.enabled).toBe(true);
+  expect(diag.connected).toBe(true);
+  expect(diag.state).toBe('Connected');
+  expect(diag.home_assistant_enabled).toBe(true);
+  expect(diag.published).toBeGreaterThan(0);
+  expect(diag.dropped).toBe(0);
+
+  // With 1s status/stats intervals the publish/flush path keeps running, so the
+  // published counter must climb over a few seconds.
+  const before = diag.published as number;
+  await new Promise((r) => setTimeout(r, 3000));
+  const after = (await read()).published as number;
+  expect(after).toBeGreaterThan(before);
+});
+
+test('The Diagnostics MQTT card reflects the live broker connection', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('.nav-link', { hasText: 'Diagnostics' }).click();
+
+  const card = page.locator('.mqtt-card');
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  // In the default (broker-less) run this reads "Disabled"; with a live broker it
+  // must reflect the connected state instead.
+  await expect(card.locator('.mqtt-status')).not.toHaveText(/Disabled/i, { timeout: 10_000 });
+});

--- a/e2e/support/mqtt-broker.mjs
+++ b/e2e/support/mqtt-broker.mjs
@@ -1,0 +1,42 @@
+// Minimal in-process MQTT broker for the e2e coverage run.
+//
+// The Playwright replay harness normally boots the app WITHOUT --mqtt, so the
+// entire MQTT layer (MqttClient connect/CONNACK/recv-loop/flush, MqttIntegration
+// state publishing, MqttHub, HA auto-discovery) never executes and stays
+// uncovered. This broker gives the app's MqttClient a real MQTT 3.1.1 / 5.0 peer
+// to connect to on loopback, so those paths run under the gcov-instrumented
+// e2e build. It is a COVERAGE aid, not a functional assertion target — its only
+// job is to accept the connection, honour SUBSCRIBE, and deliver PUBLISHes.
+//
+// Started as a Playwright `webServer` entry (Playwright waits for the TCP port);
+// stops cleanly on SIGTERM so it doesn't linger between runs.
+
+import { createServer } from 'node:net';
+import Aedes from 'aedes';
+
+const PORT = Number(process.env.AQUALINK_MQTT_PORT ?? 11883);
+const HOST = '127.0.0.1';
+
+const broker = new Aedes();
+const server = createServer(broker.handle);
+
+broker.on('client', (c) => console.log(`[mqtt-broker] connected: ${c?.id ?? '<anon>'}`));
+broker.on('subscribe', (subs, c) =>
+  console.log(`[mqtt-broker] ${c?.id ?? '<anon>'} subscribed: ${subs.map((s) => s.topic).join(', ')}`),
+);
+broker.on('publish', (packet, c) => {
+  // Ignore the broker's own $SYS keep-alive traffic; log app publishes only.
+  if (c && packet.topic && !packet.topic.startsWith('$SYS')) {
+    console.log(`[mqtt-broker] publish ${packet.topic} (${packet.payload?.length ?? 0}b)`);
+  }
+});
+
+server.listen(PORT, HOST, () => console.log(`[mqtt-broker] listening on mqtt://${HOST}:${PORT}`));
+
+const shutdown = () => {
+  server.close(() => broker.close(() => process.exit(0)));
+  // Hard bound in case a socket lingers.
+  setTimeout(() => process.exit(0), 3_000).unref();
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,18 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.61.1"
+        "@playwright/test": "^1.61.1",
+        "aedes": "^0.51.3"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -28,6 +39,310 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/aedes": {
+      "version": "0.51.3",
+      "resolved": "https://registry.npmjs.org/aedes/-/aedes-0.51.3.tgz",
+      "integrity": "sha512-aQfiI9w3RbqnowNCdcGMmCtxBFXN9bhJFcuZm24U5/NU06V3MCl42jWK2GUnu8rOypR2Ahi/aEcgq3w7CMcycg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aedes-packet": "^3.0.0",
+        "aedes-persistence": "^9.1.2",
+        "end-of-stream": "^1.4.4",
+        "fastfall": "^1.5.1",
+        "fastparallel": "^2.4.1",
+        "fastseries": "^2.0.0",
+        "hyperid": "^3.2.0",
+        "mqemitter": "^6.0.0",
+        "mqtt-packet": "^9.0.0",
+        "retimer": "^4.0.0",
+        "reusify": "^1.0.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/aedes"
+      }
+    },
+    "node_modules/aedes-packet": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aedes-packet/-/aedes-packet-3.0.0.tgz",
+      "integrity": "sha512-swASey0BxGs4/npZGWoiVDmnEyPvVFIRY6l2LVKL4rbiW8IhcIGDLfnb20Qo8U20itXlitAKPQ3MVTEbOGG5ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mqtt-packet": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/aedes-packet/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/aedes-packet/node_modules/mqtt-packet": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-7.1.2.tgz",
+      "integrity": "sha512-FFZbcZ2omsf4c5TxEQfcX9hI+JzDpDKPT46OmeIBpVA7+t32ey25UNqlqNXTmeZOr5BLsSIERpQQLsFWJS94SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.2",
+        "debug": "^4.1.1",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/aedes-packet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/aedes-persistence": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/aedes-persistence/-/aedes-persistence-9.1.2.tgz",
+      "integrity": "sha512-2Wlr5pwIK0eQOkiTwb8ZF6C20s8UPUlnsJ4kXYePZ3JlQl0NbBA176mzM8wY294BJ5wybpNc9P5XEQxqadRNcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aedes-packet": "^3.0.0",
+        "qlobber": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.13.tgz",
+      "integrity": "sha512-7OnTFAVPefgw2eBJ1xj2PGGR9FwYzSUso9decayHgCDX4sJkHLdcsYTytTg+tYv+wKF3U8gJuSBz2jJpQV4u/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.1.0"
+      }
+    },
+    "node_modules/fastfall": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fastfall/-/fastfall-1.5.1.tgz",
+      "integrity": "sha512-KH6p+Z8AKPXnmA7+Iz2Lh8ARCMr+8WNPVludm1LGkZoD2MjY6LVnRMtTKhkdzI+jr0RzQWXKzKyBJm1zoHEL4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "reusify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fastparallel": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fastparallel/-/fastparallel-2.4.1.tgz",
+      "integrity": "sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/fastseries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fastseries/-/fastseries-2.0.0.tgz",
+      "integrity": "sha512-XBU9RXeoYc2/VnvMhplAxEmZLfIk7cvTBu+xwoBuTI8pL19E03cmca17QQycKIdxgwCeFA/a4u27gv1h3ya5LQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -41,6 +356,110 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hyperid": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.3.0.tgz",
+      "integrity": "sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "uuid": "^8.3.2",
+        "uuid-parse": "^1.1.0"
+      }
+    },
+    "node_modules/hyperid/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mqemitter": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/mqemitter/-/mqemitter-6.0.2.tgz",
+      "integrity": "sha512-8RGlznQx/Nb1xC3xKUFXHWov7pn7JdH++YVwlr6SLT6k3ft1h+ImGqZdVudbdKruFckIq9wheq9s4hgCivJDow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fastparallel": "^2.4.1",
+        "qlobber": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/mqemitter/node_modules/qlobber": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/qlobber/-/qlobber-8.0.1.tgz",
+      "integrity": "sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/playwright": {
@@ -73,6 +492,224 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qlobber": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/qlobber/-/qlobber-7.0.1.tgz",
+      "integrity": "sha512-FsFg9lMuMEFNKmTO9nV7tlyPhx8BmskPPjH2akWycuYVTtWaVwhW5yCHLJQ6Q+3mvw5cFX2vMfW2l9z2SiYAbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/retimer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-4.0.0.tgz",
+      "integrity": "sha512-fZIVtvbOsQsxNSDhpdPOX4lx5Ss2ni+S72AUBitARpFhtA3UzrAjQ6gDtypB2/+l7L+1VQgAgpvAKY66mElH0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "worker-timers": "^7.0.75"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/worker-timers": {
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.1.8.tgz",
+      "integrity": "sha512-R54psRKYVLuzff7c1OTFcq/4Hue5Vlz4bFtNEIarpSiCYhpifHU3aIQI29S84o1j87ePCYqbmEJPqwBTf+3sfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "tslib": "^2.6.2",
+        "worker-timers-broker": "^6.1.8",
+        "worker-timers-worker": "^7.0.71"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.1.8.tgz",
+      "integrity": "sha512-FUCJu9jlK3A8WqLTKXM9E6kAmI/dR1vAJ8dHYLMisLNB/n3GuaFIjJ7pn16ZcD1zCOf7P6H62lWIEBi+yz/zQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "fast-unique-numbers": "^8.0.13",
+        "tslib": "^2.6.2",
+        "worker-timers-worker": "^7.0.71"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "7.0.71",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.71.tgz",
+      "integrity": "sha512-ks/5YKwZsto1c2vmljroppOKCivB/ma97g9y77MAAz2TBBjPPgpoOiS1qYQKIgvGTr2QYPT3XhJWIB6Rj2MVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.61.1"
+    "@playwright/test": "^1.61.1",
+    "aedes": "^0.51.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -97,6 +97,22 @@ const HISTORY_DB = process.env.AQUALINK_HISTORY_DB;
 // --schedules-file and run ONLY the schedules spec (schedule CRUD).
 const SCHEDULES_FILE = process.env.AQUALINK_SCHEDULES_FILE;
 
+// MQTT mode: when AQUALINK_MQTT=enabled, start a loopback MQTT broker
+// (e2e/support/mqtt-broker.mjs) and boot the app with --mqtt + --home-assistant
+// pointed at it. This is the only launch mode that exercises the MQTT layer —
+// MqttClient connect/CONNACK/recv-loop/flush, MqttIntegration state publishing,
+// MqttHub, and Home-Assistant auto-discovery — none of which the broker-less
+// default reaches. Short publish intervals keep the publish/flush paths busy.
+// Runs ONLY mqtt.spec.ts (it asserts a live broker connection).
+const MQTT_MODE = process.env.AQUALINK_MQTT === 'enabled';
+const MQTT_PORT = Number(process.env.AQUALINK_MQTT_PORT ?? 11883);
+
+// Persistence modes: point the equipment cache / preferences at real files so
+// their load-or-init + write-scheduling paths run (the default in-memory run
+// skips them). Both use the normal spec suite; they only add a --file flag.
+const EQUIPMENT_CACHE = process.env.AQUALINK_EQUIPMENT_CACHE;
+const PREFERENCES_FILE = process.env.AQUALINK_PREFERENCES_FILE;
+
 const ROOT = __dirname;
 
 // Resolve the built application binary.  The `wt` CMake preset emits it under
@@ -118,6 +134,19 @@ if (!existsSync(APP_EXE)) {
   );
 }
 
+// The loopback MQTT broker Playwright starts alongside the app in MQTT mode.
+// Playwright waits for its TCP port to accept connections before starting the
+// app, so the MqttClient's first connect attempt lands on a live broker.
+const brokerServer = {
+  command: `node "${join(ROOT, 'e2e', 'support', 'mqtt-broker.mjs')}"`,
+  port: MQTT_PORT,
+  reuseExistingServer: false,
+  stdout: 'pipe' as const,
+  stderr: 'pipe' as const,
+  env: { AQUALINK_MQTT_PORT: String(MQTT_PORT) },
+  gracefulShutdown: { signal: 'SIGTERM' as const, timeout: 5_000 },
+};
+
 export default defineConfig({
   testDir: './e2e',
   // The identity specs (auth + admin + guest) need an identity-enabled server
@@ -136,8 +165,8 @@ export default defineConfig({
   // auth.spec's wizard assertion — which is why CI drives one spec per step.
   testMatch: AUTH_MODE
     ? ['**/auth.spec.ts', '**/admin.spec.ts', '**/guest.spec.ts']
-    : (HISTORY_DB ? ['**/trends.spec.ts'] : (SCHEDULES_FILE ? ['**/schedules.spec.ts'] : undefined)),
-  testIgnore: (AUTH_MODE || HISTORY_DB || SCHEDULES_FILE) ? undefined : ['**/auth.spec.ts', '**/admin.spec.ts', '**/guest.spec.ts'],
+    : (HISTORY_DB ? ['**/trends.spec.ts'] : (SCHEDULES_FILE ? ['**/schedules.spec.ts'] : (MQTT_MODE ? ['**/mqtt.spec.ts'] : undefined))),
+  testIgnore: (AUTH_MODE || HISTORY_DB || SCHEDULES_FILE || MQTT_MODE) ? undefined : ['**/auth.spec.ts', '**/admin.spec.ts', '**/guest.spec.ts', '**/mqtt.spec.ts'],
   // Replay is deterministic but the UI is global mutable state behind one backend;
   // run serially so command-button tests don't race each other's optimistic updates.
   fullyParallel: false,
@@ -165,7 +194,11 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
+  // In MQTT mode the broker is started first (Playwright waits for its port),
+  // then the app; otherwise just the app.
+  webServer: [
+    ...(MQTT_MODE ? [brokerServer] : []),
+    {
     command: [
       `"${APP_EXE}"`,
       '--dev-mode',
@@ -192,6 +225,21 @@ export default defineConfig({
         : []),
       ...(HISTORY_DB ? [`--history-db "${HISTORY_DB}"`, '--history-flush-seconds 1'] : []),
       ...(SCHEDULES_FILE ? [`--schedules-file "${SCHEDULES_FILE}"`] : []),
+      // MQTT mode: connect to the loopback broker + enable HA discovery, with
+      // 1s status/stats intervals so the publish + flush paths run repeatedly
+      // during the spec (they are otherwise on a multi-second cadence).
+      ...(MQTT_MODE
+        ? [
+            '--mqtt',
+            `--mqtt-host ${HOST}`,
+            `--mqtt-port ${MQTT_PORT}`,
+            '--home-assistant',
+            '--mqtt-status-interval 1',
+            '--mqtt-stats-interval 1',
+          ]
+        : []),
+      ...(EQUIPMENT_CACHE ? [`--equipment-cache-file "${EQUIPMENT_CACHE}"`] : []),
+      ...(PREFERENCES_FILE ? [`--preferences-file "${PREFERENCES_FILE}"`] : []),
     ].join(' '),
     url: BASE_URL,
     // The HTTPS readiness probe must accept the self-signed cert too, or the
@@ -215,5 +263,6 @@ export default defineConfig({
     // discard all e2e coverage. The timeout bounds the wait before Playwright
     // escalates to SIGKILL if the app fails to stop.
     gracefulShutdown: { signal: 'SIGTERM', timeout: 15_000 },
-  },
+    },
+  ],
 });


### PR DESCRIPTION
Extends the merged Playwright e2e coverage to the code no unit test and no existing e2e mode reaches.

### MQTT (the big lever)
The e2e harness boots without \`--mqtt\`, so the entire MQTT layer (\`mqtt_client\` 441 uncovered, \`mqtt_integration\`, \`mqtt_hub\`, \`ha_discovery\`) never runs under coverage. This adds a real broker so it does:

- **\`e2e/support/mqtt-broker.mjs\`** — a loopback MQTT broker (\`aedes\` dev-dep) started as a Playwright \`webServer\`; Playwright waits for its TCP port before the app connects.
- **\`playwright.config.ts\`** — \`AQUALINK_MQTT=enabled\` boots the app with \`--mqtt --home-assistant\` at the broker (1s publish intervals), running only \`e2e/mqtt.spec.ts\`. Also adds \`AQUALINK_EQUIPMENT_CACHE\` / \`AQUALINK_PREFERENCES_FILE\` file-persistence modes.
- **\`e2e/mqtt.spec.ts\`** — asserts the client connects + publishes with HA discovery (guards a silent broker/protocol failure).

**Verified locally:** broker + app connect, the app publishes 90+ messages including the 10 KB \`homeassistant/device/.../config\` HA-discovery payload; \`mqtt.spec\` passes 2/2.

### ⚠️ Workflow wiring pending
The matching \`CodeScanning_E2ECoverage\` steps (E2E — MQTT / equipment-cache / preferences) are **not** in this push — the token lacked \`workflow\` scope. They must be added to \`.github/workflows/automated-codescanning.yml\` for CI to actually run these modes (diff provided by the author).