### PR TITLE
fix(homeassistant-addon): auto Jandy emulation + manual MQTT broker fields (0.12.0-beta.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.12.0-beta.8] - 2026-07-12
+
+More Home Assistant add-on fixes from real install testing — no changes to the core application.
+
+### Fixed
+
+- **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) are now shown in the options form. Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously offered nowhere to enter the broker. The add-on now also fails fast with a clear message if the host is left blank in manual mode. See [docs/homeassistant-addon.md](docs/homeassistant-addon.md).
+
+### Changed
+
+- **Jandy emulation defaults to `auto`.** `jandy_device_type` now defaults to `auto`, standing up the app's full default device set (OneTouch + IAQ + Serial Adapter) instead of forcing a single OneTouch device — the previous default suppressed IAQ status and Serial Adapter commands. Choose a specific type to restrict emulation to one device; `jandy_device_id` becomes an optional per-type bus-address override (blank uses the type's default, e.g. OneTouch → 0x41).
+
 ## [0.12.0-beta.7] - 2026-07-09
 
 Further Home Assistant add-on refinements from real install testing — no changes to the core application.

--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-beta.8
+
+- **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.
+- **Jandy emulation defaults to `auto`.** `jandy_device_type` now defaults to `auto`, standing up the full default device set (OneTouch + IAQ + Serial Adapter) instead of a single OneTouch device (which suppressed IAQ status and Serial Adapter commands). Pick a specific type to restrict emulation to one device; `jandy_device_id` is now an optional per-type bus-address override (blank = the type's default, e.g. OneTouch → 0x41).
+
 ## 0.12.0-beta.7
 
 - **Serial is one "Serial protocol" field.** Pick `usb`, `rfc2217`, or `rawtcp`, then enter the device path or `host:port`. Both fields are required, so Home Assistant always shows them (beta.6's optional field was hidden from the form). `plain` is dropped — it is the same transport as `rawtcp`.

--- a/aqualink-automate-edge/DOCS.md
+++ b/aqualink-automate-edge/DOCS.md
@@ -107,7 +107,8 @@ only if you want the app's own version (it is then persisted under `/data`):
 |---|---|
 | `log_level` | `info` (default), `debug`, or `trace`. Logs appear in the add-on's **Log** tab. |
 | `pool_configuration` | `auto` (default), or force `pool-only` / `spa-only` / `combo` / `dual`. |
-| `jandy_device_type`, `jandy_device_id` | Advanced: the identity the software presents on the RS-485 bus. Defaults suit most panels. |
+| `jandy_device_type` | Advanced: what the software emulates on the bus. `auto` (default) stands up the full default set — OneTouch + IAQ + Serial Adapter — and suits most panels. Choose a single type only to restrict emulation to that one device. |
+| `jandy_device_id` | Advanced: optional bus-address override for a single chosen type. Blank uses the type's default (OneTouch → 0x41); ignored when the type is `auto`. |
 
 Your UI preferences and an equipment cache (for an instant dashboard after a restart)
 are always persisted under `/data` — no configuration needed.

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -10,7 +10,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate (Edge)
-version: "0.12.0-beta.7"
+version: "0.12.0-beta.8"
 slug: aqualink_automate_edge
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -83,20 +83,27 @@ watchdog: "http://[HOST]:8099/api/health"
 # and the scheduler are off (use HA's Recorder and automations); each is an opt-in
 # toggle for users who want the app's own versions. Preferences + the equipment
 # cache persist to /data automatically (wired in run.sh), so they are not surfaced.
-# Only REQUIRED fields (no `?` in the schema) carry a default here. Optional (`?`)
-# fields — mqtt_host/username/password, the mqtt cert paths, auth_password — MUST NOT
-# have a default (an empty-string default on an OPTIONAL field is what made the old
-# device picker reject ''). The serial fields (serial_protocol + serial_port) are the
-# deliberate exception: they are REQUIRED BECAUSE Home Assistant hides UNUSED optional
-# options from the form — an optional serial field simply doesn't appear, and it is the
-# essential thing to configure. serial_port is a plain `str` (not the `device()` type)
-# with an empty default, so it renders a normal, always-visible text box with no device
-# validation (no '' save error); run.sh rejects an empty value at start.
+# Most fields carry a default here, but the real driver is VISIBILITY: Home Assistant
+# hides from the options form any schema field that is NOT listed in this block — so an
+# option a user must be able to reach has to appear here, even an optional one. That is
+# why the manual MQTT broker fields (mqtt_host/username/password) are surfaced with empty
+# defaults: without them the form offers no place to enter a broker when mqtt_mode=manual.
+# Empty defaults are safe on these because they are plain `str`/`password`, not the
+# `device()` type — a `device()` picker is what rejected an empty-string default in the
+# old serial field. mqtt_host is required in manual mode (run.sh rejects an empty host
+# there); username/password stay genuinely optional and are only sent when set. The serial
+# fields follow the same reasoning: serial_port is a plain `str` with an empty default so
+# it always renders, and run.sh rejects an empty value at start. Fields deliberately left
+# OUT of this block (the TLS cert paths, auth_password) stay hidden until their feature is
+# turned on — set those via the YAML editor.
 options:
   serial_protocol: usb
   serial_port: ""
   mqtt_mode: auto
+  mqtt_host: ""
   mqtt_port: 1883
+  mqtt_username: ""
+  mqtt_password: ""
   mqtt_tls: false
   mqtt_tls_skip_verify: false
   home_assistant_discovery: true
@@ -106,8 +113,8 @@ options:
   enable_history: false
   enable_scheduler: false
   pool_configuration: auto
-  jandy_device_type: onetouch
-  jandy_device_id: "0x41"
+  jandy_device_type: auto
+  jandy_device_id: ""
 schema:
   # Serial protocol: ONE explicit choice of how to reach the panel — `usb` for a local
   # device (--serial-port), or `rfc2217` / `rawtcp` for a serial-to-ethernet adapter
@@ -124,7 +131,10 @@ schema:
   serial_port: str
   # auto -> discover the HA broker ; manual -> the fields below ; disabled -> no MQTT
   mqtt_mode: list(auto|manual|disabled)
-  mqtt_host: str?
+  # Broker host for manual mode. Plain `str` (surfaced with an empty default in `options`
+  # so the form always shows it); run.sh rejects an empty value when mqtt_mode=manual and
+  # ignores it otherwise.
+  mqtt_host: str
   mqtt_port: port
   mqtt_username: str?
   mqtt_password: password?
@@ -150,5 +160,12 @@ schema:
   enable_scheduler: bool
   # Advanced (defaults suit most installs).
   pool_configuration: list(auto|pool-only|spa-only|combo|dual)
-  jandy_device_type: str
-  jandy_device_id: str
+  # `auto` (default) emulates the app's full default device set — OneTouch (menu
+  # scraping) + IAQ (status) + SerialAdapter (commands) — by omitting --jandy-device-type
+  # entirely. Pick a single type to restrict emulation to just that device (e.g.
+  # `onetouch`). run.sh maps `auto` to "no flag".
+  jandy_device_type: list(auto|onetouch|iaq|pda|rs_keypad|serialadapter)
+  # Optional bus-address override for a single chosen type. Leave blank to use that
+  # type's default instance (OneTouch -> 0x41, IAQ -> 0xA1, ...). Ignored when
+  # jandy_device_type is `auto`.
+  jandy_device_id: str?

--- a/aqualink-automate-edge/run.sh
+++ b/aqualink-automate-edge/run.sh
@@ -55,8 +55,17 @@ esac
 
 # ── Equipment / Jandy (advanced) ───────────────────────────────────────────────
 args+=("--pool-configuration" "$(bashio::config 'pool_configuration')")
-args+=("--jandy-device-type" "$(bashio::config 'jandy_device_type')")
-args+=("--jandy-device-id" "$(bashio::config 'jandy_device_id')")
+# jandy_device_type=auto (default): omit --jandy-device-type so the app stands up its
+# full default emulation set (OneTouch + IAQ + SerialAdapter). A specific type restricts
+# emulation to that one device; jandy_device_id optionally overrides its bus address
+# (blank = the type's default, e.g. OneTouch -> 0x41).
+jandy_device_type="$(bashio::config 'jandy_device_type')"
+if [ "${jandy_device_type}" != "auto" ]; then
+    args+=("--jandy-device-type" "${jandy_device_type}")
+    if bashio::config.has_value 'jandy_device_id'; then
+        args+=("--jandy-device-id" "$(bashio::config 'jandy_device_id')")
+    fi
+fi
 
 # ── MQTT ───────────────────────────────────────────────────────────────────────
 mqtt_mode="$(bashio::config 'mqtt_mode')"
@@ -77,6 +86,9 @@ if [ "${mqtt_mode}" = "auto" ]; then
         bashio::log.warning "mqtt_mode=auto but no MQTT service is available; running without MQTT."
     fi
 elif [ "${mqtt_mode}" = "manual" ]; then
+    if ! bashio::config.has_value 'mqtt_host'; then
+        bashio::exit.nok "mqtt_mode is 'manual' but mqtt_host is empty — enter the broker hostname or IP (or switch mqtt_mode to 'auto' to use the Home Assistant broker)."
+    fi
     args+=("--mqtt" "--mqtt-host" "$(bashio::config 'mqtt_host')" "--mqtt-port" "$(bashio::config 'mqtt_port')")
     if bashio::config.has_value 'mqtt_username'; then
         args+=("--mqtt-username" "$(bashio::config 'mqtt_username')")

--- a/aqualink-automate-edge/translations/en.yaml
+++ b/aqualink-automate-edge/translations/en.yaml
@@ -101,12 +101,14 @@ configuration:
   jandy_device_type:
     name: Jandy device type (advanced)
     description: >-
-      The device the software emulates on the RS-485 bus. The default suits most
-      panels — change only if you know you need to.
+      What the software emulates on the RS-485 bus. "auto" (default, recommended) stands
+      up the full default set — OneTouch, IAQ, and Serial Adapter — which suits most
+      panels. Pick a single type (e.g. "onetouch") only to restrict emulation to that one
+      device.
   jandy_device_id:
     name: Jandy device ID (advanced)
     description: >-
-      The bus address the software presents (e.g. 0x41). The default suits most
-      panels — change only if you know you need to.
+      Optional bus address for a single chosen device type (e.g. 0x41). Leave blank to
+      use that type's default, and ignored entirely when the type is "auto".
 network:
   8099/tcp: Optional direct web UI / HTTP API on your LAN (unauthenticated unless you enable the login option)

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-beta.8
+
+- **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.
+- **Jandy emulation defaults to `auto`.** `jandy_device_type` now defaults to `auto`, standing up the full default device set (OneTouch + IAQ + Serial Adapter) instead of a single OneTouch device (which suppressed IAQ status and Serial Adapter commands). Pick a specific type to restrict emulation to one device; `jandy_device_id` is now an optional per-type bus-address override (blank = the type's default, e.g. OneTouch → 0x41).
+
 ## 0.12.0-beta.7
 
 - **Serial is one "Serial protocol" field.** Pick `usb`, `rfc2217`, or `rawtcp`, then enter the device path or `host:port`. Both fields are required, so Home Assistant always shows them (beta.6's optional field was hidden from the form). `plain` is dropped — it is the same transport as `rawtcp`.

--- a/aqualink-automate/DOCS.md
+++ b/aqualink-automate/DOCS.md
@@ -107,7 +107,8 @@ only if you want the app's own version (it is then persisted under `/data`):
 |---|---|
 | `log_level` | `info` (default), `debug`, or `trace`. Logs appear in the add-on's **Log** tab. |
 | `pool_configuration` | `auto` (default), or force `pool-only` / `spa-only` / `combo` / `dual`. |
-| `jandy_device_type`, `jandy_device_id` | Advanced: the identity the software presents on the RS-485 bus. Defaults suit most panels. |
+| `jandy_device_type` | Advanced: what the software emulates on the bus. `auto` (default) stands up the full default set — OneTouch + IAQ + Serial Adapter — and suits most panels. Choose a single type only to restrict emulation to that one device. |
+| `jandy_device_id` | Advanced: optional bus-address override for a single chosen type. Blank uses the type's default (OneTouch → 0x41); ignored when the type is `auto`. |
 
 Your UI preferences and an equipment cache (for an instant dashboard after a restart)
 are always persisted under `/data` — no configuration needed.

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -81,20 +81,27 @@ watchdog: "http://[HOST]:8099/api/health"
 # and the scheduler are off (use HA's Recorder and automations); each is an opt-in
 # toggle for users who want the app's own versions. Preferences + the equipment
 # cache persist to /data automatically (wired in run.sh), so they are not surfaced.
-# Only REQUIRED fields (no `?` in the schema) carry a default here. Optional (`?`)
-# fields — mqtt_host/username/password, the mqtt cert paths, auth_password — MUST NOT
-# have a default (an empty-string default on an OPTIONAL field is what made the old
-# device picker reject ''). The serial fields (serial_protocol + serial_port) are the
-# deliberate exception: they are REQUIRED BECAUSE Home Assistant hides UNUSED optional
-# options from the form — an optional serial field simply doesn't appear, and it is the
-# essential thing to configure. serial_port is a plain `str` (not the `device()` type)
-# with an empty default, so it renders a normal, always-visible text box with no device
-# validation (no '' save error); run.sh rejects an empty value at start.
+# Most fields carry a default here, but the real driver is VISIBILITY: Home Assistant
+# hides from the options form any schema field that is NOT listed in this block — so an
+# option a user must be able to reach has to appear here, even an optional one. That is
+# why the manual MQTT broker fields (mqtt_host/username/password) are surfaced with empty
+# defaults: without them the form offers no place to enter a broker when mqtt_mode=manual.
+# Empty defaults are safe on these because they are plain `str`/`password`, not the
+# `device()` type — a `device()` picker is what rejected an empty-string default in the
+# old serial field. mqtt_host is required in manual mode (run.sh rejects an empty host
+# there); username/password stay genuinely optional and are only sent when set. The serial
+# fields follow the same reasoning: serial_port is a plain `str` with an empty default so
+# it always renders, and run.sh rejects an empty value at start. Fields deliberately left
+# OUT of this block (the TLS cert paths, auth_password) stay hidden until their feature is
+# turned on — set those via the YAML editor.
 options:
   serial_protocol: usb
   serial_port: ""
   mqtt_mode: auto
+  mqtt_host: ""
   mqtt_port: 1883
+  mqtt_username: ""
+  mqtt_password: ""
   mqtt_tls: false
   mqtt_tls_skip_verify: false
   home_assistant_discovery: true
@@ -104,8 +111,8 @@ options:
   enable_history: false
   enable_scheduler: false
   pool_configuration: auto
-  jandy_device_type: onetouch
-  jandy_device_id: "0x41"
+  jandy_device_type: auto
+  jandy_device_id: ""
 schema:
   # Serial protocol: ONE explicit choice of how to reach the panel — `usb` for a local
   # device (--serial-port), or `rfc2217` / `rawtcp` for a serial-to-ethernet adapter
@@ -122,7 +129,10 @@ schema:
   serial_port: str
   # auto -> discover the HA broker ; manual -> the fields below ; disabled -> no MQTT
   mqtt_mode: list(auto|manual|disabled)
-  mqtt_host: str?
+  # Broker host for manual mode. Plain `str` (surfaced with an empty default in `options`
+  # so the form always shows it); run.sh rejects an empty value when mqtt_mode=manual and
+  # ignores it otherwise.
+  mqtt_host: str
   mqtt_port: port
   mqtt_username: str?
   mqtt_password: password?
@@ -148,5 +158,12 @@ schema:
   enable_scheduler: bool
   # Advanced (defaults suit most installs).
   pool_configuration: list(auto|pool-only|spa-only|combo|dual)
-  jandy_device_type: str
-  jandy_device_id: str
+  # `auto` (default) emulates the app's full default device set — OneTouch (menu
+  # scraping) + IAQ (status) + SerialAdapter (commands) — by omitting --jandy-device-type
+  # entirely. Pick a single type to restrict emulation to just that device (e.g.
+  # `onetouch`). run.sh maps `auto` to "no flag".
+  jandy_device_type: list(auto|onetouch|iaq|pda|rs_keypad|serialadapter)
+  # Optional bus-address override for a single chosen type. Leave blank to use that
+  # type's default instance (OneTouch -> 0x41, IAQ -> 0xA1, ...). Ignored when
+  # jandy_device_type is `auto`.
+  jandy_device_id: str?

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -8,7 +8,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate
-version: "0.12.0-beta.7"
+version: "0.12.0-beta.8"
 slug: aqualink_automate
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/aqualink-automate/run.sh
+++ b/aqualink-automate/run.sh
@@ -55,8 +55,17 @@ esac
 
 # ── Equipment / Jandy (advanced) ───────────────────────────────────────────────
 args+=("--pool-configuration" "$(bashio::config 'pool_configuration')")
-args+=("--jandy-device-type" "$(bashio::config 'jandy_device_type')")
-args+=("--jandy-device-id" "$(bashio::config 'jandy_device_id')")
+# jandy_device_type=auto (default): omit --jandy-device-type so the app stands up its
+# full default emulation set (OneTouch + IAQ + SerialAdapter). A specific type restricts
+# emulation to that one device; jandy_device_id optionally overrides its bus address
+# (blank = the type's default, e.g. OneTouch -> 0x41).
+jandy_device_type="$(bashio::config 'jandy_device_type')"
+if [ "${jandy_device_type}" != "auto" ]; then
+    args+=("--jandy-device-type" "${jandy_device_type}")
+    if bashio::config.has_value 'jandy_device_id'; then
+        args+=("--jandy-device-id" "$(bashio::config 'jandy_device_id')")
+    fi
+fi
 
 # ── MQTT ───────────────────────────────────────────────────────────────────────
 mqtt_mode="$(bashio::config 'mqtt_mode')"
@@ -77,6 +86,9 @@ if [ "${mqtt_mode}" = "auto" ]; then
         bashio::log.warning "mqtt_mode=auto but no MQTT service is available; running without MQTT."
     fi
 elif [ "${mqtt_mode}" = "manual" ]; then
+    if ! bashio::config.has_value 'mqtt_host'; then
+        bashio::exit.nok "mqtt_mode is 'manual' but mqtt_host is empty — enter the broker hostname or IP (or switch mqtt_mode to 'auto' to use the Home Assistant broker)."
+    fi
     args+=("--mqtt" "--mqtt-host" "$(bashio::config 'mqtt_host')" "--mqtt-port" "$(bashio::config 'mqtt_port')")
     if bashio::config.has_value 'mqtt_username'; then
         args+=("--mqtt-username" "$(bashio::config 'mqtt_username')")

--- a/aqualink-automate/translations/en.yaml
+++ b/aqualink-automate/translations/en.yaml
@@ -101,12 +101,14 @@ configuration:
   jandy_device_type:
     name: Jandy device type (advanced)
     description: >-
-      The device the software emulates on the RS-485 bus. The default suits most
-      panels — change only if you know you need to.
+      What the software emulates on the RS-485 bus. "auto" (default, recommended) stands
+      up the full default set — OneTouch, IAQ, and Serial Adapter — which suits most
+      panels. Pick a single type (e.g. "onetouch") only to restrict emulation to that one
+      device.
   jandy_device_id:
     name: Jandy device ID (advanced)
     description: >-
-      The bus address the software presents (e.g. 0x41). The default suits most
-      panels — change only if you know you need to.
+      Optional bus address for a single chosen device type (e.g. 0x41). Leave blank to
+      use that type's default, and ignored entirely when the type is "auto".
 network:
   8099/tcp: Optional direct web UI / HTTP API on your LAN (unauthenticated unless you enable the login option)

--- a/docs/design/homeassistant-addon.md
+++ b/docs/design/homeassistant-addon.md
@@ -185,7 +185,9 @@ Assembled by `aqualink-automate/run.sh` (bashio → argv → the base image's
 | `log_level` | `--debug` / `--trace` (else default) | Console sink → the add-on Log tab. |
 | `enable_history` | `--history-db /data/history.db` (else off) | Off by default → HA Recorder. |
 | `enable_scheduler` | `--schedules-file /data/schedules.json` (else off) | Off by default → HA automations. |
-| `pool_configuration`, `jandy_device_type`, `jandy_device_id` | `--pool-configuration` / `--jandy-device-*` | Advanced; defaults suit most. |
+| `pool_configuration` | `--pool-configuration` | Advanced; default `auto`. |
+| `jandy_device_type` = `auto` | _(no flag)_ | Default — app stands up its full default emulation set (OneTouch + IAQ + SerialAdapter). |
+| `jandy_device_type` = a single type (+ optional `jandy_device_id`) | `--jandy-device-type <type>` (+ `--jandy-device-id`) | Restricts emulation to one device; blank id → the type's default (OneTouch → 0x41). |
 | _(not surfaced)_ | `--preferences-file /data/preferences.json`, `--equipment-cache-file /data/equipment-cache.json` | Always persisted to `/data`. |
 | _(not surfaced)_ | `MATTER_ENABLED=false`, `PUID/PGID=0`, `--address 0.0.0.0 --http-port 80 --disable-https` | Fixed by the add-on. Auth stays off — ingress authenticates. |
 

--- a/homeassistant/dev/options.json
+++ b/homeassistant/dev/options.json
@@ -12,6 +12,6 @@
   "enable_history": false,
   "enable_scheduler": false,
   "pool_configuration": "auto",
-  "jandy_device_type": "onetouch",
-  "jandy_device_id": "0x41"
+  "jandy_device_type": "auto",
+  "jandy_device_id": ""
 }


### PR DESCRIPTION
Home Assistant add-on fixes surfaced from real install testing (no core app changes), released as 0.12.0-beta.8.

## Fixed
- **Manual MQTT mode is configurable again.** `mqtt_host` / `mqtt_username` / `mqtt_password` are now surfaced in the options form (Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker), and an empty host in manual mode is rejected with a clear message.

## Changed
- **Jandy emulation defaults to `auto`.** `jandy_device_type` now defaults to `auto`, standing up the app's full default device set (OneTouch + IAQ + Serial Adapter) instead of forcing a single OneTouch device (which suppressed IAQ status and Serial Adapter commands). A specific type restricts emulation to one device; `jandy_device_id` becomes an optional per-type bus-address override.

## Release
- `chore(release)`: bumps both add-on channels to `0.12.0-beta.8` + CHANGELOG entries. Edge regenerated (no drift); version lock-step verified.
