### PR TITLE
fix(homeassistant-addon): point the container health probe at the add-on port

### DIFF
--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **The add-on now reaches "Running", and the Watchdog no longer kill-loops it.** The container health probe inherited from the app image still pointed at the app's default port `80`, but the add-on runs the app on `8099` (since 0.12.0-beta.6) — so the container never reported healthy: the add-on sat in "Starting" forever and, with **Watchdog** enabled, was restarted every ~80 seconds. The probe now targets the add-on's real port. If you disabled the Watchdog toggle to work around this, it is safe to turn back on.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate-edge/Dockerfile
+++ b/aqualink-automate-edge/Dockerfile
@@ -29,6 +29,14 @@ RUN apt-get update \
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
+# The base image's HEALTHCHECK curls ${AQUALINK_API_URL}/api/health, and the base
+# default points at the app's default port 80 — but run.sh starts the app on the
+# add-on's fixed port 8099. Without this override the probe fails forever, Docker
+# reports the container "unhealthy", the Supervisor never shows the add-on as
+# "Running", and the add-on Watchdog kill/restarts it every ~80s. (The Matter
+# sidecar, the env's other consumer, is disabled in the add-on.)
+ENV AQUALINK_API_URL=http://127.0.0.1:8099
+
 # tini (from the base image) stays PID 1 and now supervises run.sh, which builds the
 # argv and execs the base image's docker-entrypoint.sh.
 ENTRYPOINT ["/usr/bin/tini", "--", "/run.sh"]

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **The add-on now reaches "Running", and the Watchdog no longer kill-loops it.** The container health probe inherited from the app image still pointed at the app's default port `80`, but the add-on runs the app on `8099` (since 0.12.0-beta.6) — so the container never reported healthy: the add-on sat in "Starting" forever and, with **Watchdog** enabled, was restarted every ~80 seconds. The probe now targets the add-on's real port. If you disabled the Watchdog toggle to work around this, it is safe to turn back on.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate/Dockerfile
+++ b/aqualink-automate/Dockerfile
@@ -29,6 +29,14 @@ RUN apt-get update \
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
+# The base image's HEALTHCHECK curls ${AQUALINK_API_URL}/api/health, and the base
+# default points at the app's default port 80 — but run.sh starts the app on the
+# add-on's fixed port 8099. Without this override the probe fails forever, Docker
+# reports the container "unhealthy", the Supervisor never shows the add-on as
+# "Running", and the add-on Watchdog kill/restarts it every ~80s. (The Matter
+# sidecar, the env's other consumer, is disabled in the add-on.)
+ENV AQUALINK_API_URL=http://127.0.0.1:8099
+
 # tini (from the base image) stays PID 1 and now supervises run.sh, which builds the
 # argv and execs the base image's docker-entrypoint.sh.
 ENTRYPOINT ["/usr/bin/tini", "--", "/run.sh"]

--- a/docs/homeassistant-addon.md
+++ b/docs/homeassistant-addon.md
@@ -65,7 +65,7 @@ The options form maps directly onto the application's settings (full reference:
 - **Web UI** — served through Home Assistant **ingress**: it appears in the sidebar and
   via **Open Web UI**, secured by your Home Assistant login and **not exposed on the
   LAN**. Because ingress provides authentication, the app's own auth is left off. For
-  direct LAN access (e.g. a wall tablet), assign a host port to `80/tcp` in the add-on's
+  direct LAN access (e.g. a wall tablet), assign a host port to `8099/tcp` in the add-on's
   **Network** panel — that port is unauthenticated by default, so firewall it **or** turn
   on `enable_auth` (with `auth_username`/`auth_password`) to make the app enforce its own
   login there. The admin is bootstrapped on first enable; `/api/health` stays open so the


### PR DESCRIPTION
## Summary

The Home Assistant add-on never reached **Running** and, with the **Watchdog** toggle enabled, was killed and restarted every ~80 seconds. The Supervisor logged:

```
WARNING [supervisor.apps.app] Watchdog found app Aqualink Automate (Edge) is unhealthy, restarting...
```

**Root cause:** the add-on wrapper inherits the app image's Docker `HEALTHCHECK`, which curls `${AQUALINK_API_URL}/api/health` with the base default `http://127.0.0.1:80` — but `run.sh` starts the app on the add-on's fixed port **8099** (since 0.12.0-beta.6). Nothing listens on 80, so the container never reported healthy; the Supervisor holds an add-on in "Starting" until Docker health passes, and the Watchdog restarts an unhealthy container. The ~80s cycle matches the healthcheck parameters exactly (20s start-period + 3 failed probes at 30s intervals). The `config.yaml` `watchdog:` URL already targets 8099 correctly — container health trips first, so it never mattered.

## Changes

- `aqualink-automate/Dockerfile`: override `ENV AQUALINK_API_URL=http://127.0.0.1:8099` so the inherited health probe targets the real port. Safe: the env's only other consumer is the Matter sidecar, which the add-on disables.
- `aqualink-automate/CHANGELOG.md`: Unreleased entry (notes users can re-enable the Watchdog toggle once on the fixed version).
- `aqualink-automate-edge/`: regenerated via `scripts/gen-homeassistant-edge-addon.ps1` (no hand edits).
- `docs/homeassistant-addon.md`: corrected a stale `80/tcp` direct-port reference to `8099/tcp`.

## Delivery note

The wrapper is a prebuilt image the Supervisor pulls, so this reaches installs with the next release (the fixed `homeassistant-{arch}` wrapper images). Until then the workaround is to disable the add-on Watchdog toggle.

## Testing

- Root cause confirmed against a live HAOS install: Supervisor watchdog kill-loop every ~80s while the add-on stayed in "Starting"; disabling the Watchdog toggle stopped the restarts, consistent with Docker container health (not the `watchdog:` URL) being the trigger.
- Edge no-drift: generator re-run produces the committed output (CI `Home Assistant Add-on` enforces).