### PR TITLE
docs: sync MQTT/HA entity docs and site nav with code

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -139,7 +139,7 @@ its default form — starts as root to drop privileges. A tailored AppArmor prof
 confines that surface to only what it needs (serial devices, `/data`, TCP for the HTTP
 server / MQTT client / remote serial, and the exec chain), so a compromise cannot roam
 the host. The canonical profile lives with the Home Assistant add-on at
-[`aqualink-automate/apparmor.txt.draft`](../aqualink-automate/apparmor.txt.draft).
+[`aqualink-automate/apparmor.txt.draft`](https://github.com/iainchesworth/aqualink-automate/blob/main/aqualink-automate/apparmor.txt.draft).
 
 - **Home Assistant add-on.** The Supervisor auto-loads and **enforces** a file named
   exactly `apparmor.txt` in the add-on folder. The profile currently ships as

--- a/docs/homeassistant-addon.md
+++ b/docs/homeassistant-addon.md
@@ -14,7 +14,7 @@ failure, and applying updates. The add-on is a thin wrapper around the same mult
 image the project already publishes; it does not rebuild the application.
 
 The add-on manifests live at the root of this repository
-([`aqualink-automate/`](../aqualink-automate/) and `aqualink-automate-edge/`, with
+([`aqualink-automate/`](https://github.com/iainchesworth/aqualink-automate/tree/main/aqualink-automate) and `aqualink-automate-edge/`, with
 `repository.yaml`); the design rationale is in
 [docs/design/homeassistant-addon.md](design/homeassistant-addon.md).
 
@@ -22,7 +22,7 @@ The add-on manifests live at the root of this repository
 
 - **Home Assistant OS** or **Home Assistant Supervised**. Add-ons require the
   Supervisor, so **HA Container** and **HA Core** cannot install them — on those, run
-  the application with the project's [`docker-compose.yml`](../docker-compose.yml) or a
+  the application with the project's [`docker-compose.yml`](https://github.com/iainchesworth/aqualink-automate/blob/main/docker-compose.yml) or a
   native package instead (see [INSTALL.md](INSTALL.md)).
 - A host architecture of **`aarch64`** (64-bit Pi 4/5, most HAOS installs) or
   **`amd64`**. 32-bit `armv7`/`armhf` (Pi 3 and older 32-bit HAOS) is **not supported** —

--- a/docs/mqtt-home-assistant.md
+++ b/docs/mqtt-home-assistant.md
@@ -100,7 +100,7 @@ These carry current state and are published **retained**, so a subscriber that c
 | `aqualink/system/status` | `{ "online": true, "uptime_seconds": ... }` |
 | `aqualink/system/version` | Application version and build date. |
 | `aqualink/system/equipment` | `model_number`, `firmware_revision`. |
-| `aqualink/pool/temperatures` | `air`, `pool`, `spa`, `freeze_protect`, `pool_setpoint`, `spa_setpoint`. |
+| `aqualink/pool/temperatures` | `air`, `pool`, `spa`, `freeze_protect`, `pool_setpoint`, `pool_setpoint_2`, `spa_setpoint`, `pool_heater_2_enabled`. Each temperature is an object with `celsius`/`fahrenheit` (null when not reported); all except `pool_setpoint_2` add a `last_updated` timestamp and a `stale` flag, which is only ever true for the live readings (`air`, `pool`, `spa`). |
 | `aqualink/pool/chemistry` | `orp.value_mv`, `ph.value`, `salt.value_ppm`. |
 | `aqualink/pool/circulation` | `mode`, `spa_mode`, `clean_mode`, `pool_configuration`, optional `active_body`, optional `timeout_remaining_seconds`. |
 | `aqualink/pool/configuration` | `pool_type`, `system_board`, `equipment_mode`, `date`, `time`. |
@@ -168,8 +168,9 @@ Inbound payloads are parsed as JSON. If a payload is not valid JSON, the raw str
 | `aqualink/command/chlorinator/percentage` | number `0`–`100` | Set the chlorinator output percentage. |
 | `aqualink/command/chlorinator/boost` | `ON` or `OFF` | Enable or disable chlorinator boost. |
 | `aqualink/command/circulation/mode` | `pool`, `spa`, or `spillover` | Set the circulation mode. |
+| `aqualink/command/heater/{slug}` | `ON` or `OFF` | Enable or disable one discovered heater's thermostat (routed to the heater's body of water; the controller decides when to actually fire). |
 
-**Note:** The `device/{slug}`, `chlorinator/*`, and per-device commands are registered once the matching pool devices are discovered on the wire. Until a device is seen, its command topic has no handler.
+**Note:** The `device/{slug}`, `heater/{slug}`, `chlorinator/*`, and per-device commands are registered once the matching pool devices are discovered on the wire. Until a device is seen, its command topic has no handler.
 
 ### Responses
 
@@ -216,12 +217,17 @@ Each entity's `unique_id` follows the pattern `<ha-device-id>_<suffix>`.
 
 ### Static entity types
 
-These entities are always published:
+These entities are always published (pool-/spa-specific rows are omitted on systems without that body; before the pool configuration is detected, both bodies' entities are emitted):
 
 | Entity | Platform | Notes |
 | --- | --- | --- |
 | Pool / Spa / Air / Freeze Protect temperatures | `sensor` | `device_class: temperature`, unit degC. |
+| Pool / Spa / Air Temperature Last Updated | `sensor` | `device_class: timestamp`, `entity_category: diagnostic`. Freshness companion for each live temperature, reading its `last_updated` field. |
+| Pool / Spa / Air Temperature Stale | `binary_sensor` | `device_class: problem`, `entity_category: diagnostic`. On when the reading is older than `--temperature-staleness-threshold` (a never-seen reading is null, not stale). Lets you see a reading has gone old without the value disappearing — the controller only reports temperatures while the filter pump runs. |
 | Pool / Spa setpoint | `number` | Follows the `temperature_units` preference: min 15, max 41, step 0.5, °C (default), or min 59, max 106, step 1, °F. Command on `command/setpoint/{pool,spa}`, interpreted in the declared unit. Changing the preference republishes discovery so HA picks up the new unit/range. (Temperature *sensors* stay declared °C — their payload is Celsius and HA converts sensors to its own unit system.) |
+| Pool Setpoint 2 | `sensor` | The POOLSP2 / panel "TEMP2" maintenance setpoint (reported only on single-body systems). Read-only — a `sensor`, not a writable `number` — because the POOLSP2 write path is not yet validated on live hardware. Shows a value only when the panel reports it. |
+| Pool Heater 2 (TEMP2) | `binary_sensor` | Whether TEMP2 maintenance heating is enabled. Read-only, `payload_on: true` / `payload_off: false`. |
+| Spa Mode (switch) | `switch` | Dual-body systems only. Convenient pool↔spa toggle: on sends `spa`, off sends `pool` on `command/circulation/mode` (the same handler as the select below). |
 | ORP | `sensor` | `device_class: voltage`, unit mV. |
 | pH | `sensor` | `device_class: ph`. |
 | Salt Level | `sensor` | unit ppm. |
@@ -256,7 +262,7 @@ One entity (or a small set) is published per discovered pool device:
 | --- | --- | --- |
 | Pump | `switch` | `state_on: Running`, `state_off: Off`. |
 | Auxiliary | `switch` | `state_on: On`, `state_off: Off`. |
-| Heater | `sensor` | `Off` / `Heating` / `Enabled`. |
+| Heater | `sensor` + `switch` | Sensor: `Off` / `Heating` / `Enabled`. Switch "{label} Enable": on when the heater is `Heating` or `Enabled`, command on `command/heater/{slug}` — it enables/disables the heater's thermostat; the controller decides when to actually fire and enforces its own preconditions (e.g. spa heat requires spa mode + pump). |
 | Chlorinator | `switch` + extras | `state_on: On`, `state_off: Off`, plus the entities below. |
 
 Switch entities use `payload_on: ON` / `payload_off: OFF` on their command topic.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
       - Configuration: configuration.md
       - Usage, HTTP API & WebSocket: usage-and-api.md
       - MQTT & Home Assistant: mqtt-home-assistant.md
+      - Home Assistant add-on: homeassistant-addon.md
       - Matter (smart home): MATTER.md
       - Raspberry Pi: raspberry-pi.md
       - RS-485 wiring: hardware-rs485-connectivity.md


### PR DESCRIPTION
Fixes confirmed documentation drift found during a code survey (each item re-verified against `src/core/mqtt/ha_discovery.cpp`, `MqttHub::SerializeTemperatures`, and `MqttIntegration` on current `develop` before this update):

- **docs/mqtt-home-assistant.md** — catch the entity tables up to `HomeAssistantDiscovery`:
  - temperature freshness companions (`* Last Updated` timestamp sensors + `* Stale` problem binary_sensors for pool/spa/air, `entity_category: diagnostic`)
  - read-only **Pool Setpoint 2** sensor (POOLSP2/TEMP2; deliberately not a writable `number`)
  - **Pool Heater 2 (TEMP2)** binary_sensor
  - dual-body **Spa Mode** switch (on→`spa`, off→`pool` via `command/circulation/mode`)
  - per-heater **"{label} Enable"** switch (`heater_{slug}_switch`, command `command/heater/{slug}`), plus a `command/heater/{slug}` row in the command-topic table (handler: `MqttIntegration` `register_heater` → `SetHeaterMode`)
  - `aqualink/pool/temperatures` payload row rewritten to match `MqttHub::SerializeTemperatures` exactly: every temperature object is `celsius`/`fahrenheit` (null when not reported); all except `pool_setpoint_2` add `last_updated` + `stale` (`stale` only ever true for the live `air`/`pool`/`spa` readings)
- **mkdocs.yml** — add the Home Assistant add-on page to the User guide nav (it was orphaned, reachable only via inline links).
- Convert repo-root relative links (`apparmor.txt.draft`, `docker-compose.yml`, the add-on folder) to full GitHub URLs — they 404'd on the published site and failed `mkdocs build --strict`.

Rebased onto current `develop`: the add-on LAN-port correction (80 → 8099) that was originally part of this change landed independently via #124 and dropped out of the diff.

Overlap with #128 (open): the `docs/SECURITY.md` and `docker-compose.yml` URL hunks are byte-identical on both branches and will auto-resolve in either merge order. The `mkdocs.yml` nav line collides with #128's `homeassistant-companion.md` entry at the same spot — whichever merges second hits a trivial conflict; resolve by keeping **both** nav entries. (The companion entry can't be added here: the page doesn't exist on `develop` yet and would fail the strict build.)

`mkdocs build --strict` passes on this branch as rebased (only pre-existing INFO-level notices remain).