### PR TITLE
docs(ci-cd): complete the workflow inventory and sync stale sections with the workflows

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,22 +4,28 @@
 
 ## Workflow set
 
-The pipeline is ten workflow files plus two composite actions, all under `.github/`.
+The table below is the complete inventory of everything under `.github/` — the core build/test/release pipeline, the scanners, and the self-contained supporting workflows, plus the repo's composite actions. Every workflow has a section below.
 
 | File | Kind | Purpose |
 |------|------|---------|
 | `.github/workflows/ci.yml` | Workflow | Build, test, e2e, and Docker verification on every push and PR. |
 | `.github/workflows/_build.yml` | Reusable workflow (`workflow_call`) | The shared configure/build/test/package matrix. Called by both `ci.yml` and `release.yml`. |
-| `.github/workflows/release.yml` | Workflow | Build packages, publish the Docker image, and create the GitHub release for a `v*` tag. |
+| `.github/workflows/release.yml` | Workflow | Build packages, publish the Docker + Home Assistant add-on images, create the GitHub release, and publish the APT/DNF repos for a `v*` tag. |
+| `.github/workflows/publish-repos.yml` | Reusable workflow (`workflow_call`) + dispatch | Publish the GPG-signed APT/DNF package repos to `gh-pages`. Called by `release.yml` after the release is created; dispatchable to (re)publish a tag. |
+| `.github/workflows/auto-tag.yml` | Workflow | Opt-in (repo variable `AUTO_TAG_ENABLED`): advances the prerelease counter tag on a code push to `main`, firing `release.yml`. Off by default — tags are pushed by hand. |
+| `.github/workflows/suggest-version.yml` | Workflow | Advisory next-version suggestion on the `develop` → `main` release PR (sticky comment). Never creates a tag. |
 | `.github/workflows/automated-codescanning.yml` | Workflow | CodeQL (C/C++ and JavaScript/TypeScript), SonarCloud, and MSVC static analysis on PRs and a weekly cron. |
 | `.github/workflows/cleanup-branch-caches.yml` | Workflow | Delete a PR's branch caches when it closes. |
 | `.github/workflows/trivy.yml` | Workflow | Trivy scan of the runtime container image (OS packages + Node deps) → Security tab. |
 | `.github/workflows/osv-scanner.yml` | Workflow | OSV-Scanner CVE check of declared dependencies, incl. the vcpkg C++ manifest → Security tab. |
 | `.github/workflows/scorecard.yml` | Workflow | OpenSSF Scorecard supply-chain posture grade → Security tab. |
-| `.github/workflows/fuzzing.yml` | Workflow | Bounded libFuzzer run over the RS-485 protocol decoders on a weekly cron + decoder-touching PRs. Feeds Scorecard's Fuzzing check. See [fuzzing.md](fuzzing.md). |
+| `.github/workflows/fuzzing.yml` | Workflow | Bounded libFuzzer run over the untrusted-input parsers (RS-485 decoders plus the JSON/config/web/auth inputs) on a weekly cron + parser-touching PRs. Feeds Scorecard's Fuzzing check. See [fuzzing.md](fuzzing.md). |
 | `.github/workflows/dependabot-auto-merge.yml` | Workflow | Flags non-major Dependabot PRs for GitHub auto-merge; they land on `develop` once the required checks pass. |
+| `.github/workflows/docs.yml` | Workflow | Build the MkDocs site (`mkdocs build --strict`) and publish it to the root of `gh-pages` on docs-affecting pushes to `main`. |
+| `.github/workflows/homeassistant-addon.yml` | Workflow | Validate the Home Assistant add-on wrapper (YAML, shellcheck, translation coverage, generated-Edge-channel drift, version lock-step) on add-on-touching pushes and PRs. |
 | `.github/actions/setup-cpp-toolchain` | Composite action | Install the platform-appropriate compiler and build tools. |
 | `.github/actions/setup-vcpkg-cache` | Composite action | Configure and restore the OS-keyed vcpkg binary cache. |
+| `.github/actions/setup-msvc-env` | Composite action | Load the MSVC environment on self-hosted Windows runners (sources `vcvars64.bat`, exports the env delta to `$GITHUB_ENV`). |
 
 `ci.yml` and `release.yml` share one build definition (`_build.yml`), so the suites that run on a PR and the suites that gate a release can never drift.
 
@@ -39,19 +45,24 @@ on:
 
 Only `main` and `develop` build on push. Feature branches build via their `pull_request` into `develop`/`main` (the `pull_request` trigger targets those two branches). A WIP push to a branch that has no open PR runs no CI at all — and a push to a branch that *does* have a PR is already covered by the PR run, so this also avoids the push+PR double-run.
 
-Concurrency is keyed on the PR number (or the ref for branch pushes) with `cancel-in-progress: true`, so a new push supersedes an in-flight run for the same PR or branch.
+Concurrency is keyed on the PR head branch (or the ref for branch pushes) with `cancel-in-progress: true`, so a new push supersedes an in-flight run for the same PR or branch.
 
 ### Jobs
 
 | Job | Runs on | What it does |
 |-----|---------|--------------|
