### PR TITLE
chore(release): Home Assistant add-on 0.12.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.12.0-beta.9] - 2026-08-07
+
+Home Assistant add-on maintenance release — no changes to the core application.
+
+### Fixed
+
+- **Add-on storage map renamed `addon_config` → `app_config`**, following the Supervisor's add-ons→apps rename. This silences the deprecation warning the Supervisor logged on every store refresh ("uses legacy map type 'addon_config'; use 'app_config' instead."). Same mount, same paths — but the add-on now needs Supervisor 2026.07.1 (2026-07-08) or newer; an older Supervisor will not list or update the add-on until it self-updates. See [docs/homeassistant-addon.md](docs/homeassistant-addon.md).
+
+### Changed
+
+- Dependency updates: Matter bridge (matter.js group) and Playwright test tooling (Dependabot).
+
 ## [0.12.0-beta.8] - 2026-07-12
 
 More Home Assistant add-on fixes from real install testing — no changes to the core application.

--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0-beta.9
 
 - **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
   add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -10,7 +10,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate (Edge)
-version: "0.12.0-beta.8"
+version: "0.12.0-beta.9"
 slug: aqualink_automate_edge
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0-beta.9
 
 - **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
   add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -8,7 +8,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate
-version: "0.12.0-beta.8"
+version: "0.12.0-beta.9"
 slug: aqualink_automate
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel


### PR DESCRIPTION
Release prep for **v0.12.0-beta.9** — ships the `addon_config` → `app_config` storage-map rename (#126) to Home Assistant.

- `CHANGELOG.md`: new `[0.12.0-beta.9]` section (add-on maintenance release, no core app changes).
- Add-on `CHANGELOG.md`: `Unreleased` → `0.12.0-beta.9`.
- Both channels bumped to `0.12.0-beta.9` via `sync-homeassistant-addon-version.ps1`; edge regenerated (idempotent, version preserved).

After this lands on `develop`: promote `develop` → `main`, then tag `v0.12.0-beta.9` (the release lock-step guard requires the edge channel version == tag, which this provides).