### PR TITLE
fix(homeassistant-addon): rename storage map addon_config to app_config

### DIFF
--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
+  add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation
+  warning logged on every store refresh). Same mount, same paths — but the new name
+  needs Supervisor 2026.07.1 (2026-07-08) or newer; an older Supervisor will not list
+  or update the add-on until it self-updates.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -48,13 +48,19 @@ services:
 # Storage maps:
 #   - ssl (read-only): HA's /ssl share, so the MQTT TLS certificate options
 #     (mqtt_ca_cert / mqtt_client_cert / mqtt_client_key) can point at files there.
-#   - addon_config (read-write): the add-on's own user-accessible config directory
-#     (/config in the container; /addon_configs/<slug> on the host, editable via Samba /
-#     the File editor) for user-managed files.
+#   - app_config (read-write): the add-on's own user-accessible config directory
+#     (/config in the container; /app_configs/<slug> on the host — /addon_configs/
+#     before Supervisor 2026.07 — editable via Samba / the File editor) for
+#     user-managed files. `app_config` is the add-ons→apps rename of `addon_config`
+#     (Supervisor 2026.07.1, 2026-07-08); the old name still works but logs a
+#     deprecation warning on every store refresh, while the new name requires
+#     Supervisor >= 2026.07.1 (an older Supervisor rejects the manifest and hides
+#     the add-on until it auto-updates — acceptable, since the Supervisor
+#     self-updates and only the latest version is supported).
 map:
   - type: ssl
     read_only: true
-  - type: addon_config
+  - type: app_config
     read_only: false
 # Web UI via INGRESS: Home Assistant serves the UI through its own authenticated
 # proxy and shows it in the sidebar — not published on the LAN, and secured by HA's

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
+  add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation
+  warning logged on every store refresh). Same mount, same paths — but the new name
+  needs Supervisor 2026.07.1 (2026-07-08) or newer; an older Supervisor will not list
+  or update the add-on until it self-updates.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -46,13 +46,19 @@ services:
 # Storage maps:
 #   - ssl (read-only): HA's /ssl share, so the MQTT TLS certificate options
 #     (mqtt_ca_cert / mqtt_client_cert / mqtt_client_key) can point at files there.
-#   - addon_config (read-write): the add-on's own user-accessible config directory
-#     (/config in the container; /addon_configs/<slug> on the host, editable via Samba /
-#     the File editor) for user-managed files.
+#   - app_config (read-write): the add-on's own user-accessible config directory
+#     (/config in the container; /app_configs/<slug> on the host — /addon_configs/
+#     before Supervisor 2026.07 — editable via Samba / the File editor) for
+#     user-managed files. `app_config` is the add-ons→apps rename of `addon_config`
+#     (Supervisor 2026.07.1, 2026-07-08); the old name still works but logs a
+#     deprecation warning on every store refresh, while the new name requires
+#     Supervisor >= 2026.07.1 (an older Supervisor rejects the manifest and hides
+#     the add-on until it auto-updates — acceptable, since the Supervisor
+#     self-updates and only the latest version is supported).
 map:
   - type: ssl
     read_only: true
-  - type: addon_config
+  - type: app_config
     read_only: false
 # Web UI via INGRESS: Home Assistant serves the UI through its own authenticated
 # proxy and shows it in the sidebar — not published on the LAN, and secured by HA's


### PR DESCRIPTION
Supersedes #125 (same commit, Gitflow-conform branch name).

## Summary

The Supervisor renamed the add-on map types as part of the add-ons→apps rename (`app_config` / `local_apps` / `all_app_configs`, shipped in Supervisor 2026.07.1, 2026-07-08). The legacy `addon_config` name still works but logs a deprecation warning on every store refresh:

> App 'Aqualink Automate (Edge)' uses legacy map type 'addon_config'; use 'app_config' instead.

- Rename the storage map `addon_config` → `app_config` in `aqualink-automate/config.yaml` (same mount, same `/config` container path; the Supervisor migrates the host dir to `/app_configs/<slug>` itself).
- Regenerate `aqualink-automate-edge/` via `scripts/gen-homeassistant-edge-addon.ps1`.
- Add an Unreleased changelog entry documenting the new minimum Supervisor requirement.

## Compatibility

The new name requires Supervisor ≥ 2026.07.1 — an older Supervisor rejects the manifest and hides the add-on until it self-updates. Acceptable: the Supervisor auto-updates by default (opting out is unsupported), only the latest version is supported upstream, and the failure mode self-heals on update. Verified in the Supervisor source that the legacy names remain warning-only with no removal date (supervisor/apps/const.py, validate.py) and that both names produce the identical mount (docker/app.py).

Docs check: `docs/homeassistant-addon.md`, `DOCS.md`, and `run.sh` never reference `addon_config` or the host path — no doc changes needed. No options/schema change, so translations are unaffected.