### PR TITLE
fix(ha-addon): single Serial protocol field + auto device identity (0.12.0-beta.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.12.0-beta.7] - 2026-07-09
+
+Further Home Assistant add-on refinements from real install testing — no changes to the core application.
+
+### Fixed
+
+- **The serial field is visible again.** beta.6 made the serial field optional, which Home Assistant hides from the options form. Serial configuration is now a required **Serial protocol** selector (`usb` / `rfc2217` / `rawtcp`) plus the device or address (`serial_port`), both always shown. `plain` is dropped — it is the same transport as `rawtcp`. See [docs/homeassistant-addon.md](docs/homeassistant-addon.md).
+
+### Added
+
+- **Automatic Home Assistant device identity.** The add-on generates a stable, unique device identifier on first start and persists it under `/data`, so your equipment stays the **same** Home Assistant device across restarts and updates — no `ha-device-id` to configure.
+
 ## [0.12.0-beta.6] - 2026-07-09
 
 Home Assistant add-on refinements from the first real install testing — no changes to the core application. The add-on manifests also moved to the repository root (Home Assistant reads a custom repository from the root).

--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-beta.7
+
+- **Serial is one "Serial protocol" field.** Pick `usb`, `rfc2217`, or `rawtcp`, then enter the device path or `host:port`. Both fields are required, so Home Assistant always shows them (beta.6's optional field was hidden from the form). `plain` is dropped — it is the same transport as `rawtcp`.
+- **Automatic device identity.** A stable, unique Home Assistant device id is generated on first start and stored under `/data`, so your equipment stays the same device across restarts and updates — nothing to configure.
+
 ## 0.12.0-beta.6
 
 - **Serial is now one field.** `serial_port` takes either a device path (`/dev/serial/by-id/…`, or any non-standard path) or a network `host:port`, auto-detected — no more mode selector. This also fixes a "Device '' does not exist" error when saving.

--- a/aqualink-automate-edge/DOCS.md
+++ b/aqualink-automate-edge/DOCS.md
@@ -55,14 +55,15 @@ The `/api/health` liveness endpoint stays open, so the add-on watchdog keeps wor
 
 ### Serial connection
 
-One field — **`serial_port`** — accepts *either* kind of connection, auto-detected:
+Two fields: pick the **`serial_protocol`**, then enter the **`serial_port`** (the device or address):
 
-| You have… | Enter |
+| `serial_protocol` | `serial_port` to enter |
 |---|---|
-| A **local** USB-RS485 adapter | A device path — **prefer `/dev/serial/by-id/usb-…`** (it survives reboots) or `/dev/ttyUSB0`. Non-standard paths work too; just type them. |
-| A **network** serial adapter | Its **`host:port`**, e.g. `192.168.1.50:8899` or `adapter.example.com:9001`. Anything that isn't a `/dev/…` path is treated as a network address. |
+| **`usb`** — a local USB-RS485 adapter or built-in UART | A device path — **prefer `/dev/serial/by-id/usb-…`** (it survives reboots) or `/dev/ttyUSB0`. Non-standard paths work too; just type them. |
+| **`rfc2217`** — a network serial adapter (telnet transport; suits most) | Its **`host:port`**, e.g. `192.168.1.50:8899` or `adapter.example.com:9001`. |
+| **`rawtcp`** — a network serial adapter (plain TCP stream) | Its **`host:port`**, as above. |
 
-`remote_protocol` (`rfc2217` default / `rawtcp` / `plain`) applies only to a network address. USB adapters are mapped into the container automatically (`uart`).
+USB adapters are mapped into the container automatically (`uart`).
 
 *Finding a device path:* **Settings → System → Hardware** lists the host's serial devices, or use the Terminal add-on (`ls -l /dev/serial/by-id/`).
 
@@ -76,6 +77,10 @@ One field — **`serial_port`** — accepts *either* kind of connection, auto-de
 
 With `mqtt_mode: auto` and the Mosquitto add-on running, the add-on discovers the
 broker through the Supervisor — you do **not** enter any MQTT credentials.
+
+The add-on generates a stable, unique Home Assistant device identifier on first start
+and stores it under `/data`, so your equipment stays the **same** device across restarts
+and updates — there is no device ID to configure.
 
 **TLS with certificates.** When the broker uses TLS, place the certificate files in Home
 Assistant's **`/ssl`** share (via Samba / the File editor) and give just the **filename**:

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -10,7 +10,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate (Edge)
-version: "0.12.0-beta.6"
+version: "0.12.0-beta.7"
 slug: aqualink_automate_edge
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -84,11 +84,17 @@ watchdog: "http://[HOST]:8099/api/health"
 # toggle for users who want the app's own versions. Preferences + the equipment
 # cache persist to /data automatically (wired in run.sh), so they are not surfaced.
 # Only REQUIRED fields (no `?` in the schema) carry a default here. Optional (`?`)
-# fields — serial_port, mqtt_host/username/password, the mqtt cert paths, auth_password
-# — MUST NOT have a default (per the HA app schema; an empty-string default on an
-# optional field is what made the device picker reject '').
+# fields — mqtt_host/username/password, the mqtt cert paths, auth_password — MUST NOT
+# have a default (an empty-string default on an OPTIONAL field is what made the old
+# device picker reject ''). The serial fields (serial_protocol + serial_port) are the
+# deliberate exception: they are REQUIRED BECAUSE Home Assistant hides UNUSED optional
+# options from the form — an optional serial field simply doesn't appear, and it is the
+# essential thing to configure. serial_port is a plain `str` (not the `device()` type)
+# with an empty default, so it renders a normal, always-visible text box with no device
+# validation (no '' save error); run.sh rejects an empty value at start.
 options:
-  remote_protocol: rfc2217
+  serial_protocol: usb
+  serial_port: ""
   mqtt_mode: auto
   mqtt_port: 1883
   mqtt_tls: false
@@ -103,14 +109,19 @@ options:
   jandy_device_type: onetouch
   jandy_device_id: "0x41"
 schema:
-  # ONE field, auto-detected in run.sh: a value starting with "/" is a local device
-  # path (--serial-port); anything else is a network address host:port
-  # (--remote-serial-port). Free text so any path (incl. /dev/serial/by-id/...) or a
-  # non-standard device works. uart:true still maps host TTY devices into the container.
-  serial_port: str?
-  # Only applies when serial_port is a network address. rfc2217 -> --rfc2217 ;
-  # rawtcp -> --rawtcp ; plain -> --no-rfc2217.
-  remote_protocol: list(rfc2217|rawtcp|plain)
+  # Serial protocol: ONE explicit choice of how to reach the panel — `usb` for a local
+  # device (--serial-port), or `rfc2217` / `rawtcp` for a serial-to-ethernet adapter
+  # (--remote-serial-port + the matching transport flag). The app has only these two
+  # network transports: rfc2217 (telnet) and raw TCP; `--no-rfc2217` ("plain") is just
+  # another spelling of rawtcp (both set use_rfc2217=false), so it is NOT surfaced.
+  # REQUIRED so Home Assistant always renders it (HA hides UNUSED optional fields).
+  serial_protocol: list(usb|rfc2217|rawtcp)
+  # The device to connect to. For `usb`: a local path (--serial-port) like
+  # /dev/serial/by-id/usb-... (preferred) or /dev/ttyUSB0 (uart:true maps host TTYs in).
+  # For `rfc2217` / `rawtcp`: a host:port (--remote-serial-port). REQUIRED plain `str`
+  # (NOT the `device()` type, so no '' validation error and it is always visible);
+  # run.sh rejects an empty value.
+  serial_port: str
   # auto -> discover the HA broker ; manual -> the fields below ; disabled -> no MQTT
   mqtt_mode: list(auto|manual|disabled)
   mqtt_host: str?

--- a/aqualink-automate-edge/run.sh
+++ b/aqualink-automate-edge/run.sh
@@ -32,25 +32,24 @@ args=("--address" "0.0.0.0" "--http-port" "8099" "--disable-https")
 args+=("--preferences-file" "${DATA}/preferences.json")
 args+=("--equipment-cache-file" "${DATA}/equipment-cache.json")
 
-# ── Serial transport (one field, auto-detected) ────────────────────────────────
-# A value starting with "/" is a local device path (--serial-port); anything else is
-# treated as a network address host:port (--remote-serial-port + the chosen protocol).
-# uart:true maps host TTY devices into the container so /dev/... paths resolve.
+# ── Serial protocol (one explicit choice: usb / rfc2217 / rawtcp) ───────────────
+# serial_protocol picks local (--serial-port) vs a network serial-to-ethernet adapter
+# (--remote-serial-port + the transport flag); serial_port is the device path or
+# host:port. Both are required. uart:true maps host TTY devices into the container so
+# /dev/... paths resolve.
 if ! bashio::config.has_value 'serial_port'; then
-    bashio::exit.nok "serial_port is required — set a device path (e.g. /dev/serial/by-id/...) or a network address (host:port)."
+    bashio::exit.nok "serial_port is required — for USB set the device path (e.g. /dev/serial/by-id/...); for a network adapter set the address (host:port)."
 fi
 serial_port="$(bashio::config 'serial_port')"
-case "${serial_port}" in
-    /*)
+case "$(bashio::config 'serial_protocol')" in
+    usb)
         args+=("--serial-port" "${serial_port}")
         ;;
-    *)
-        args+=("--remote-serial-port" "${serial_port}")
-        case "$(bashio::config 'remote_protocol')" in
-            rfc2217) args+=("--rfc2217") ;;
-            rawtcp)  args+=("--rawtcp") ;;
-            plain)   args+=("--no-rfc2217") ;;
-        esac
+    rfc2217)
+        args+=("--remote-serial-port" "${serial_port}" "--rfc2217")
+        ;;
+    rawtcp)
+        args+=("--remote-serial-port" "${serial_port}" "--rawtcp")
         ;;
 esac
 
@@ -109,7 +108,17 @@ fi
 
 # Home Assistant MQTT discovery rides on top of MQTT (never valid when disabled).
 if [ "${mqtt_mode}" != "disabled" ] && bashio::config.true 'home_assistant_discovery'; then
-    args+=("--home-assistant")
+    # Stable, unique device identity. HA groups all discovered entities under one
+    # device keyed by --ha-device-id. Persist a random id to /data on first boot so it
+    # stays constant across restarts AND add-on updates (unlike anything derived from
+    # the serial endpoint or container state, which would orphan the device on change),
+    # and is unique per install so two add-on instances on one broker never collide.
+    # Regenerates only if /data is wiped (a full uninstall).
+    ha_device_id_file="${DATA}/ha-device-id"
+    if [ ! -s "${ha_device_id_file}" ]; then
+        printf 'aqualink_%s\n' "$(tr -d '-' < /proc/sys/kernel/random/uuid | cut -c1-12)" > "${ha_device_id_file}"
+    fi
+    args+=("--home-assistant" "--ha-device-id" "$(cat "${ha_device_id_file}")")
 fi
 
 # ── History (opt-in; default OFF → use HA's Recorder) ──────────────────────────

--- a/aqualink-automate-edge/translations/en.yaml
+++ b/aqualink-automate-edge/translations/en.yaml
@@ -5,18 +5,19 @@
 # MUST match a field in config.yaml `schema:` — the `Home Assistant Add-on` CI job
 # fails on any missing or extra key.
 configuration:
+  serial_protocol:
+    name: Serial protocol
+    description: >-
+      How Aqualink Automate reaches the panel: "usb" for a local serial device on this
+      host (a USB-RS485 adapter or a built-in UART), or "rfc2217" / "rawtcp" for a
+      serial-to-ethernet adapter on your LAN. "rfc2217" suits most adapters; "rawtcp" is
+      a plain TCP stream. This decides how the address below is used.
   serial_port:
-    name: Serial connection
+    name: Serial device or network address
     description: >-
-      Either a local serial device — a path like /dev/serial/by-id/usb-... (preferred;
-      it survives reboots) or /dev/ttyUSB0 — OR a network serial adapter as host:port
-      (e.g. 192.168.1.50:8899). Anything that isn't a /dev path is treated as a network
-      address. USB adapters are mapped in automatically.
-  remote_protocol:
-    name: Network serial protocol
-    description: >-
-      Only used when the connection above is a network address. "rfc2217" suits most
-      serial-to-ethernet adapters; "rawtcp" for a raw TCP stream; "plain" for a plain socket.
+      For "usb": a local device path — /dev/serial/by-id/usb-... (preferred; it survives
+      reboots) or /dev/ttyUSB0 (USB adapters are mapped in automatically). For "rfc2217"
+      or "rawtcp": the adapter's address as host:port (e.g. 192.168.1.50:8899).
   mqtt_mode:
     name: MQTT mode
     description: >-

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-beta.7
+
+- **Serial is one "Serial protocol" field.** Pick `usb`, `rfc2217`, or `rawtcp`, then enter the device path or `host:port`. Both fields are required, so Home Assistant always shows them (beta.6's optional field was hidden from the form). `plain` is dropped — it is the same transport as `rawtcp`.
+- **Automatic device identity.** A stable, unique Home Assistant device id is generated on first start and stored under `/data`, so your equipment stays the same device across restarts and updates — nothing to configure.
+
 ## 0.12.0-beta.6
 
 - **Serial is now one field.** `serial_port` takes either a device path (`/dev/serial/by-id/…`, or any non-standard path) or a network `host:port`, auto-detected — no more mode selector. This also fixes a "Device '' does not exist" error when saving.

--- a/aqualink-automate/DOCS.md
+++ b/aqualink-automate/DOCS.md
@@ -55,14 +55,15 @@ The `/api/health` liveness endpoint stays open, so the add-on watchdog keeps wor
 
 ### Serial connection
 
-One field — **`serial_port`** — accepts *either* kind of connection, auto-detected:
+Two fields: pick the **`serial_protocol`**, then enter the **`serial_port`** (the device or address):
 
-| You have… | Enter |
+| `serial_protocol` | `serial_port` to enter |
 |---|---|
-| A **local** USB-RS485 adapter | A device path — **prefer `/dev/serial/by-id/usb-…`** (it survives reboots) or `/dev/ttyUSB0`. Non-standard paths work too; just type them. |
-| A **network** serial adapter | Its **`host:port`**, e.g. `192.168.1.50:8899` or `adapter.example.com:9001`. Anything that isn't a `/dev/…` path is treated as a network address. |
+| **`usb`** — a local USB-RS485 adapter or built-in UART | A device path — **prefer `/dev/serial/by-id/usb-…`** (it survives reboots) or `/dev/ttyUSB0`. Non-standard paths work too; just type them. |
+| **`rfc2217`** — a network serial adapter (telnet transport; suits most) | Its **`host:port`**, e.g. `192.168.1.50:8899` or `adapter.example.com:9001`. |
+| **`rawtcp`** — a network serial adapter (plain TCP stream) | Its **`host:port`**, as above. |
 
-`remote_protocol` (`rfc2217` default / `rawtcp` / `plain`) applies only to a network address. USB adapters are mapped into the container automatically (`uart`).
+USB adapters are mapped into the container automatically (`uart`).
 
 *Finding a device path:* **Settings → System → Hardware** lists the host's serial devices, or use the Terminal add-on (`ls -l /dev/serial/by-id/`).
 
@@ -76,6 +77,10 @@ One field — **`serial_port`** — accepts *either* kind of connection, auto-de
 
 With `mqtt_mode: auto` and the Mosquitto add-on running, the add-on discovers the
 broker through the Supervisor — you do **not** enter any MQTT credentials.
+
+The add-on generates a stable, unique Home Assistant device identifier on first start
+and stores it under `/data`, so your equipment stays the **same** device across restarts
+and updates — there is no device ID to configure.
 
 **TLS with certificates.** When the broker uses TLS, place the certificate files in Home
 Assistant's **`/ssl`** share (via Samba / the File editor) and give just the **filename**:

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -82,11 +82,17 @@ watchdog: "http://[HOST]:8099/api/health"
 # toggle for users who want the app's own versions. Preferences + the equipment
 # cache persist to /data automatically (wired in run.sh), so they are not surfaced.
 # Only REQUIRED fields (no `?` in the schema) carry a default here. Optional (`?`)
-# fields — serial_port, mqtt_host/username/password, the mqtt cert paths, auth_password
-# — MUST NOT have a default (per the HA app schema; an empty-string default on an
-# optional field is what made the device picker reject '').
+# fields — mqtt_host/username/password, the mqtt cert paths, auth_password — MUST NOT
+# have a default (an empty-string default on an OPTIONAL field is what made the old
+# device picker reject ''). The serial fields (serial_protocol + serial_port) are the
+# deliberate exception: they are REQUIRED BECAUSE Home Assistant hides UNUSED optional
+# options from the form — an optional serial field simply doesn't appear, and it is the
+# essential thing to configure. serial_port is a plain `str` (not the `device()` type)
+# with an empty default, so it renders a normal, always-visible text box with no device
+# validation (no '' save error); run.sh rejects an empty value at start.
 options:
-  remote_protocol: rfc2217
+  serial_protocol: usb
+  serial_port: ""
   mqtt_mode: auto
   mqtt_port: 1883
   mqtt_tls: false
@@ -101,14 +107,19 @@ options:
   jandy_device_type: onetouch
   jandy_device_id: "0x41"
 schema:
-  # ONE field, auto-detected in run.sh: a value starting with "/" is a local device
-  # path (--serial-port); anything else is a network address host:port
-  # (--remote-serial-port). Free text so any path (incl. /dev/serial/by-id/...) or a
-  # non-standard device works. uart:true still maps host TTY devices into the container.
-  serial_port: str?
-  # Only applies when serial_port is a network address. rfc2217 -> --rfc2217 ;
-  # rawtcp -> --rawtcp ; plain -> --no-rfc2217.
-  remote_protocol: list(rfc2217|rawtcp|plain)
+  # Serial protocol: ONE explicit choice of how to reach the panel — `usb` for a local
+  # device (--serial-port), or `rfc2217` / `rawtcp` for a serial-to-ethernet adapter
+  # (--remote-serial-port + the matching transport flag). The app has only these two
+  # network transports: rfc2217 (telnet) and raw TCP; `--no-rfc2217` ("plain") is just
+  # another spelling of rawtcp (both set use_rfc2217=false), so it is NOT surfaced.
+  # REQUIRED so Home Assistant always renders it (HA hides UNUSED optional fields).
+  serial_protocol: list(usb|rfc2217|rawtcp)
+  # The device to connect to. For `usb`: a local path (--serial-port) like
+  # /dev/serial/by-id/usb-... (preferred) or /dev/ttyUSB0 (uart:true maps host TTYs in).
+  # For `rfc2217` / `rawtcp`: a host:port (--remote-serial-port). REQUIRED plain `str`
+  # (NOT the `device()` type, so no '' validation error and it is always visible);
+  # run.sh rejects an empty value.
+  serial_port: str
   # auto -> discover the HA broker ; manual -> the fields below ; disabled -> no MQTT
   mqtt_mode: list(auto|manual|disabled)
   mqtt_host: str?

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -8,7 +8,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate
-version: "0.12.0-beta.6"
+version: "0.12.0-beta.7"
 slug: aqualink_automate
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/aqualink-automate/run.sh
+++ b/aqualink-automate/run.sh
@@ -32,25 +32,24 @@ args=("--address" "0.0.0.0" "--http-port" "8099" "--disable-https")
 args+=("--preferences-file" "${DATA}/preferences.json")
 args+=("--equipment-cache-file" "${DATA}/equipment-cache.json")
 
-# ── Serial transport (one field, auto-detected) ────────────────────────────────
-# A value starting with "/" is a local device path (--serial-port); anything else is
-# treated as a network address host:port (--remote-serial-port + the chosen protocol).
-# uart:true maps host TTY devices into the container so /dev/... paths resolve.
+# ── Serial protocol (one explicit choice: usb / rfc2217 / rawtcp) ───────────────
+# serial_protocol picks local (--serial-port) vs a network serial-to-ethernet adapter
+# (--remote-serial-port + the transport flag); serial_port is the device path or
+# host:port. Both are required. uart:true maps host TTY devices into the container so
+# /dev/... paths resolve.
 if ! bashio::config.has_value 'serial_port'; then
-    bashio::exit.nok "serial_port is required — set a device path (e.g. /dev/serial/by-id/...) or a network address (host:port)."
+    bashio::exit.nok "serial_port is required — for USB set the device path (e.g. /dev/serial/by-id/...); for a network adapter set the address (host:port)."
 fi
 serial_port="$(bashio::config 'serial_port')"
-case "${serial_port}" in
-    /*)
+case "$(bashio::config 'serial_protocol')" in
+    usb)
         args+=("--serial-port" "${serial_port}")
         ;;
-    *)
-        args+=("--remote-serial-port" "${serial_port}")
-        case "$(bashio::config 'remote_protocol')" in
-            rfc2217) args+=("--rfc2217") ;;
-            rawtcp)  args+=("--rawtcp") ;;
-            plain)   args+=("--no-rfc2217") ;;
-        esac
+    rfc2217)
+        args+=("--remote-serial-port" "${serial_port}" "--rfc2217")
+        ;;
+    rawtcp)
+        args+=("--remote-serial-port" "${serial_port}" "--rawtcp")
         ;;
 esac
 
@@ -109,7 +108,17 @@ fi
 
 # Home Assistant MQTT discovery rides on top of MQTT (never valid when disabled).
 if [ "${mqtt_mode}" != "disabled" ] && bashio::config.true 'home_assistant_discovery'; then
-    args+=("--home-assistant")
+    # Stable, unique device identity. HA groups all discovered entities under one
+    # device keyed by --ha-device-id. Persist a random id to /data on first boot so it
+    # stays constant across restarts AND add-on updates (unlike anything derived from
+    # the serial endpoint or container state, which would orphan the device on change),
+    # and is unique per install so two add-on instances on one broker never collide.
+    # Regenerates only if /data is wiped (a full uninstall).
+    ha_device_id_file="${DATA}/ha-device-id"
+    if [ ! -s "${ha_device_id_file}" ]; then
+        printf 'aqualink_%s\n' "$(tr -d '-' < /proc/sys/kernel/random/uuid | cut -c1-12)" > "${ha_device_id_file}"
+    fi
+    args+=("--home-assistant" "--ha-device-id" "$(cat "${ha_device_id_file}")")
 fi
 
 # ── History (opt-in; default OFF → use HA's Recorder) ──────────────────────────

--- a/aqualink-automate/translations/en.yaml
+++ b/aqualink-automate/translations/en.yaml
@@ -5,18 +5,19 @@
 # MUST match a field in config.yaml `schema:` — the `Home Assistant Add-on` CI job
 # fails on any missing or extra key.
 configuration:
+  serial_protocol:
+    name: Serial protocol
+    description: >-
+      How Aqualink Automate reaches the panel: "usb" for a local serial device on this
+      host (a USB-RS485 adapter or a built-in UART), or "rfc2217" / "rawtcp" for a
+      serial-to-ethernet adapter on your LAN. "rfc2217" suits most adapters; "rawtcp" is
+      a plain TCP stream. This decides how the address below is used.
   serial_port:
-    name: Serial connection
+    name: Serial device or network address
     description: >-
-      Either a local serial device — a path like /dev/serial/by-id/usb-... (preferred;
-      it survives reboots) or /dev/ttyUSB0 — OR a network serial adapter as host:port
-      (e.g. 192.168.1.50:8899). Anything that isn't a /dev path is treated as a network
-      address. USB adapters are mapped in automatically.
-  remote_protocol:
-    name: Network serial protocol
-    description: >-
-      Only used when the connection above is a network address. "rfc2217" suits most
-      serial-to-ethernet adapters; "rawtcp" for a raw TCP stream; "plain" for a plain socket.
+      For "usb": a local device path — /dev/serial/by-id/usb-... (preferred; it survives
+      reboots) or /dev/ttyUSB0 (USB adapters are mapped in automatically). For "rfc2217"
+      or "rawtcp": the adapter's address as host:port (e.g. 192.168.1.50:8899).
   mqtt_mode:
     name: MQTT mode
     description: >-

--- a/docs/homeassistant-addon.md
+++ b/docs/homeassistant-addon.md
@@ -49,15 +49,19 @@ release exists yet, so both are marked experimental and track the newest release
 The options form maps directly onto the application's settings (full reference:
 [Configuration reference](configuration.md)). Key choices:
 
-- **Serial** — one `serial_port` field, auto-detected: a **device path** (`/dev/serial/by-id/…`,
-  preferred; or any non-standard path) maps to `--serial-port`, while a **`host:port`**
-  is treated as a network adapter (`--remote-serial-port`) with `remote_protocol`
-  (`rfc2217` / `rawtcp` / `plain`).
+- **Serial** — pick the **protocol** (`serial_protocol`): **`usb`** for a local device
+  (a USB-RS485 adapter or a built-in UART → `--serial-port`), or **`rfc2217`** / **`rawtcp`**
+  for a serial-to-ethernet adapter (→ `--remote-serial-port` with the matching transport;
+  `rfc2217` suits most adapters, `rawtcp` is a plain TCP stream). Then set the **device or
+  address** (`serial_port`): a path (`/dev/serial/by-id/…`, preferred; or any non-standard
+  path) for `usb`, or a **`host:port`** for the network protocols.
 - **MQTT** — `mqtt_mode: auto` (recommended) discovers the broker Home Assistant already
   uses (e.g. the Mosquitto add-on) through the Supervisor, so you enter **no** MQTT
   credentials. `manual` exposes the broker fields; `disabled` turns MQTT off.
   `home_assistant_discovery` publishes auto-discovery so your equipment appears as
-  Home Assistant entities.
+  Home Assistant entities. A stable, unique device identifier is generated automatically
+  on first start and persisted under `/data`, so your equipment stays the **same** Home
+  Assistant device across restarts and add-on updates (no `ha-device-id` to set).
 - **Web UI** — served through Home Assistant **ingress**: it appears in the sidebar and
   via **Open Web UI**, secured by your Home Assistant login and **not exposed on the
   LAN**. Because ingress provides authentication, the app's own auth is left off. For


### PR DESCRIPTION
Home Assistant add-on refinements from real HAOS install testing. **No core application changes** — add-on wrapper only.

## Changes
- **Serial is one required `serial_protocol` field** (`usb` / `rfc2217` / `rawtcp`) + the `serial_port` device/address box. Fixes beta.6's serial field being *hidden* (HA collapses unused optional options; it was `str?`). Both fields required → always rendered. `run.sh` switches on the protocol instead of guessing from a leading `/`.
- **Dropped `plain`** — verified in `aqualink-automate.cpp` that `--no-rfc2217` ("plain") just sets `use_rfc2217=false`, identical to `--rawtcp`; not a distinct transport.
- **Automatic HA device identity** — `run.sh` persists a random `--ha-device-id` (`aqualink_<12hex>`) to `/data` on first boot when discovery is on: stable across restarts/updates, unique per install, not serial-derived (a serial hash would orphan the HA device when the adapter changes).
- Bumped both channels to `0.12.0-beta.7`; updated en.yaml, DOCS.md, docs, CHANGELOGs; edge regenerated (drift-free).

## Validation
- `run.sh` harness (real script, live `/data`, container): 15/15 — protocol→flags mapping, device-id created + **stable across restarts** + format, empty-port fail-fast.
- schema↔translation parity 22/22 both channels; `bash -n` clean; version lock-step guard (edge = 0.12.0-beta.7) passes.