### PR TITLE
ci: tolerate dpkg lock contention in runner apt-get steps

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -182,13 +182,21 @@ jobs:
       # image bakes these in (cicd/packer/scripts/linux/06-dev-tools.sh), but install
       # them here too so the build also works on a not-yet-rebuilt image and on the
       # GitHub-hosted macOS runner. Windows builds libbacktrace without this path.
+      # On Linux, skip apt entirely when the packages are already present (the baked
+      # image case) and otherwise wait for the dpkg lock instead of failing — the
+      # self-hosted runners run unattended-upgrades, which briefly holds
+      # /var/lib/dpkg/lock-frontend and made a bare apt-get die with exit 100.
       - name: Install autotools for libbacktrace (Linux/macOS)
         if: ${{ runner.os != 'Windows' && !(inputs.do_package && runner.os == 'Linux') }}
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq autoconf autoconf-archive automake libtool
+            if dpkg -s autoconf autoconf-archive automake libtool >/dev/null 2>&1; then
+              echo "autotools already installed; skipping apt-get"
+            else
+              sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
+              sudo apt-get -o DPkg::Lock::Timeout=600 install -y -qq autoconf autoconf-archive automake libtool
+            fi
           elif [ "$RUNNER_OS" = "macOS" ]; then
             brew install autoconf autoconf-archive automake libtool
           fi

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -101,22 +101,29 @@ jobs:
       # runtimes (libclang_rt.fuzzer.a / libclang_rt.asan*.a). Neither aminya/setup-cpp's
       # apt.llvm.org clang (hosted) NOR the self-hosted runner image ships them, so install
       # the matching libclang-rt-<major>-dev for the selected clang. Runs on EVERY Linux
-      # runner (the autotools step below likewise apt-installs unconditionally); if the
-      # package isn't already indexed, add the apt.llvm.org source for that version + codename.
+      # runner, installing only when the package is missing; if it isn't already
+      # indexed, add the apt.llvm.org source for that version + codename.
       - name: Install LLVM compiler-rt runtimes (fuzzer + sanitizers)
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          # -o DPkg::Lock::Timeout waits out transient dpkg-lock holders on the
+          # persistent self-hosted runners (unattended-upgrades) instead of exit 100.
+          apt_get() { sudo apt-get -o DPkg::Lock::Timeout=600 "$@"; }
           ver="$(clang --version | sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p' | head -1)"
-          echo "Installing compiler-rt runtimes for clang major version ${ver}"
-          sudo apt-get update -qq
-          if ! sudo apt-get install -y -qq "libclang-rt-${ver}-dev"; then
-            echo "libclang-rt-${ver}-dev not indexed; adding apt.llvm.org source"
-            . /etc/os-release
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
-            echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${ver} main" | sudo tee "/etc/apt/sources.list.d/llvm-${ver}.list" >/dev/null
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq "libclang-rt-${ver}-dev"
+          if dpkg -s "libclang-rt-${ver}-dev" >/dev/null 2>&1; then
+            echo "libclang-rt-${ver}-dev already installed; skipping apt-get"
+          else
+            echo "Installing compiler-rt runtimes for clang major version ${ver}"
+            apt_get update -qq
+            if ! apt_get install -y -qq "libclang-rt-${ver}-dev"; then
+              echo "libclang-rt-${ver}-dev not indexed; adding apt.llvm.org source"
+              . /etc/os-release
+              wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+              echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${ver} main" | sudo tee "/etc/apt/sources.list.d/llvm-${ver}.list" >/dev/null
+              apt_get update -qq
+              apt_get install -y -qq "libclang-rt-${ver}-dev"
+            fi
           fi
           echo "compiler-rt libs:"; ls "/usr/lib/llvm-${ver}/lib/clang/${ver}/lib/"*/ 2>/dev/null | grep -i "fuzzer\|asan" || true
 
@@ -131,11 +138,18 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;default,readwrite"
 
+      # Skip apt when the packages are already baked into the runner image; otherwise
+      # wait for the dpkg lock (unattended-upgrades briefly holds it on the
+      # self-hosted runners) instead of failing with exit 100. Mirrors _build.yml.
       - name: Install autotools for libbacktrace
         shell: bash
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq autoconf autoconf-archive automake libtool
+          if dpkg -s autoconf autoconf-archive automake libtool >/dev/null 2>&1; then
+            echo "autotools already installed; skipping apt-get"
+          else
+            sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
+            sudo apt-get -o DPkg::Lock::Timeout=600 install -y -qq autoconf autoconf-archive automake libtool
+          fi
 
       - name: Configure
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9


### PR DESCRIPTION
## Summary

`Build & Test / Linux GCC` on PR #126 failed 2s into the **Install autotools for libbacktrace** step:

> E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1340469 (unattended-upgr)

The persistent self-hosted runners run `unattended-upgrades`, which briefly holds the dpkg frontend lock; a bare `apt-get` fails immediately (exit 100) instead of waiting.

## Changes

For the host-level apt steps that run on the self-hosted pool (`_build.yml` autotools step; `fuzzing.yml` autotools + libclang-rt steps):

- **Fast-path:** skip `apt-get` entirely when the packages are already installed (`dpkg -s`) — the self-hosted image bakes them in (`cicd/packer/scripts/linux/06-dev-tools.sh`), so the common case now touches apt not at all.
- **Lock tolerance:** when installing is actually needed, run `apt-get -o DPkg::Lock::Timeout=600` so it waits out a transient lock holder instead of dying.

Left untouched: apt calls inside the glibc-2.36 packaging container and on `ubuntu-latest` (docs / publish-repos / homeassistant-addon) — fresh filesystems with no concurrent unattended-upgrades.

No doc updates needed: nothing under `docs/` describes this step (checked `docs/ci-cd.md`, `docs/design/cicd-redesign.md`).