+| `changes` | `ubuntu-latest` | Classifies the change via the GitHub API: `docs/**`, `mkdocs.yml`, `docs.yml`, `LICENSE`, and `*.md` never affect the binary. The heavy jobs below run only when it reports `code == 'true'`; anything not clearly docs counts as code. |
 | `branch-name` | `ubuntu-latest` | PR only. Validates the PR head branch matches `<type>/<name>` with an allowed commit type, failing a non-conforming name. `develop`/`main` heads are accepted so the `develop` -> `main` release-promotion PR passes, and `dependabot/**` heads are accepted because Dependabot's branch names are not configurable (see [Dependabot auto-merge](#dependabot-auto-merge-dependabot-auto-mergeyml)). A **required** status check on `develop`/`main`, so a misnamed branch cannot merge. |
 | `build-and-test` | Per-OS matrix (see [_build.yml](#_buildyml)) | Calls `_build.yml` with no packaging. Configures, builds, and runs the full test suite on Linux, Windows, and macOS. |
-| `e2e-ui` | Linux | Builds only the app binary, then runs the Playwright UI suite once per mode (see the mode table below). |
+| `e2e-ui` | Linux | Downloads the install tree uploaded by `build-and-test` (no recompile), then runs the Playwright UI suite once per mode (see the mode table below). |
 | `matter-bridge` | Linux | Node job in `matter-bridge/`: `npm ci`, typecheck (including the matter.js bridge), build, and unit tests. |
 | `i18n-catalogs` | `ubuntu-latest` | Runs `scripts/check-i18n-keys.ps1`: every key referenced in web-UI code exists in `en.js`, and every shipped locale catalog has exact key + placeholder parity with English (see `docs/i18n.md`). Part of the `ci-status` aggregate. |
+| `platform-macros` | `ubuntu-latest` | Runs `scripts/check-os-macros.ps1`: no OS preprocessor macro may gate shared, non-platform source (see [platform-isolation.md](platform-isolation.md)). Part of the `ci-status` aggregate. |
 | `version-check` | `ubuntu-latest` | PR-into-`main` only. Compares what `git describe` resolves on the PR head versus the base. **Blocking at the job level** — when the resolved version is unchanged it emits `::error::` and `exit 1`, failing the job. It is, however, intentionally excluded from the `ci-status` aggregator's `needs` list, so a failed `version-check` does not by itself fail the aggregated `ci-status` required check. |
 | `docker-verify` | Linux | Builds the `ci` and `runtime` Docker targets, smoke-tests the runtime image with `--version`, and asserts the Matter sidecar is bundled. |
+| `ci-status` | `ubuntu-latest` | The aggregated **required** status check (alongside `branch-name`). Runs `if: always()` over every job above except `branch-name` and `version-check`, and fails only when one of them reported `failure`/`cancelled` — skipped jobs (docs-only changes, fork-gated jobs) count as OK, so a required check is never left pending. |
+
+**Docs-only gating.** `build-and-test`, `e2e-ui`, `matter-bridge`, `version-check`, and `docker-verify` are all gated on `changes` reporting `code == 'true'`, so a docs-only change skips the whole build/test matrix while `ci-status` still reports success. `branch-name`, `i18n-catalogs`, and `platform-macros` run regardless (cheap, source-only checks).
 
 **e2e-ui modes.** The Playwright runs mirror the modes encoded in `playwright.config.ts`, selected by environment variable. The three identity specs each run in their own step because they have incompatible auth-store preconditions (auth.spec needs an empty store for the first-run wizard; admin.spec self-seeds an admin; guest.spec configures the Guest scope), so each must boot against a fresh `--auth-state-dir`:
 
@@ -63,12 +74,10 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 | identity — guest mode + kiosk PIN | `AQUALINK_AUTH_MODE=enabled`, `npx playwright test e2e/guest.spec.ts` | anonymous guest browsing, affordance gating, kiosk PIN |
 | history enabled | `AQUALINK_HISTORY_DB` | recorded series + chart |
 | scheduler enabled | `AQUALINK_SCHEDULES_FILE` | schedule CRUD |
-| TLS (https) | `AQUALINK_TLS=enabled` | the default (non-identity) suite over an HTTPS origin (self-signed cert auto-provisioned), exercising the server's TLS/SSL session path and certificate self-provisioning |
-| bootstrap admin | `AQUALINK_AUTH_MODE=enabled`, `AQUALINK_BOOTSTRAP_ADMIN=wbadmin`, `AQUALINK_BOOTSTRAP_ADMIN_PASSWORD=…`, `npx playwright test e2e/admin.spec.ts` | headless `--bootstrap-admin` start-up provisioning; admin.spec then logs in against the seeded admin |
-| open bind — warning | `AQUALINK_OPEN_BIND=warn` | non-loopback bind (0.0.0.0) with auth off → the open-control-plane start-up warning |
-| open bind — ack | `AQUALINK_OPEN_BIND=ack` | as above plus `--insecure-no-auth` → the acknowledged-posture branch |
 
-**docker-verify checks.** It builds the `ci` target, then the `runtime` target (tagged `aqualink-automate:verify`), runs `docker run --rm -e MATTER_ENABLED=false aqualink-automate:verify --version`, and confirms the bundled sidecar is present (`node --version` plus a test for `/opt/matter-bridge/dist/index.js`). Both Docker builds are wrapped in a bounded retry so a transient Docker Hub base-image timeout does not fail CI. The `Dockerfile` base (both the build and runtime stages) is `ubuntu:25.04` — note this is a different release from the self-hosted runner image, which Packer provisions on Ubuntu 26.04 LTS (see [Provisioning](#provisioning) below).
+The remaining modes (TLS, bootstrap admin, open bind, MQTT, and the persistence modes) run in `automated-codescanning.yml`'s coverage sweep, which is a superset of this table — see [automated-codescanning.yml](#automated-codescanningyml).
+
+**docker-verify checks.** It builds the `ci` target, then the `runtime` target (tagged `aqualink-automate:verify`), runs `docker run --rm -e MATTER_ENABLED=false aqualink-automate:verify --version`, and confirms the bundled sidecar is present (`node --version` plus a test for `/opt/matter-bridge/dist/index.js`). Both Docker builds are wrapped in a bounded retry so a transient Docker Hub base-image timeout does not fail CI. This cold, from-source build is kept deliberately as the gate that the multi-stage `Dockerfile` + vcpkg toolchain still build end to end — the release path's `docker-publish` assembles its image from prebuilt install trees and skips this, so `docker-verify` is its safety net.
 
 ## _build.yml
 
@@ -79,8 +88,9 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 | Input | Type | Default | Used by |
 |-------|------|---------|---------|
 | `do_package` | boolean | `false` | Also run `cpack`, the per-OS install/extract smoke test, and the package artifact upload. The release path sets this `true`. |
-| `version_tag` | string | `""` | The resolved `v*` tag. Used only to create a local git tag for `workflow_dispatch` release builds (see below). |
+| `version_tag` | string | `""` | The resolved `v*` tag, threaded into configure as `DERIVED_VERSION_OVERRIDE` so the build stamps it deterministically (see below). Empty in CI. |
 | `fetch_depth` | number | `1` | Checkout depth. CI uses `1`; releases pass `0` so `git describe` and the cut-from-main check see full history and tags. |
+| `upload_installtree` | boolean | `false` | On Linux, run `cmake --install` and upload the relocatable FHS install tree(s) that `e2e-ui` and the assembled release image consume instead of recompiling. Both CI and the release path set this `true`. |
 
 ### The matrix
 
@@ -95,7 +105,7 @@ The job runs a four-row matrix with `fail-fast: false`, so one platform failing 
 
 These are the same presets you use locally — see [INSTALL.md](INSTALL.md).
 
-The arm64 row builds **natively** on an aarch64 runner (no cross-compile / QEMU) so the `.deb`/`.rpm`/`.tgz` install on a Raspberry Pi and other arm64 hosts; CPack derives the package architecture from the target, so the packages are correctly labelled `arm64`/`aarch64`. The install-tree upload (consumed by `e2e-ui` and the Docker image) stays on the x64 `config-linux-gcc` row only.
+The arm64 row builds **natively** on an aarch64 runner (no cross-compile / QEMU) so the `.deb`/`.rpm`/`.tgz` install on a Raspberry Pi and other arm64 hosts; CPack derives the package architecture from the target, so the packages are correctly labelled `arm64`/`aarch64`. Both Linux rows can upload their install tree (`installtree-linux-gcc` / `installtree-linux-gcc-arm64`, gated on the `upload_installtree` input): CI uploads only the x64 tree (for `e2e-ui`), while the release path uploads both so `docker-publish` can assemble the multi-arch image without recompiling.
 
 Runner selection per row is `vars.RUNNER_LINUX` / `vars.RUNNER_LINUX_ARM` / `vars.RUNNER_WINDOWS` with a GitHub-hosted fallback (the arm64 row falls back to `ubuntu-24.04-arm`); macOS always runs on `macos-latest`. See [Self-hosted runners](#self-hosted-runners).
 
@@ -105,21 +115,15 @@ The `Test` step runs the full test preset with **no `-L` label filter**, so unit
 
 ### Packaging (release path only)
 
-When `do_package` is `true`, after the test step the job also:
+When `do_package` is `true`:
 
-1. Runs `cpack --preset=<package_preset>`.
-2. Smoke-tests the package on a clean target — installs the `.deb` in a fresh `debian:bookworm` container (Linux; the glibc-2.36 / Raspberry Pi OS baseline), extracts the ZIP and runs the exe (Windows), or extracts the TGZ and runs the binary (macOS). Each asserts `aqualink-automate --version` succeeds. The Linux test deliberately uses `debian:bookworm` rather than the build image: it catches both a missing runtime dependency and a regression to a too-new glibc/libstdc++ baseline (which a newer-distro test would silently pass) before the package is published.
+1. On Linux, the whole configure/build/test/`cpack` sequence for the release path runs **inside a `gcc:15-bookworm` container** (glibc 2.36 — the Debian Bookworm / Raspberry Pi OS baseline), natively per arch, so the produced packages run on a stock Pi and every newer distro; the bundled gcc-15 libstdc++/libgcc keep the older-glibc base safe for the C++23 code. Windows and macOS run `cpack --preset=<package_preset>` on the host after the normal build.
+2. Smoke-tests the package on a clean target — installs the `.deb` in a fresh `debian:bookworm` container (Linux), extracts the ZIP and runs the exe (Windows), or extracts the TGZ and runs the binary (macOS). Each asserts `aqualink-automate --version` succeeds. The Linux test deliberately uses a clean `debian:bookworm` rather than the build image: it catches both a missing runtime dependency and a regression to a too-new glibc/libstdc++ baseline (which a newer-distro test would silently pass) before the package is published.
 3. Uploads the packages as an artifact named `packages-<configure_preset>` (for example `packages-config-linux-gcc`), with `retention-days: 30`.
 
-### Version stamping for dispatch builds
+### Version stamping
 
-A `workflow_dispatch` release build is for a tag that does not exist yet (`github-release` pushes it at the very end). To make `git describe` stamp the right version, `_build.yml` creates a **local** tag at the start of the packaging path:
-
-```bash
-git tag "<version_tag>" HEAD   # only when do_package && event == workflow_dispatch
-```
-
-**Note:** The version is also threaded explicitly into the configure step. `_build.yml` passes `-DDERIVED_VERSION_OVERRIDE=${{ inputs.version_tag || '0.0.0-dev' }}` (so a CI build with no tag stamps `0.0.0-dev`), and `cmake/GitVersionDerivation.cmake` honors `DERIVED_VERSION_OVERRIDE` (it is also how the Docker image is versioned, since the build context omits `.git`). For a `workflow_dispatch` release build the local tag created above lets `git describe` resolve the same `v*` version that is passed through as the override.
+The version is threaded explicitly into the configure step: `_build.yml` passes `-DDERIVED_VERSION_OVERRIDE=${{ inputs.version_tag || '0.0.0-dev' }}` (so a CI build with no tag stamps `0.0.0-dev` rather than emitting a noisy `git describe` warning on the shallow checkout), and `cmake/GitVersionDerivation.cmake` honors `DERIVED_VERSION_OVERRIDE` over `git describe` (it is also how the Docker image is versioned, since the build context omits `.git`). Release callers pass the resolved tag as `version_tag`, so a `workflow_dispatch` build stamps the right version even though its tag does not exist yet (`github-release` pushes it at the very end) — no local pre-tagging is needed.
 
 ## release.yml
 
@@ -143,17 +147,21 @@ There is **no `push` to `main` trigger** — pushing to `main` does not release.
 ### Job graph
 
 ```
-resolve-version ──> build-packages (_build.yml) ──> docker-publish ──> github-release
+resolve-version ──> build-packages (_build.yml) ──> docker-publish ──┬─> homeassistant-addon-publish
+                                                                     └─> github-release ──> publish-repos (publish-repos.yml)
 ```
 
-`docker-publish` and `github-release` are skipped on a dry run (`is_dry_run == 'true'`); `build-packages` still runs so the pipeline can be validated end to end without publishing.
+Every job after `build-packages` is skipped on a dry run (`is_dry_run == 'true'`); `build-packages` still runs so the pipeline can be validated end to end without publishing. A `cleanup-failed-prerelease` job additionally watches the graph with `if: always()` (below).
 
 | Job | What it does |
 |-----|--------------|
-| `resolve-version` | Resolves the version from the trigger, validates the tag, and enforces the release guards (below). |
-| `build-packages` | Calls `_build.yml` with `do_package: true`, `fetch_depth: 0`, and the resolved `version_tag`. |
-| `docker-publish` | Builds and pushes the `runtime` image, then smoke-tests the published image. |
+| `resolve-version` | Resolves the version from the trigger, validates the tag, and enforces the release guards (below). Also re-runs the Home Assistant add-on version lock-step check (`scripts/sync-homeassistant-addon-version.ps1 -Check`), so a release cannot ship a drifted add-on version. |
+| `build-packages` | Calls `_build.yml` with `do_package: true`, `upload_installtree: true`, `fetch_depth: 0`, and the resolved `version_tag`. |
+| `docker-publish` | Assembles and pushes the multi-arch `runtime` image from the prebuilt install trees, then smoke-tests the published image on both architectures. |
+| `homeassistant-addon-publish` | Builds and pushes the per-arch Home Assistant add-on wrapper images (`homeassistant-amd64` / `homeassistant-aarch64`) on top of the just-published app image, attests them, and smoke-tests the pulled wrapper (bashio + `run.sh` present). |
 | `github-release` | Pushes the tag for dispatch builds, downloads the package artifacts, and creates the GitHub release. |
+| `publish-repos` | Calls `publish-repos.yml` (with `contents: write` and `secrets: inherit`) to sign and publish the APT/DNF repos from the just-created release — see [Release helpers](#release-helpers-auto-tagyml-suggest-versionyml-publish-reposyml). |
+| `cleanup-failed-prerelease` | If a non-dry-run **prerelease** fails after its tag exists, deletes the orphaned tag — never a stable tag, and never one that already has a published release — so the same version can be re-tagged cleanly. |
 
 ### resolve-version guards
 
@@ -168,10 +176,10 @@ resolve-version ──> build-packages (_build.yml) ──> docker-publish ─�
 This job runs only on Linux when not a dry run, with `packages: write` (GHCR push) plus `id-token: write` + `attestations: write` (attestation signing).
 
 1. Logs in to GHCR, and to Docker Hub only if `DOCKERHUB_USERNAME` is set (so fork PRs and credential-less runs still build anonymously).
-2. Derives tags from `docker/metadata-action`: `type=sha`, the full semver, `major.minor`, and a raw `latest` tag enabled **only when the release is not a prerelease**.
-3. Builds and pushes the `runtime` target to GHCR (and Docker Hub when credentials are present), wrapped in a bounded retry (up to 3 attempts) so a transient Docker Hub CDN timeout does not fail the release. `--metadata-file` records the pushed image-index digest.
+2. Derives tags from `docker/metadata-action`: `type=sha`, the full semver, `major.minor`, a raw `latest` tag enabled **only when the release is not a prerelease**, and a raw `edge` tag enabled **only for prereleases** (the floating prerelease channel — see the tag table in [releasing.md](releasing.md)).
+3. Downloads the per-arch install trees uploaded by `build-packages` and **assembles** the multi-arch (`linux/amd64` + `linux/arm64`, via QEMU) `runtime-assembled` target from them — no C++ recompile; only the Matter sidecar's TypeScript builds — pushing to GHCR (and Docker Hub when credentials are present), wrapped in a bounded retry (up to 3 attempts) so a transient Docker Hub CDN timeout does not fail the release. `--metadata-file` records the pushed image-index digest. (CI's from-source `docker-verify` remains the cold-build gate for the `runtime` target itself.)
 4. **Attests the image by digest:** a keyless [build-provenance attestation](https://docs.github.com/actions/security-guides/using-artifact-attestations) (`actions/attest-build-provenance`, Sigstore/OIDC) and an SPDX **SBOM** attestation (`anchore/sbom-action` → `actions/attest-sbom`), both `push-to-registry: true` so they attach to the image in GHCR. Attesting by digest (not tag) binds the proof to the exact bytes pushed.
-5. Runs a post-push smoke test: pulls the GHCR image and asserts `--version` contains the resolved version. Because `buildx build --push` pushes straight to the registry, this genuinely exercises the published artifact rather than a local cache.
+5. Runs a post-push smoke test: pulls the GHCR image and asserts `--version` contains the resolved version, for **both** architectures (arm64 under QEMU). Because `buildx build --push` pushes straight to the registry, this genuinely exercises the published artifact rather than a local cache.
 
 ### github-release
 
@@ -187,6 +195,24 @@ Both attestation mechanisms are described end-to-end for consumers in [SECURITY.
 
 See [docs/releasing.md](releasing.md) for the operator-facing release walkthrough.
 
+## Release helpers (auto-tag.yml, suggest-version.yml, publish-repos.yml)
+
+Three small workflows surround `release.yml`. None is part of the PR gate.
+
+### suggest-version.yml
+
+Propose-only. On a `develop` → `main` release PR (`pull_request` into `main`, types opened/synchronize/reopened) it runs `scripts/next-version.sh --markdown` against the full history + tags and upserts the result as a sticky PR comment plus a job summary. It **never creates or pushes a tag** — the human still decides the version and pushes it (see the pre-release checklist in [releasing.md](releasing.md)). The same script is runnable locally: `scripts/next-version.sh`.
+
+### auto-tag.yml
+
+Opt-in tag advancement. It triggers on every push to `main`, but the single job runs **only when the repo variable `AUTO_TAG_ENABLED` is `"true"`** — by default it does nothing and versions are tagged by hand. When enabled, it advances **only the prerelease counter** (`vX.Y.Z-<channel>.N` → `.N+1`, channel from `AUTO_TAG_CHANNEL`, default `beta`) and pushes the tag, which fires `release.yml` exactly like a manual tag push. Everything else stays a human decision by design: it refuses to invent a first tag, bump the base version, or switch channels, and it skips when there are no new commits since the last tag or when the delta is docs-only (same classifier as `ci.yml`'s `changes` job — a docs merge must not trigger a redundant binary release).
+
+### publish-repos.yml
+
+Publishes the GPG-signed **APT** (reprepro) and **DNF** (createrepo_c) package repositories to the `gh-pages` branch, so users can `apt install` / `dnf install` and receive upgrades. It is a reusable workflow invoked by `release.yml`'s `publish-repos` job right after the GitHub release is created — a `release: published` trigger would never fire, because GitHub suppresses events for actions performed with the default `GITHUB_TOKEN` — and it is also dispatchable with a `tag` input to (re)publish an existing release. It downloads the release's `.deb`/`.rpm` assets, signs each `.rpm` in place (`rpm --addsign`; the DNF repo advertises `gpgcheck=1`, a per-package check), builds both repos, signs the repo metadata, and publishes with `keep_files: true` so previously published versions accumulate. **It no-ops until the `REPO_GPG_PRIVATE_KEY` secret is configured** — the one-time setup and operator walkthrough live in [releasing.md](releasing.md).
+
+`docs.yml` shares the `gh-pages` branch with this workflow: the rendered docs site owns the root `index.html` and page tree, the package machinery owns `apt/`, `rpm/`, `key.gpg`, and the `install-*.sh` scripts. The filename sets are disjoint and both publish with `keep_files: true`, so neither clobbers the other (see [Docs site](#docs-site-docsyml)).
+
 ## automated-codescanning.yml
 
 Code scanning is slow (each scanner does a full compile), so it runs only where code is genuinely new.
@@ -195,6 +221,8 @@ Code scanning is slow (each scanner does a full compile), so it runs only where 
 
 ```yaml
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["develop", "main"]
   schedule:
@@ -202,7 +230,9 @@ on:
   workflow_dispatch:
 ```
 
-There is **no `push` trigger.** Scanning happens on PRs into `develop` or `main`, on the weekly cron baseline of the default branch, or on demand. A former `push: [main, feature/**, bug/**]` trigger was removed because it re-scanned already-scanned code.
+Scanning happens on PRs into `develop` or `main`, once per merge to `main`, on the weekly cron, or on demand. The `push: [main]` trigger exists to keep the **default-branch security baseline** current: SARIF uploaded from a `pull_request` run is recorded against the throwaway `refs/pull/N/merge` ref and never updates `main`'s baseline in the Security tab, so without it the baseline would depend solely on the weekly cron. (The old `push: [main, feature/**, bug/**]` trigger that re-scanned every feature push remains gone — the push run fires once per promotion merge.)
+
+Both triggers carry a docs `paths-ignore` (`docs/**`, `**/*.md`, `mkdocs.yml`, `docs.yml`, `LICENSE`): docs-only changes touch no compiled code, and since none of these jobs is a required status check, a path-filtered (non-running) workflow does not block the PR — unlike `ci.yml`, which must use a gate job (`changes`) for the same purpose.
 
 ### Jobs
 
@@ -210,13 +240,25 @@ There is **no `push` trigger.** Scanning happens on PRs into `develop` or `main`
 |-----|---------|---------|
 | `CodeScanning_CodeQL` | Linux | CodeQL (`c-cpp`). Runs its own full build, filters the SARIF to `src/**`, and uploads to the Security tab. |
 | `CodeScanning_CodeQL_JS` | Linux (GitHub-hosted) | CodeQL (`javascript-typescript`, `build-mode: none`) for the Alpine.js web UI (`assets/web/scripts`, `sw.js`) and the TypeScript Matter sidecar (`matter-bridge/src`). No compile, so it runs on `ubuntu-latest` (not the self-hosted C++ fleet); `.github/codeql/codeql-config-js.yml` scopes it to first-party source (vendored/minified libraries and `i18n/` data excluded). |
-| `CodeScanning_E2ECoverage` | Linux | Builds a gcov-instrumented `aqualink-automate` (`config-linux-gcc-coverage`), runs the four Playwright modes against it, and `gcovr`s the `.gcda` into a SonarQube coverage report (`coverage-e2e.xml`) uploaded as the `e2e-coverage-xml` artifact. |
+| `CodeScanning_E2ECoverage` | Linux | Builds a gcov-instrumented `aqualink-automate` (`config-linux-gcc-coverage`), drives the full Playwright mode sweep against it (see below), and `gcovr`s the `.gcda` into a SonarQube coverage report (`coverage-e2e.xml`) uploaded as the `e2e-coverage-xml` artifact. |
 | `CodeScanning_SonarCloud` | Linux | SonarCloud via build-wrapper over a coverage build (`config-linux-gcc-coverage`, `-DUSE_SONARQUBE=ON`). Runs its own full compile, produces the unit/integration coverage report, downloads the e2e report, and scans with **both** (`sonar.coverageReportPaths` comma-separated; Sonar merges line coverage). |
 | `CodeScanning_MSVCCodeAnalysis` | Windows | MSVC code analysis (`NativeRecommendedRules.ruleset`) over the `config-windows-msvc` build; uploads SARIF. |
 
 Each job has the same skip condition: it does not run for a `develop` -> `main` promotion PR, because that code was already scanned when it entered `develop`. Re-scanning the promotion is pure duplication.
 
 **Coverage = unit + e2e.** The SonarCloud new-code coverage gate reflects what *both* test layers exercise. The unit/integration binary's coverage alone misses every line only the running app reaches (HTTP routes, WebSocket, MQTT, bootstrap), which read as uncovered and depressed the gate. `CodeScanning_E2ECoverage` instruments the app, drives the Playwright suite against it (the app exits cleanly on Playwright's `SIGTERM` — see `gracefulShutdown` in `playwright.config.ts` — so gcov flushes `.gcda`), and emits a second report. `CodeScanning_SonarCloud` `needs:` it and merges the two; if the e2e job fails, the scan still runs with unit-only coverage (it never drops the whole gate).
+
+**The coverage mode sweep.** The job runs the six `e2e-ui` modes from [ci.yml](#ciyml) plus seven more that exist to reach code the default modes cannot. Every mode step is `continue-on-error` — this job harvests coverage, it is not a functional gate (`e2e-ui` is), so a spec flake must not discard coverage already written:
+
+| Run | Env set | Exercises |
+|-----|---------|-----------|
+| TLS (https) | `AQUALINK_TLS=enabled` | the default (non-identity) suite over an HTTPS origin (self-signed cert auto-provisioned) — the server's TLS/SSL session path and certificate self-provisioning |
+| bootstrap admin | `AQUALINK_AUTH_MODE=enabled`, `AQUALINK_BOOTSTRAP_ADMIN=…`, `AQUALINK_BOOTSTRAP_ADMIN_PASSWORD=…`, `npx playwright test e2e/admin.spec.ts` | headless `--bootstrap-admin` start-up provisioning; admin.spec then logs in against the seeded admin |
+| open bind — warning | `AQUALINK_OPEN_BIND=warn` | non-loopback bind (0.0.0.0) with auth off → the open-control-plane start-up warning |
+| open bind — ack | `AQUALINK_OPEN_BIND=ack` | as above plus `--insecure-no-auth` → the acknowledged-posture branch |
+| MQTT (broker + HA discovery) | `AQUALINK_MQTT=enabled`, `npx playwright test e2e/mqtt.spec.ts` | the only e2e mode that exercises the MQTT layer: Playwright starts a loopback broker and the app runs `--mqtt --home-assistant` against it (MqttClient, MqttIntegration, MqttHub, HA auto-discovery) |
+| equipment cache persisted | `AQUALINK_EQUIPMENT_CACHE=<file>` | the equipment-cache load-or-init + write-scheduling paths, skipped by the in-memory default |
+| preferences persisted | `AQUALINK_PREFERENCES_FILE=<file>` | the preferences load/persist path against a real file rather than in-memory only |
 
 ## Supply-chain scanning (trivy.yml, osv-scanner.yml, scorecard.yml)
 
@@ -230,21 +272,21 @@ Three lightweight workflows cover the supply-chain surfaces the compile-heavy `a
 
 Division of labour with the existing tooling: **CodeQL / SonarCloud / MSVC** scan first-party source; **Dependabot** *updates* the Actions + npm manifests (and raises its own vulnerability alerts for them); **OSV-Scanner** closes the vcpkg gap Dependabot cannot see; **Trivy** covers the image layers no source or manifest scanner reaches. The vcpkg-built C++ libraries inside the image carry no package metadata for Trivy to match, so OSV-Scanner (reading the manifest) is what covers them — the two do not overlap.
 
-The three PR-facing jobs (`trivy.yml`, `osv-scanner.yml`) share the code scanners' promotion-PR skip and fork-PR gating. `scorecard.yml` does not run on `pull_request` at all (its checks are repository-level and need a token a fork PR lacks). The weekly crons are staggered (22:17 / 22:27 / 22:37 UTC) so they do not all contend at once.
+The two PR-facing workflows (`trivy.yml`, `osv-scanner.yml`) share the code scanners' promotion-PR skip and fork-PR gating. `scorecard.yml` does not run on `pull_request` at all (its checks are repository-level and need a token a fork PR lacks). The weekly crons are staggered (22:17 / 22:27 / 22:37 UTC) so they do not all contend at once.
 
 ### Scorecard hardening applied
 
 Two Scorecard checks are satisfied structurally rather than per-finding:
 
 - **Token permissions** — every workflow declares `permissions: {}` (deny-all) at the top level and re-grants the minimum `write` scope on the single job that needs it (e.g. `contents: write` on the tag/publish jobs, `actions: write` on the cache-cleanup job, `security-events: write` on the SARIF-upload jobs). A top-level write is what Scorecard penalizes; a narrowly job-scoped write is the recommended pattern and the residual per-job grants are the least privilege each job genuinely requires.
-- **Pinned dependencies** — the external base images in the root `Dockerfile` (`ubuntu:26.04`, `node:24-bookworm-slim`) are pinned by `@sha256:` digest. `.github/dependabot.yml` carries a `docker` ecosystem entry so Dependabot advances those digests weekly — a digest pin without an update path would otherwise freeze the image onto a stale, unpatched base. (Internal `FROM <stage>` references and the GitHub-hosted runner toolchains are not digest-pinnable and are not flagged as real findings.)
+- **Pinned dependencies** — the external base images in the root `Dockerfile` (`ubuntu:26.04`, `node:26-bookworm-slim`) are pinned by `@sha256:` digest. `.github/dependabot.yml` carries a `docker` ecosystem entry so Dependabot advances those digests weekly — a digest pin without an update path would otherwise freeze the image onto a stale, unpatched base. (Internal `FROM <stage>` references and the GitHub-hosted runner toolchains are not digest-pinnable and are not flagged as real findings.)
 
 ## Fuzzing (fuzzing.yml)
 
-`fuzzing.yml` runs the libFuzzer harnesses over the **untrusted RS-485 protocol decoders** (Jandy + Pentair message deserialisers) — the one supply-chain surface the posture scanners above cannot reach, because it is a *runtime* property of first-party parsing code. It builds the `config-linux-llvm-fuzzing` preset (Clang + `-fsanitize=fuzzer,address`), seeds a corpus from the recorded `test/fixtures/**/*.cap` captures, and fuzzes each harness for a bounded time; a crash fails the job and uploads the reproducer as an artifact. This gives the OpenSSF Scorecard **Fuzzing** check a genuine signal rather than a posture tick.
+`fuzzing.yml` runs the libFuzzer harnesses over the app's **untrusted-input parsers** — the RS-485 protocol decoders (Jandy + Pentair message deserialisers) plus the schedule/WebSocket JSON, MQTT payload, config, query-string, JWT, duration, and replay-line parsers — the one supply-chain surface the posture scanners above cannot reach, because it is a *runtime* property of first-party parsing code. It builds the `config-linux-llvm-fuzzing` preset (Clang + `-fsanitize=fuzzer,address`), seeds each harness's corpus (the decoder corpora come from the recorded `test/fixtures/**/*.cap` captures), and fuzzes each harness for a bounded time; a crash fails the job and uploads the reproducer as an artifact. This gives the OpenSSF Scorecard **Fuzzing** check a genuine signal rather than a posture tick.
 
-- **Triggers:** weekly cron (`47 22 * * 1`, staggered after the supply-chain crons); `pull_request` touching `src/jandy/**`, `src/pentair/**`, `src/core/protocol/**`, `fuzz/**`, or the fuzzing scaffolding; and `workflow_dispatch` (with a `max_total_time` input). It is **not** a required gate — a bounded run is best-effort reassurance, but any crash it does find is a real bug.
-- **Matrix:** one job per harness (`fuzz-jandy-message`, `fuzz-pentair-message`), on the GitHub-hosted `ubuntu-latest` (or `vars.RUNNER_LINUX`), with the same fork-PR gating as the build jobs.
+- **Triggers:** weekly cron (`47 22 * * 1`, staggered after the supply-chain crons); `pull_request` touching a fuzzed parser's source (`src/jandy/**`, `src/pentair/**`, and the fuzzed `src/core/` subsystems) or the fuzzing scaffolding (`fuzz/**`, `cmake/Fuzzing.cmake`); and `workflow_dispatch` (with a `max_total_time` input). It is **not** a required gate — a bounded run is best-effort reassurance, but any crash it does find is a real bug.
+- **Matrix:** one job per harness — ten of them, `fuzz-jandy-message` through `fuzz-replay-line` (the full list lives in [fuzzing.md](fuzzing.md)) — on the GitHub-hosted `ubuntu-latest` (or `vars.RUNNER_LINUX`), with the same fork-PR gating as the build jobs.
 - A crash is handled per the bug-fix discipline: fix the decoder + add a regression test, never weaken the parser. Full harness/corpus/run docs: [fuzzing.md](fuzzing.md).
 
 ## cleanup-branch-caches.yml
@@ -263,6 +305,28 @@ Routine dependency bumps merge themselves. `.github/dependabot.yml` raises one g
 - The squash commit takes the PR title, which Dependabot already emits in Conventional Commit form (`ci:`/`build:` prefixes configured in `.github/dependabot.yml`).
 - Requires the repository setting **Allow auto-merge** (Settings > General > Pull Requests), which is enabled on this repo.
 
+## Docs site (docs.yml)
+
+The documentation site (MkDocs Material — the published subset is selected by the `nav` + `exclude_docs` in `mkdocs.yml`) is built from the in-repo Markdown and published to the **root** of the `gh-pages` branch, so the docs home is the GitHub Pages landing page.
+
+- **Triggers:** push to `main` touching `docs/**`, `overrides/**`, `mkdocs.yml`, `README.md`, or the workflow itself; plus `workflow_dispatch`.
+- **Build:** `pip install "mkdocs-material[imaging]>=9.7"` (a floor, no upper cap) plus the Cairo imaging libraries for the social-cards plugin, then `mkdocs build --strict` — broken internal links and other warnings **fail the build** instead of shipping a broken page.
+- **Publish:** `peaceiris/actions-gh-pages` with `keep_files: true`, preserving the APT/DNF package tree that `publish-repos.yml` owns on the same branch (`apt/`, `rpm/`, `key.gpg`, `install-*.sh`); the filename sets are disjoint, so neither workflow deletes the other's files. Its `publish-docs` concurrency group is separate from `publish-repos`, so a docs build and a package publish can run at the same time.
+
+## Home Assistant add-on validation (homeassistant-addon.yml)
+
+Validates the Home Assistant add-on wrapper — the repo-root `repository.yaml` plus the stable `aqualink-automate/` and generated `aqualink-automate-edge/` channels (see [homeassistant-addon.md](homeassistant-addon.md)) — whenever it changes: `push` to `main`/`develop` and `pull_request` into `develop`/`main`, path-filtered to the add-on files and their generator/sync scripts.
+
+One `validate` job (GitHub-hosted, no third-party actions to pin) checks, in order:
+
+1. **YAML parses** — `repository.yaml`, both channels' `config.yaml`, and every translation catalog.
+2. **The Edge channel is generated, not hand-edited** — re-runs `scripts/gen-homeassistant-edge-addon.ps1` and fails on any diff, so the two channels can never drift by hand.
+3. **Options translations cover `config.yaml`** — every locale must document exactly the schema keys (`configuration:`) and ports (`network:`), no missing and no extra (mirrors the web UI's i18n key check).
+4. **`run.sh` passes shellcheck.**
+5. **Version lock-step** — each channel's `config.yaml` `version` equals every `build.yaml` base-image tag, via `scripts/sync-homeassistant-addon-version.ps1 -Check` (the same script the release process uses as the single writer in set mode, and which `release.yml` re-checks — so CI and release can never disagree).
+
+The add-on wrapper **images** are published by `release.yml`'s `homeassistant-addon-publish` job, not by this workflow.
+
 ## Self-hosted runners
 
 Every Linux and Windows job picks its runner from a repository variable, falling back to GitHub-hosted runners when the variable is unset. macOS always runs on `macos-latest` (GitHub-hosted).
@@ -273,7 +337,7 @@ Set these under **Settings > Variables > Actions**. Each value is a JSON array o
 
 | Variable | Type | Example | Applies to |
 |----------|------|---------|------------|
-| `RUNNER_LINUX` | JSON label array | `["self-hosted","linux","x64"]` | x64 Linux rows of `_build.yml`, `e2e-ui`, `matter-bridge`, `docker-verify`, `docker-publish`, CodeQL, E2ECoverage, SonarCloud |
+| `RUNNER_LINUX` | JSON label array | `["self-hosted","linux","x64"]` | x64 Linux rows of `_build.yml`, `e2e-ui`, `matter-bridge`, `docker-verify`, `docker-publish`, `homeassistant-addon-publish`, the fuzzing matrix, CodeQL, E2ECoverage, SonarCloud |
 | `RUNNER_LINUX_ARM` | JSON label array | `["self-hosted","linux","arm64"]` | The arm64 Linux row of `_build.yml`. Falls back to the GitHub-hosted `ubuntu-24.04-arm` (free for public repos). |
 | `RUNNER_WINDOWS` | JSON label array | `["self-hosted","windows","x64"]` | Windows row of `_build.yml`, MSVC code analysis |
 
@@ -287,7 +351,7 @@ Self-hosted jobs also run extra steps the hosted jobs skip — they clean the wo
 
 Runner VM images are built with Packer under `cicd/packer/`. See [cicd/packer/README.md](https://github.com/iainchesworth/aqualink-automate/blob/main/cicd/packer/README.md) for the full provisioning, deployment, and registration procedure.
 
-The Linux runner base is **Ubuntu 26.04 LTS** (GCC 15, Clang/LLVM 21), provisioned by `cicd/packer/linux-runner.pkr.hcl` (boots `ISOs/ubuntu-26.04-autoinstall.iso`) and the `cicd/packer/scripts/linux/0{2,3}-*-toolchain.sh` scripts. Both the Architecture table in `cicd/packer/README.md` and the Packer template agree on this base. The Windows runner base is Windows Server 2022. (Note this 26.04 runner image is a different release from the `ubuntu:25.04` Docker base used by `Dockerfile`; see the docker-verify note above.)
+The Linux runner base is **Ubuntu 26.04 LTS** (GCC 15, Clang/LLVM 21), provisioned by `cicd/packer/linux-runner.pkr.hcl` (boots `ISOs/ubuntu-26.04-autoinstall.iso`) and the `cicd/packer/scripts/linux/0{2,3}-*-toolchain.sh` scripts. Both the Architecture table in `cicd/packer/README.md` and the Packer template agree on this base. The Windows runner base is Windows Server 2022.
 
 ## Caching
 


### PR DESCRIPTION
## Summary

`docs/ci-cd.md`'s "Workflow set" table claimed ten workflow files + two composite actions; there are fifteen and three. This audit reconciled the whole document against every file in `.github/workflows/`, verifying each description against the workflow's actual triggers and jobs before writing.

### Workflow set table
- Now the complete inventory: adds `publish-repos.yml`, `auto-tag.yml`, `suggest-version.yml`, `docs.yml`, and `homeassistant-addon.yml` rows, plus the `setup-msvc-env` composite action; drops the rotting file count from the intro.

### Sections synced with the code
- **release.yml** — the job graph showed four jobs; there are seven. Documents `homeassistant-addon-publish`, `publish-repos`, and `cleanup-failed-prerelease`; the multi-arch `runtime-assembled` image built from prebuilt install trees; the `edge` prerelease tag; the both-arch smoke test.
- **_build.yml** — adds the `upload_installtree` input; per-arch install trees (CI x64-only, release both); Linux release builds inside the `gcc:15-bookworm` (glibc-2.36) container; version stamping is `DERIVED_VERSION_OVERRIDE` only (the documented local `git tag` step no longer exists).
- **ci.yml** — documents the `changes`, `platform-macros`, and `ci-status` jobs and the docs-only gating; `e2e-ui` consumes the `build-and-test` install tree (no recompile); the mode table is trimmed to the six modes `e2e-ui` actually runs.
- **automated-codescanning.yml** — the doc said "there is no push trigger"; the `push: [main]` Security-tab-baseline trigger (with docs `paths-ignore`) is now documented, as is the full 13-mode coverage sweep (incl. the MQTT loopback-broker and persistence modes).
- **fuzzing.yml** — ten harnesses over all untrusted-input parsers (the doc listed two decoders-only), with the current PR path filters.
- New sections: **Release helpers** (`auto-tag.yml` was previously documented nowhere), **Docs site**, **Home Assistant add-on validation**.
- Fixes stale base-image references (`ubuntu:25.04` → `26.04`, `node:24` → `node:26`) and small wording drift (concurrency key, "three PR-facing jobs", `RUNNER_LINUX` applies-to list).

## Validation

- Every claim verified against the workflow files on `develop`.
- `mkdocs build --strict` run locally: this change adds **zero** warnings. (The two pre-existing warnings on `develop` are relative links that `main` already converted to absolute URLs in dae67707; they self-heal at the next promotion merge, and docs CI only builds from `main`.)

## Note

PR #128 (`feat/ha-companion-package`) edits the same intro/table region and adds its own `ha-companion.yml` row — whichever lands second hits a small conflict; resolve by keeping this inventory plus #128's row and section.
