### PR TITLE
ci: auto-merge routine Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,11 @@ jobs:
   # Enforce the branch naming convention on every PR. Branches must be
   # <type>/<name> with an allowed Conventional Commit type (see CONTRIBUTING.md).
   # develop/main are accepted as PR heads so the develop->main release-promotion
-  # PR (head_ref == develop) is never blocked. This "Branch Name" check is a
-  # required status check on develop/main, so a misnamed branch cannot merge. (A
+  # PR (head_ref == develop) is never blocked, and dependabot/** is accepted
+  # because Dependabot's branch names are not configurable (and this check being
+  # required would otherwise permanently block every Dependabot PR — see the
+  # dependabot-auto-merge workflow). This "Branch Name" check is a required
+  # status check on develop/main, so a misnamed branch cannot merge. (A
   # server-side branch-name ruleset would also block at push/creation time, but
   # that rule type needs a GitHub organization plan — unavailable on a user repo.)
   branch-name:
@@ -93,6 +96,10 @@ jobs:
         run: |
           if [[ "$HEAD_REF" == "develop" || "$HEAD_REF" == "main" ]]; then
             echo "Core branch '$HEAD_REF' — allowed (release promotion)."
+            exit 0
+          fi
+          if [[ "$HEAD_REF" == dependabot/* ]]; then
+            echo "Dependabot branch '$HEAD_REF' — allowed (branch names are not configurable)."
             exit 0
           fi
           pattern='^(feat|fix|docs|ci|test|refactor|chore|build|perf)/[a-z0-9._-]+$'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+# Enable GitHub auto-merge on routine Dependabot PRs so grouped dependency bumps
+# land on develop without manual intervention.
+#
+# How it works: this job only flips the PR's auto-merge bit — GitHub itself then
+# merges (squash) once every REQUIRED status check passes. The required checks on
+# develop are "Branch Name" (which exempts dependabot/** heads — Dependabot's
+# branch names are not configurable) and the aggregated "CI Status", so nothing
+# merges without the full build/test matrix going green. Non-required checks
+# (e.g. SonarCloud, which cannot pass on Dependabot PRs — Dependabot-triggered
+# runs receive Dependabot secrets, not repo secrets like SONAR_TOKEN) do not
+# block it.
+#
+# Scope: only non-major updates auto-merge. For grouped PRs fetch-metadata
+# reports the HIGHEST bump in the group, so a group containing any semver-major
+# update stays open for manual review; digest-only bumps (the docker group's
+# pinned base images) report no semver level and auto-merge. The squash commit
+# takes the PR title, which is already Conventional-Commit shaped via the
+# commit-message prefixes in .github/dependabot.yml.
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'iainchesworth/aqualink-automate'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge (non-major updates only)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git switch -c fix/heater-setpoint-decode  # a bug fix
 
 This convention is checked automatically:
 
-- A **Branch Name** check runs on every pull request and fails a non-conforming head branch (`.github/workflows/ci.yml`). `develop` and `main` are accepted as heads so the `develop` -> `main` release-promotion PR is never blocked. It is a [required status check](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) on `develop` and `main`, so a non-conforming branch cannot merge.
+- A **Branch Name** check runs on every pull request and fails a non-conforming head branch (`.github/workflows/ci.yml`). `develop` and `main` are accepted as heads so the `develop` -> `main` release-promotion PR is never blocked, and `dependabot/**` heads are accepted because Dependabot's branch names are not configurable. It is a [required status check](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) on `develop` and `main`, so a non-conforming branch cannot merge.
 - Push/creation-time enforcement (a server-side branch-name **ruleset**) is a GitHub organization feature and is not available on this user-owned repository, so a misnamed branch can exist locally — it just fails CI and, once the check is required, cannot merge.
 
 Continuous integration builds on a `push` only to the long-lived branches `main` and `develop`. Feature branches build via their **pull request** into `develop`/`main` instead — so a work-in-progress push to a branch that has no open PR runs no CI (see `.github/workflows/ci.yml`).

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,7 +4,7 @@
 
 ## Workflow set
 
-The pipeline is nine workflow files plus two composite actions, all under `.github/`.
+The pipeline is ten workflow files plus two composite actions, all under `.github/`.
 
 | File | Kind | Purpose |
 |------|------|---------|
@@ -17,6 +17,7 @@ The pipeline is nine workflow files plus two composite actions, all under `.gith
 | `.github/workflows/osv-scanner.yml` | Workflow | OSV-Scanner CVE check of declared dependencies, incl. the vcpkg C++ manifest → Security tab. |
 | `.github/workflows/scorecard.yml` | Workflow | OpenSSF Scorecard supply-chain posture grade → Security tab. |
 | `.github/workflows/fuzzing.yml` | Workflow | Bounded libFuzzer run over the RS-485 protocol decoders on a weekly cron + decoder-touching PRs. Feeds Scorecard's Fuzzing check. See [fuzzing.md](fuzzing.md). |
+| `.github/workflows/dependabot-auto-merge.yml` | Workflow | Flags non-major Dependabot PRs for GitHub auto-merge; they land on `develop` once the required checks pass. |
 | `.github/actions/setup-cpp-toolchain` | Composite action | Install the platform-appropriate compiler and build tools. |
 | `.github/actions/setup-vcpkg-cache` | Composite action | Configure and restore the OS-keyed vcpkg binary cache. |
 
@@ -44,7 +45,7 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 
 | Job | Runs on | What it does |
 |-----|---------|--------------|
-| `branch-name` | `ubuntu-latest` | PR only. Validates the PR head branch matches `<type>/<name>` with an allowed commit type, failing a non-conforming name. `develop`/`main` heads are accepted so the `develop` -> `main` release-promotion PR passes. A **required** status check on `develop`/`main`, so a misnamed branch cannot merge. |
+| `branch-name` | `ubuntu-latest` | PR only. Validates the PR head branch matches `<type>/<name>` with an allowed commit type, failing a non-conforming name. `develop`/`main` heads are accepted so the `develop` -> `main` release-promotion PR passes, and `dependabot/**` heads are accepted because Dependabot's branch names are not configurable (see [Dependabot auto-merge](#dependabot-auto-merge-dependabot-auto-mergeyml)). A **required** status check on `develop`/`main`, so a misnamed branch cannot merge. |
 | `build-and-test` | Per-OS matrix (see [_build.yml](#_buildyml)) | Calls `_build.yml` with no packaging. Configures, builds, and runs the full test suite on Linux, Windows, and macOS. |
 | `e2e-ui` | Linux | Builds only the app binary, then runs the Playwright UI suite once per mode (see the mode table below). |
 | `matter-bridge` | Linux | Node job in `matter-bridge/`: `npm ci`, typecheck (including the matter.js bridge), build, and unit tests. |
@@ -252,6 +253,15 @@ This workflow keeps the Actions cache from filling up with stale per-PR entries.
 
 - **Trigger:** `pull_request` with `types: [closed]`.
 - **Action:** On `ubuntu-latest` with `actions: write`, it installs the `gh-actions-cache` extension and deletes every cache key scoped to the closed PR's merge ref (`refs/pull/<number>/merge`). Deletion failures do not fail the workflow.
+
+## Dependabot auto-merge (dependabot-auto-merge.yml)
+
+Routine dependency bumps merge themselves. `.github/dependabot.yml` raises one grouped weekly PR per ecosystem (GitHub Actions, npm root, npm `matter-bridge/`, Docker digests) against `develop`; `dependabot-auto-merge.yml` runs on each Dependabot PR and — for non-major updates — enables GitHub **auto-merge** (squash) via `gh pr merge --auto`. GitHub then performs the merge only once every **required** status check passes ("Branch Name", which exempts `dependabot/**` heads, and the aggregated "CI Status"), so nothing lands without the full build/test matrix going green.
+
+- **Major bumps stay manual.** `dependabot/fetch-metadata` reports the *highest* update type in a grouped PR, so any group containing a semver-major update is left open for review. Digest-only bumps (the Docker group) carry no semver level and auto-merge.
+- **SonarCloud is expected to fail on Dependabot PRs** (Dependabot-triggered runs receive Dependabot secrets, not repo secrets such as `SONAR_TOKEN`). It is not a required check, so it does not hold up the merge.
+- The squash commit takes the PR title, which Dependabot already emits in Conventional Commit form (`ci:`/`build:` prefixes configured in `.github/dependabot.yml`).
+- Requires the repository setting **Allow auto-merge** (Settings > General > Pull Requests), which is enabled on this repo.
 
 ## Self-hosted runners
 


### PR DESCRIPTION
## Summary

Dependabot's grouped weekly PRs could never merge on their own: the required **Branch Name** check rejects `dependabot/**` heads (Dependabot's branch names are not configurable), so every bump needed a manual admin-merge.

- **ci.yml** — exempt `dependabot/**` heads from the Branch Name check (alongside the existing `develop`/`main` release-promotion exemption).
- **dependabot-auto-merge.yml** (new) — on each Dependabot PR, enables GitHub auto-merge (squash) for non-major updates using `dependabot/fetch-metadata` (SHA-pinned). GitHub performs the merge only once the required checks (Branch Name + CI Status) pass, so nothing lands without the full build/test matrix going green. Groups containing a semver-major bump stay open for manual review; digest-only Docker bumps auto-merge.
- **docs/ci-cd.md** — workflow-set table row + a dedicated section describing the flow (including why SonarCloud is expected to fail on Dependabot PRs and does not block).
- **docs/CONTRIBUTING.md** — note the `dependabot/**` exemption where the Branch Name check is described.

The repository setting **Allow auto-merge** has been enabled to support this.

## Test plan

- CI on this PR exercises the modified `ci.yml` (Branch Name still passes for a `ci/*` head).
- The new workflow is Dependabot-gated (`github.event.pull_request.user.login == 'dependabot[bot]'`), so it no-ops on this PR; first real exercise is next week's grouped Dependabot PRs.