### PR TITLE
Release 0.12.0-beta.9 — Home Assistant add-on app_config rename

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -182,13 +182,21 @@ jobs:
       # image bakes these in (cicd/packer/scripts/linux/06-dev-tools.sh), but install
       # them here too so the build also works on a not-yet-rebuilt image and on the
       # GitHub-hosted macOS runner. Windows builds libbacktrace without this path.
+      # On Linux, skip apt entirely when the packages are already present (the baked
+      # image case) and otherwise wait for the dpkg lock instead of failing — the
+      # self-hosted runners run unattended-upgrades, which briefly holds
+      # /var/lib/dpkg/lock-frontend and made a bare apt-get die with exit 100.
       - name: Install autotools for libbacktrace (Linux/macOS)
         if: ${{ runner.os != 'Windows' && !(inputs.do_package && runner.os == 'Linux') }}
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq autoconf autoconf-archive automake libtool
+            if dpkg -s autoconf autoconf-archive automake libtool >/dev/null 2>&1; then
+              echo "autotools already installed; skipping apt-get"
+            else
+              sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
+              sudo apt-get -o DPkg::Lock::Timeout=600 install -y -qq autoconf autoconf-archive automake libtool
+            fi
           elif [ "$RUNNER_OS" = "macOS" ]; then
             brew install autoconf autoconf-archive automake libtool
           fi

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -100,7 +100,7 @@ jobs:
           fi
           rm -rf build install
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: ${{ inputs.fetch_depth }}

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: write   # push the next prerelease tag
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/automated-codescanning.yml
+++ b/.github/workflows/automated-codescanning.yml
@@ -92,7 +92,7 @@ jobs:
         fi
         rm -rf build install
 
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
@@ -102,7 +102,7 @@ jobs:
         compiler: gcc-15
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: ${{ matrix.language }}
 
@@ -141,7 +141,7 @@ jobs:
         VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         upload: false
 
@@ -155,7 +155,7 @@ jobs:
         output: '../results/cpp.sarif'
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         category: "/language:${{ matrix.language }}"
 
@@ -198,17 +198,17 @@ jobs:
 
     steps:
     # No submodules: JS/TS analysis needs none of the C++ deps under deps/.
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: javascript-typescript
         build-mode: none
         config-file: ./.github/codeql/codeql-config-js.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         category: "/language:javascript-typescript"
 
@@ -257,7 +257,7 @@ jobs:
         fi
         rm -rf build install
 
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
@@ -311,7 +311,7 @@ jobs:
       env:
         VCPKG_ROOT: ${{ github.workspace }}/deps/vcpkg
 
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: "22"
         cache: npm
@@ -541,7 +541,7 @@ jobs:
         fi
         rm -rf build install
 
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         submodules: recursive
@@ -552,7 +552,7 @@ jobs:
         compiler: gcc-15
 
     - name: Install build-wrapper
-      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@713881670b6b3676cda39549040e2d88c70d582e # v8
+      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8
 
     - name: Setup vcpkg cache (self-hosted)
       if: contains(vars.RUNNER_LINUX || '', 'self-hosted')
@@ -613,7 +613,7 @@ jobs:
         fi
 
     - name: Run SonarCloud scan
-      uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -655,7 +655,7 @@ jobs:
         fi
         rm -rf build install
 
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
@@ -724,7 +724,7 @@ jobs:
         ignoredPaths: ${{ github.workspace }}/deps;${{ github.workspace }}/src/version;${{ github.workspace }}/test
 
     - name: Upload SARIF to GitHub
-      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         sarif_file: ${{ steps.run-analysis.outputs.sarif }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,11 @@ jobs:
   # Enforce the branch naming convention on every PR. Branches must be
   # <type>/<name> with an allowed Conventional Commit type (see CONTRIBUTING.md).
   # develop/main are accepted as PR heads so the develop->main release-promotion
-  # PR (head_ref == develop) is never blocked. This "Branch Name" check is a
-  # required status check on develop/main, so a misnamed branch cannot merge. (A
+  # PR (head_ref == develop) is never blocked, and dependabot/** is accepted
+  # because Dependabot's branch names are not configurable (and this check being
+  # required would otherwise permanently block every Dependabot PR — see the
+  # dependabot-auto-merge workflow). This "Branch Name" check is a required
+  # status check on develop/main, so a misnamed branch cannot merge. (A
   # server-side branch-name ruleset would also block at push/creation time, but
   # that rule type needs a GitHub organization plan — unavailable on a user repo.)
   branch-name:
@@ -93,6 +96,10 @@ jobs:
         run: |
           if [[ "$HEAD_REF" == "develop" || "$HEAD_REF" == "main" ]]; then
             echo "Core branch '$HEAD_REF' — allowed (release promotion)."
+            exit 0
+          fi
+          if [[ "$HEAD_REF" == dependabot/* ]]; then
+            echo "Dependabot branch '$HEAD_REF' — allowed (branch names are not configurable)."
             exit 0
           fi
           pattern='^(feat|fix|docs|ci|test|refactor|chore|build|perf)/[a-z0-9._-]+$'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     name: I18n Catalogs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check catalog completeness and locale parity
         shell: pwsh
         run: ./scripts/check-i18n-keys.ps1 -Root $PWD
@@ -127,7 +127,7 @@ jobs:
     name: Platform Macros
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check for OS macros in shared code
         shell: pwsh
         run: ./scripts/check-os-macros.ps1 -Root $PWD
@@ -161,7 +161,7 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_LINUX || '["ubuntu-latest"]') }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
@@ -178,7 +178,7 @@ jobs:
           tar xzf installtree-art/installtree-linux-gcc.tar.gz -C installtree
           chmod +x installtree/bin/aqualink-automate
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
@@ -270,9 +270,9 @@ jobs:
         working-directory: matter-bridge
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -342,7 +342,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
@@ -354,7 +354,7 @@ jobs:
       # receive no secrets) still build anonymously.
       - name: Login to Docker Hub
         if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/cleanup-branch-caches.yml
+++ b/.github/workflows/cleanup-branch-caches.yml
@@ -17,7 +17,7 @@ jobs:
       actions: write   # delete the closed PR's caches
     steps:
       - name: Check out code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Clean Up Caches
         run: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+# Enable GitHub auto-merge on routine Dependabot PRs so grouped dependency bumps
+# land on develop without manual intervention.
+#
+# How it works: this job only flips the PR's auto-merge bit — GitHub itself then
+# merges (squash) once every REQUIRED status check passes. The required checks on
+# develop are "Branch Name" (which exempts dependabot/** heads — Dependabot's
+# branch names are not configurable) and the aggregated "CI Status", so nothing
+# merges without the full build/test matrix going green. Non-required checks
+# (e.g. SonarCloud, which cannot pass on Dependabot PRs — Dependabot-triggered
+# runs receive Dependabot secrets, not repo secrets like SONAR_TOKEN) do not
+# block it.
+#
+# Scope: only non-major updates auto-merge. For grouped PRs fetch-metadata
+# reports the HIGHEST bump in the group, so a group containing any semver-major
+# update stays open for manual review; digest-only bumps (the docker group's
+# pinned base images) report no semver level and auto-merge. The squash commit
+# takes the PR title, which is already Conventional-Commit shaped via the
+# commit-message prefixes in .github/dependabot.yml.
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'iainchesworth/aqualink-automate'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge (non-major updates only)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,10 +44,10 @@ jobs:
       contents: write # push to gh-pages
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -87,7 +87,7 @@ jobs:
           fi
           rm -rf build install
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 1

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -101,22 +101,29 @@ jobs:
       # runtimes (libclang_rt.fuzzer.a / libclang_rt.asan*.a). Neither aminya/setup-cpp's
       # apt.llvm.org clang (hosted) NOR the self-hosted runner image ships them, so install
       # the matching libclang-rt-<major>-dev for the selected clang. Runs on EVERY Linux
-      # runner (the autotools step below likewise apt-installs unconditionally); if the
-      # package isn't already indexed, add the apt.llvm.org source for that version + codename.
+      # runner, installing only when the package is missing; if it isn't already
+      # indexed, add the apt.llvm.org source for that version + codename.
       - name: Install LLVM compiler-rt runtimes (fuzzer + sanitizers)
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          # -o DPkg::Lock::Timeout waits out transient dpkg-lock holders on the
+          # persistent self-hosted runners (unattended-upgrades) instead of exit 100.
+          apt_get() { sudo apt-get -o DPkg::Lock::Timeout=600 "$@"; }
           ver="$(clang --version | sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p' | head -1)"
-          echo "Installing compiler-rt runtimes for clang major version ${ver}"
-          sudo apt-get update -qq
-          if ! sudo apt-get install -y -qq "libclang-rt-${ver}-dev"; then
-            echo "libclang-rt-${ver}-dev not indexed; adding apt.llvm.org source"
-            . /etc/os-release
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
-            echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${ver} main" | sudo tee "/etc/apt/sources.list.d/llvm-${ver}.list" >/dev/null
-            sudo apt-get update -qq
-            sudo apt-get install -y -qq "libclang-rt-${ver}-dev"
+          if dpkg -s "libclang-rt-${ver}-dev" >/dev/null 2>&1; then
+            echo "libclang-rt-${ver}-dev already installed; skipping apt-get"
+          else
+            echo "Installing compiler-rt runtimes for clang major version ${ver}"
+            apt_get update -qq
+            if ! apt_get install -y -qq "libclang-rt-${ver}-dev"; then
+              echo "libclang-rt-${ver}-dev not indexed; adding apt.llvm.org source"
+              . /etc/os-release
+              wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+              echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-${ver} main" | sudo tee "/etc/apt/sources.list.d/llvm-${ver}.list" >/dev/null
+              apt_get update -qq
+              apt_get install -y -qq "libclang-rt-${ver}-dev"
+            fi
           fi
           echo "compiler-rt libs:"; ls "/usr/lib/llvm-${ver}/lib/clang/${ver}/lib/"*/ 2>/dev/null | grep -i "fuzzer\|asan" || true
 
@@ -131,11 +138,18 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;default,readwrite"
 
+      # Skip apt when the packages are already baked into the runner image; otherwise
+      # wait for the dpkg lock (unattended-upgrades briefly holds it on the
+      # self-hosted runners) instead of failing with exit 100. Mirrors _build.yml.
       - name: Install autotools for libbacktrace
         shell: bash
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq autoconf autoconf-archive automake libtool
+          if dpkg -s autoconf autoconf-archive automake libtool >/dev/null 2>&1; then
+            echo "autotools already installed; skipping apt-get"
+          else
+            sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
+            sudo apt-get -o DPkg::Lock::Timeout=600 install -y -qq autoconf autoconf-archive automake libtool
+          fi
 
       - name: Configure
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9

--- a/.github/workflows/homeassistant-addon.yml
+++ b/.github/workflows/homeassistant-addon.yml
@@ -26,7 +26,7 @@ jobs:
     name: Validate add-on
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install YAML parser
         run: sudo apt-get update && sudo apt-get install -y python3-yaml shellcheck

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -61,11 +61,11 @@ jobs:
 
       - name: Checkout (work tree)
         if: env.HAVE_GPG_KEY == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Checkout gh-pages (existing repo state)
         if: env.HAVE_GPG_KEY == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       # Needed for the "cut from main" guard below (merge-base ancestry check).
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -180,7 +180,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
@@ -198,14 +198,14 @@ jobs:
       # credential-less runs still build anonymously. See docs/releasing.md.
       - name: Login to Docker Hub
         if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -386,7 +386,7 @@ jobs:
           - { ha_arch: amd64,   platform: linux/amd64 }
           - { ha_arch: aarch64, platform: linux/arm64 }
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # QEMU lets buildx assemble the linux/arm64 wrapper on the x64 runner. The layer
       # is just apt (jq) + a bashio tarball + run.sh, so the emulated work is light.
@@ -394,7 +394,7 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -487,7 +487,7 @@ jobs:
       HAVE_GPG_KEY: ${{ secrets.REPO_GPG_PRIVATE_KEY != '' && 'true' || 'false' }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Push tag for dispatch builds
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 
     - name: Run Scorecard analysis
-      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
       with:
         results_file: results.sarif
         results_format: sarif
@@ -50,7 +50,7 @@ jobs:
         publish_results: true
 
     - name: Upload Scorecard SARIF
-      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         sarif_file: results.sarif
         category: scorecard

--- a/.github/workflows/suggest-version.yml
+++ b/.github/workflows/suggest-version.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Full history + tags so the script can anchor on the highest v* tag and
       # examine every commit being published.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -63,7 +63,7 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Build ONLY the runtime-base stage: Ubuntu + NodeSource Node + the Matter
     # sidecar (matter-builder is a build dependency of runtime-base). This does NOT
@@ -88,7 +88,7 @@ jobs:
     # (default exit-code 0), so this always has a SARIF to publish.
     - name: Upload Trivy SARIF
       if: ${{ !cancelled() }}
-      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         sarif_file: trivy-results.sarif
         category: trivy-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 See [docs/releasing.md](docs/releasing.md) for how releases and version numbers are cut.
 
+## [0.12.0-beta.9] - 2026-08-07
+
+Home Assistant add-on maintenance release — no changes to the core application.
+
+### Fixed
+
+- **Add-on storage map renamed `addon_config` → `app_config`**, following the Supervisor's add-ons→apps rename. This silences the deprecation warning the Supervisor logged on every store refresh ("uses legacy map type 'addon_config'; use 'app_config' instead."). Same mount, same paths — but the add-on now needs Supervisor 2026.07.1 (2026-07-08) or newer; an older Supervisor will not list or update the add-on until it self-updates. See [docs/homeassistant-addon.md](docs/homeassistant-addon.md).
+
+### Changed
+
+- Dependency updates: Matter bridge (matter.js group) and Playwright test tooling (Dependabot).
+
 ## [0.12.0-beta.8] - 2026-07-12
 
 More Home Assistant add-on fixes from real install testing — no changes to the core application.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage: base (shared tooling for dev, ci, and runtime builds)
 # ==============================================================================
 
-FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS base
+FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS base
 
 ARG GCC_VERSION=15
 ARG LLVM_VERSION=21
@@ -180,7 +180,7 @@ RUN npm run build \
 #   - runtime-assembled : app from a prebuilt install tree staged into the context
 #                         (no recompile; used by release.yml docker-publish)
 
-FROM ubuntu:26.04@sha256:b7f48194d4d8b763a478a621cdc81c27be222ba2206ca3ca6bc42b49685f3d9e AS runtime-base
+FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bca2b7063bb AS runtime-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0-beta.9
 
 - **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
   add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation

--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
+  add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation
+  warning logged on every store refresh). Same mount, same paths — but the new name
+  needs Supervisor 2026.07.1 (2026-07-08) or newer; an older Supervisor will not list
+  or update the add-on until it self-updates.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate-edge/CHANGELOG.md
+++ b/aqualink-automate-edge/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **The add-on now reaches "Running", and the Watchdog no longer kill-loops it.** The container health probe inherited from the app image still pointed at the app's default port `80`, but the add-on runs the app on `8099` (since 0.12.0-beta.6) — so the container never reported healthy: the add-on sat in "Starting" forever and, with **Watchdog** enabled, was restarted every ~80 seconds. The probe now targets the add-on's real port. If you disabled the Watchdog toggle to work around this, it is safe to turn back on.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate-edge/Dockerfile
+++ b/aqualink-automate-edge/Dockerfile
@@ -29,6 +29,14 @@ RUN apt-get update \
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
+# The base image's HEALTHCHECK curls ${AQUALINK_API_URL}/api/health, and the base
+# default points at the app's default port 80 — but run.sh starts the app on the
+# add-on's fixed port 8099. Without this override the probe fails forever, Docker
+# reports the container "unhealthy", the Supervisor never shows the add-on as
+# "Running", and the add-on Watchdog kill/restarts it every ~80s. (The Matter
+# sidecar, the env's other consumer, is disabled in the add-on.)
+ENV AQUALINK_API_URL=http://127.0.0.1:8099
+
 # tini (from the base image) stays PID 1 and now supervises run.sh, which builds the
 # argv and execs the base image's docker-entrypoint.sh.
 ENTRYPOINT ["/usr/bin/tini", "--", "/run.sh"]

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -48,13 +48,19 @@ services:
 # Storage maps:
 #   - ssl (read-only): HA's /ssl share, so the MQTT TLS certificate options
 #     (mqtt_ca_cert / mqtt_client_cert / mqtt_client_key) can point at files there.
-#   - addon_config (read-write): the add-on's own user-accessible config directory
-#     (/config in the container; /addon_configs/<slug> on the host, editable via Samba /
-#     the File editor) for user-managed files.
+#   - app_config (read-write): the add-on's own user-accessible config directory
+#     (/config in the container; /app_configs/<slug> on the host — /addon_configs/
+#     before Supervisor 2026.07 — editable via Samba / the File editor) for
+#     user-managed files. `app_config` is the add-ons→apps rename of `addon_config`
+#     (Supervisor 2026.07.1, 2026-07-08); the old name still works but logs a
+#     deprecation warning on every store refresh, while the new name requires
+#     Supervisor >= 2026.07.1 (an older Supervisor rejects the manifest and hides
+#     the add-on until it auto-updates — acceptable, since the Supervisor
+#     self-updates and only the latest version is supported).
 map:
   - type: ssl
     read_only: true
-  - type: addon_config
+  - type: app_config
     read_only: false
 # Web UI via INGRESS: Home Assistant serves the UI through its own authenticated
 # proxy and shows it in the sidebar — not published on the LAN, and secured by HA's

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -10,7 +10,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate (Edge)
-version: "0.12.0-beta.8"
+version: "0.12.0-beta.9"
 slug: aqualink_automate_edge
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.0-beta.9
 
 - **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
   add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **Storage map renamed `addon_config` → `app_config`**, following the Supervisor's
+  add-ons→apps rename (silences the "uses legacy map type 'addon_config'" deprecation
+  warning logged on every store refresh). Same mount, same paths — but the new name
+  needs Supervisor 2026.07.1 (2026-07-08) or newer; an older Supervisor will not list
+  or update the add-on until it self-updates.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate/CHANGELOG.md
+++ b/aqualink-automate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **The add-on now reaches "Running", and the Watchdog no longer kill-loops it.** The container health probe inherited from the app image still pointed at the app's default port `80`, but the add-on runs the app on `8099` (since 0.12.0-beta.6) — so the container never reported healthy: the add-on sat in "Starting" forever and, with **Watchdog** enabled, was restarted every ~80 seconds. The probe now targets the add-on's real port. If you disabled the Watchdog toggle to work around this, it is safe to turn back on.
+
 ## 0.12.0-beta.8
 
 - **Manual MQTT mode is configurable again.** The broker fields (`mqtt_host`, `mqtt_username`, `mqtt_password`) now appear in the options form — Home Assistant hides optional fields that carry no default, so `mqtt_mode: manual` previously had nowhere to enter the broker. An empty host in manual mode is now rejected with a clear message.

--- a/aqualink-automate/Dockerfile
+++ b/aqualink-automate/Dockerfile
@@ -29,6 +29,14 @@ RUN apt-get update \
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
+# The base image's HEALTHCHECK curls ${AQUALINK_API_URL}/api/health, and the base
+# default points at the app's default port 80 — but run.sh starts the app on the
+# add-on's fixed port 8099. Without this override the probe fails forever, Docker
+# reports the container "unhealthy", the Supervisor never shows the add-on as
+# "Running", and the add-on Watchdog kill/restarts it every ~80s. (The Matter
+# sidecar, the env's other consumer, is disabled in the add-on.)
+ENV AQUALINK_API_URL=http://127.0.0.1:8099
+
 # tini (from the base image) stays PID 1 and now supervises run.sh, which builds the
 # argv and execs the base image's docker-entrypoint.sh.
 ENTRYPOINT ["/usr/bin/tini", "--", "/run.sh"]

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -46,13 +46,19 @@ services:
 # Storage maps:
 #   - ssl (read-only): HA's /ssl share, so the MQTT TLS certificate options
 #     (mqtt_ca_cert / mqtt_client_cert / mqtt_client_key) can point at files there.
-#   - addon_config (read-write): the add-on's own user-accessible config directory
-#     (/config in the container; /addon_configs/<slug> on the host, editable via Samba /
-#     the File editor) for user-managed files.
+#   - app_config (read-write): the add-on's own user-accessible config directory
+#     (/config in the container; /app_configs/<slug> on the host — /addon_configs/
+#     before Supervisor 2026.07 — editable via Samba / the File editor) for
+#     user-managed files. `app_config` is the add-ons→apps rename of `addon_config`
+#     (Supervisor 2026.07.1, 2026-07-08); the old name still works but logs a
+#     deprecation warning on every store refresh, while the new name requires
+#     Supervisor >= 2026.07.1 (an older Supervisor rejects the manifest and hides
+#     the add-on until it auto-updates — acceptable, since the Supervisor
+#     self-updates and only the latest version is supported).
 map:
   - type: ssl
     read_only: true
-  - type: addon_config
+  - type: app_config
     read_only: false
 # Web UI via INGRESS: Home Assistant serves the UI through its own authenticated
 # proxy and shows it in the sidebar — not published on the LAN, and secured by HA's

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -8,7 +8,7 @@
 # `version` is the single source of truth: it is both the wrapper image tag pulled and
 # the base image tag built FROM. The CI `Home Assistant Add-on` check enforces it.
 name: Aqualink Automate
-version: "0.12.0-beta.8"
+version: "0.12.0-beta.9"
 slug: aqualink_automate
 # Pre-1.0: no stable release exists yet, so the main channel is marked experimental.
 # Flip to `stable` at the first non-prerelease release. The generated Edge channel

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git switch -c fix/heater-setpoint-decode  # a bug fix
 
 This convention is checked automatically:
 
-- A **Branch Name** check runs on every pull request and fails a non-conforming head branch (`.github/workflows/ci.yml`). `develop` and `main` are accepted as heads so the `develop` -> `main` release-promotion PR is never blocked. It is a [required status check](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) on `develop` and `main`, so a non-conforming branch cannot merge.
+- A **Branch Name** check runs on every pull request and fails a non-conforming head branch (`.github/workflows/ci.yml`). `develop` and `main` are accepted as heads so the `develop` -> `main` release-promotion PR is never blocked, and `dependabot/**` heads are accepted because Dependabot's branch names are not configurable. It is a [required status check](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging) on `develop` and `main`, so a non-conforming branch cannot merge.
 - Push/creation-time enforcement (a server-side branch-name **ruleset**) is a GitHub organization feature and is not available on this user-owned repository, so a misnamed branch can exist locally — it just fails CI and, once the check is required, cannot merge.
 
 Continuous integration builds on a `push` only to the long-lived branches `main` and `develop`. Feature branches build via their **pull request** into `develop`/`main` instead — so a work-in-progress push to a branch that has no open PR runs no CI (see `.github/workflows/ci.yml`).

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,22 +4,28 @@
 
 ## Workflow set
 
-The pipeline is ten workflow files plus two composite actions, all under `.github/`.
+The table below is the complete inventory of everything under `.github/` — the core build/test/release pipeline, the scanners, and the self-contained supporting workflows, plus the repo's composite actions. Every workflow has a section below.
 
 | File | Kind | Purpose |
 |------|------|---------|
 | `.github/workflows/ci.yml` | Workflow | Build, test, e2e, and Docker verification on every push and PR. |
 | `.github/workflows/_build.yml` | Reusable workflow (`workflow_call`) | The shared configure/build/test/package matrix. Called by both `ci.yml` and `release.yml`. |
-| `.github/workflows/release.yml` | Workflow | Build packages, publish the Docker image, and create the GitHub release for a `v*` tag. |
+| `.github/workflows/release.yml` | Workflow | Build packages, publish the Docker + Home Assistant add-on images, create the GitHub release, and publish the APT/DNF repos for a `v*` tag. |
+| `.github/workflows/publish-repos.yml` | Reusable workflow (`workflow_call`) + dispatch | Publish the GPG-signed APT/DNF package repos to `gh-pages`. Called by `release.yml` after the release is created; dispatchable to (re)publish a tag. |
+| `.github/workflows/auto-tag.yml` | Workflow | Opt-in (repo variable `AUTO_TAG_ENABLED`): advances the prerelease counter tag on a code push to `main`, firing `release.yml`. Off by default — tags are pushed by hand. |
+| `.github/workflows/suggest-version.yml` | Workflow | Advisory next-version suggestion on the `develop` → `main` release PR (sticky comment). Never creates a tag. |
 | `.github/workflows/automated-codescanning.yml` | Workflow | CodeQL (C/C++ and JavaScript/TypeScript), SonarCloud, and MSVC static analysis on PRs and a weekly cron. |
 | `.github/workflows/cleanup-branch-caches.yml` | Workflow | Delete a PR's branch caches when it closes. |
 | `.github/workflows/trivy.yml` | Workflow | Trivy scan of the runtime container image (OS packages + Node deps) → Security tab. |
 | `.github/workflows/osv-scanner.yml` | Workflow | OSV-Scanner CVE check of declared dependencies, incl. the vcpkg C++ manifest → Security tab. |
 | `.github/workflows/scorecard.yml` | Workflow | OpenSSF Scorecard supply-chain posture grade → Security tab. |
-| `.github/workflows/fuzzing.yml` | Workflow | Bounded libFuzzer run over the RS-485 protocol decoders on a weekly cron + decoder-touching PRs. Feeds Scorecard's Fuzzing check. See [fuzzing.md](fuzzing.md). |
+| `.github/workflows/fuzzing.yml` | Workflow | Bounded libFuzzer run over the untrusted-input parsers (RS-485 decoders plus the JSON/config/web/auth inputs) on a weekly cron + parser-touching PRs. Feeds Scorecard's Fuzzing check. See [fuzzing.md](fuzzing.md). |
 | `.github/workflows/dependabot-auto-merge.yml` | Workflow | Flags non-major Dependabot PRs for GitHub auto-merge; they land on `develop` once the required checks pass. |
+| `.github/workflows/docs.yml` | Workflow | Build the MkDocs site (`mkdocs build --strict`) and publish it to the root of `gh-pages` on docs-affecting pushes to `main`. |
+| `.github/workflows/homeassistant-addon.yml` | Workflow | Validate the Home Assistant add-on wrapper (YAML, shellcheck, translation coverage, generated-Edge-channel drift, version lock-step) on add-on-touching pushes and PRs. |
 | `.github/actions/setup-cpp-toolchain` | Composite action | Install the platform-appropriate compiler and build tools. |
 | `.github/actions/setup-vcpkg-cache` | Composite action | Configure and restore the OS-keyed vcpkg binary cache. |
+| `.github/actions/setup-msvc-env` | Composite action | Load the MSVC environment on self-hosted Windows runners (sources `vcvars64.bat`, exports the env delta to `$GITHUB_ENV`). |
 
 `ci.yml` and `release.yml` share one build definition (`_build.yml`), so the suites that run on a PR and the suites that gate a release can never drift.
 
@@ -39,19 +45,24 @@ on:
 
 Only `main` and `develop` build on push. Feature branches build via their `pull_request` into `develop`/`main` (the `pull_request` trigger targets those two branches). A WIP push to a branch that has no open PR runs no CI at all — and a push to a branch that *does* have a PR is already covered by the PR run, so this also avoids the push+PR double-run.
 
-Concurrency is keyed on the PR number (or the ref for branch pushes) with `cancel-in-progress: true`, so a new push supersedes an in-flight run for the same PR or branch.
+Concurrency is keyed on the PR head branch (or the ref for branch pushes) with `cancel-in-progress: true`, so a new push supersedes an in-flight run for the same PR or branch.
 
 ### Jobs
 
 | Job | Runs on | What it does |
 |-----|---------|--------------|
+| `changes` | `ubuntu-latest` | Classifies the change via the GitHub API: `docs/**`, `mkdocs.yml`, `docs.yml`, `LICENSE`, and `*.md` never affect the binary. The heavy jobs below run only when it reports `code == 'true'`; anything not clearly docs counts as code. |
 | `branch-name` | `ubuntu-latest` | PR only. Validates the PR head branch matches `<type>/<name>` with an allowed commit type, failing a non-conforming name. `develop`/`main` heads are accepted so the `develop` -> `main` release-promotion PR passes, and `dependabot/**` heads are accepted because Dependabot's branch names are not configurable (see [Dependabot auto-merge](#dependabot-auto-merge-dependabot-auto-mergeyml)). A **required** status check on `develop`/`main`, so a misnamed branch cannot merge. |
 | `build-and-test` | Per-OS matrix (see [_build.yml](#_buildyml)) | Calls `_build.yml` with no packaging. Configures, builds, and runs the full test suite on Linux, Windows, and macOS. |
-| `e2e-ui` | Linux | Builds only the app binary, then runs the Playwright UI suite once per mode (see the mode table below). |
+| `e2e-ui` | Linux | Downloads the install tree uploaded by `build-and-test` (no recompile), then runs the Playwright UI suite once per mode (see the mode table below). |
 | `matter-bridge` | Linux | Node job in `matter-bridge/`: `npm ci`, typecheck (including the matter.js bridge), build, and unit tests. |
 | `i18n-catalogs` | `ubuntu-latest` | Runs `scripts/check-i18n-keys.ps1`: every key referenced in web-UI code exists in `en.js`, and every shipped locale catalog has exact key + placeholder parity with English (see `docs/i18n.md`). Part of the `ci-status` aggregate. |
+| `platform-macros` | `ubuntu-latest` | Runs `scripts/check-os-macros.ps1`: no OS preprocessor macro may gate shared, non-platform source (see [platform-isolation.md](platform-isolation.md)). Part of the `ci-status` aggregate. |
 | `version-check` | `ubuntu-latest` | PR-into-`main` only. Compares what `git describe` resolves on the PR head versus the base. **Blocking at the job level** — when the resolved version is unchanged it emits `::error::` and `exit 1`, failing the job. It is, however, intentionally excluded from the `ci-status` aggregator's `needs` list, so a failed `version-check` does not by itself fail the aggregated `ci-status` required check. |
 | `docker-verify` | Linux | Builds the `ci` and `runtime` Docker targets, smoke-tests the runtime image with `--version`, and asserts the Matter sidecar is bundled. |
+| `ci-status` | `ubuntu-latest` | The aggregated **required** status check (alongside `branch-name`). Runs `if: always()` over every job above except `branch-name` and `version-check`, and fails only when one of them reported `failure`/`cancelled` — skipped jobs (docs-only changes, fork-gated jobs) count as OK, so a required check is never left pending. |
+
+**Docs-only gating.** `build-and-test`, `e2e-ui`, `matter-bridge`, `version-check`, and `docker-verify` are all gated on `changes` reporting `code == 'true'`, so a docs-only change skips the whole build/test matrix while `ci-status` still reports success. `branch-name`, `i18n-catalogs`, and `platform-macros` run regardless (cheap, source-only checks).
 
 **e2e-ui modes.** The Playwright runs mirror the modes encoded in `playwright.config.ts`, selected by environment variable. The three identity specs each run in their own step because they have incompatible auth-store preconditions (auth.spec needs an empty store for the first-run wizard; admin.spec self-seeds an admin; guest.spec configures the Guest scope), so each must boot against a fresh `--auth-state-dir`:
 
@@ -63,12 +74,10 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 | identity — guest mode + kiosk PIN | `AQUALINK_AUTH_MODE=enabled`, `npx playwright test e2e/guest.spec.ts` | anonymous guest browsing, affordance gating, kiosk PIN |
 | history enabled | `AQUALINK_HISTORY_DB` | recorded series + chart |
 | scheduler enabled | `AQUALINK_SCHEDULES_FILE` | schedule CRUD |
-| TLS (https) | `AQUALINK_TLS=enabled` | the default (non-identity) suite over an HTTPS origin (self-signed cert auto-provisioned), exercising the server's TLS/SSL session path and certificate self-provisioning |
-| bootstrap admin | `AQUALINK_AUTH_MODE=enabled`, `AQUALINK_BOOTSTRAP_ADMIN=wbadmin`, `AQUALINK_BOOTSTRAP_ADMIN_PASSWORD=…`, `npx playwright test e2e/admin.spec.ts` | headless `--bootstrap-admin` start-up provisioning; admin.spec then logs in against the seeded admin |
-| open bind — warning | `AQUALINK_OPEN_BIND=warn` | non-loopback bind (0.0.0.0) with auth off → the open-control-plane start-up warning |
-| open bind — ack | `AQUALINK_OPEN_BIND=ack` | as above plus `--insecure-no-auth` → the acknowledged-posture branch |
 
-**docker-verify checks.** It builds the `ci` target, then the `runtime` target (tagged `aqualink-automate:verify`), runs `docker run --rm -e MATTER_ENABLED=false aqualink-automate:verify --version`, and confirms the bundled sidecar is present (`node --version` plus a test for `/opt/matter-bridge/dist/index.js`). Both Docker builds are wrapped in a bounded retry so a transient Docker Hub base-image timeout does not fail CI. The `Dockerfile` base (both the build and runtime stages) is `ubuntu:25.04` — note this is a different release from the self-hosted runner image, which Packer provisions on Ubuntu 26.04 LTS (see [Provisioning](#provisioning) below).
+The remaining modes (TLS, bootstrap admin, open bind, MQTT, and the persistence modes) run in `automated-codescanning.yml`'s coverage sweep, which is a superset of this table — see [automated-codescanning.yml](#automated-codescanningyml).
+
+**docker-verify checks.** It builds the `ci` target, then the `runtime` target (tagged `aqualink-automate:verify`), runs `docker run --rm -e MATTER_ENABLED=false aqualink-automate:verify --version`, and confirms the bundled sidecar is present (`node --version` plus a test for `/opt/matter-bridge/dist/index.js`). Both Docker builds are wrapped in a bounded retry so a transient Docker Hub base-image timeout does not fail CI. This cold, from-source build is kept deliberately as the gate that the multi-stage `Dockerfile` + vcpkg toolchain still build end to end — the release path's `docker-publish` assembles its image from prebuilt install trees and skips this, so `docker-verify` is its safety net.
 
 ## _build.yml
 
@@ -79,8 +88,9 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 | Input | Type | Default | Used by |
 |-------|------|---------|---------|
 | `do_package` | boolean | `false` | Also run `cpack`, the per-OS install/extract smoke test, and the package artifact upload. The release path sets this `true`. |
-| `version_tag` | string | `""` | The resolved `v*` tag. Used only to create a local git tag for `workflow_dispatch` release builds (see below). |
+| `version_tag` | string | `""` | The resolved `v*` tag, threaded into configure as `DERIVED_VERSION_OVERRIDE` so the build stamps it deterministically (see below). Empty in CI. |
 | `fetch_depth` | number | `1` | Checkout depth. CI uses `1`; releases pass `0` so `git describe` and the cut-from-main check see full history and tags. |
+| `upload_installtree` | boolean | `false` | On Linux, run `cmake --install` and upload the relocatable FHS install tree(s) that `e2e-ui` and the assembled release image consume instead of recompiling. Both CI and the release path set this `true`. |
 
 ### The matrix
 
@@ -95,7 +105,7 @@ The job runs a four-row matrix with `fail-fast: false`, so one platform failing 
 
 These are the same presets you use locally — see [INSTALL.md](INSTALL.md).
 
-The arm64 row builds **natively** on an aarch64 runner (no cross-compile / QEMU) so the `.deb`/`.rpm`/`.tgz` install on a Raspberry Pi and other arm64 hosts; CPack derives the package architecture from the target, so the packages are correctly labelled `arm64`/`aarch64`. The install-tree upload (consumed by `e2e-ui` and the Docker image) stays on the x64 `config-linux-gcc` row only.
+The arm64 row builds **natively** on an aarch64 runner (no cross-compile / QEMU) so the `.deb`/`.rpm`/`.tgz` install on a Raspberry Pi and other arm64 hosts; CPack derives the package architecture from the target, so the packages are correctly labelled `arm64`/`aarch64`. Both Linux rows can upload their install tree (`installtree-linux-gcc` / `installtree-linux-gcc-arm64`, gated on the `upload_installtree` input): CI uploads only the x64 tree (for `e2e-ui`), while the release path uploads both so `docker-publish` can assemble the multi-arch image without recompiling.
 
 Runner selection per row is `vars.RUNNER_LINUX` / `vars.RUNNER_LINUX_ARM` / `vars.RUNNER_WINDOWS` with a GitHub-hosted fallback (the arm64 row falls back to `ubuntu-24.04-arm`); macOS always runs on `macos-latest`. See [Self-hosted runners](#self-hosted-runners).
 
@@ -105,21 +115,15 @@ The `Test` step runs the full test preset with **no `-L` label filter**, so unit
 
 ### Packaging (release path only)
 
-When `do_package` is `true`, after the test step the job also:
+When `do_package` is `true`:
 
-1. Runs `cpack --preset=<package_preset>`.
-2. Smoke-tests the package on a clean target — installs the `.deb` in a fresh `debian:bookworm` container (Linux; the glibc-2.36 / Raspberry Pi OS baseline), extracts the ZIP and runs the exe (Windows), or extracts the TGZ and runs the binary (macOS). Each asserts `aqualink-automate --version` succeeds. The Linux test deliberately uses `debian:bookworm` rather than the build image: it catches both a missing runtime dependency and a regression to a too-new glibc/libstdc++ baseline (which a newer-distro test would silently pass) before the package is published.
+1. On Linux, the whole configure/build/test/`cpack` sequence for the release path runs **inside a `gcc:15-bookworm` container** (glibc 2.36 — the Debian Bookworm / Raspberry Pi OS baseline), natively per arch, so the produced packages run on a stock Pi and every newer distro; the bundled gcc-15 libstdc++/libgcc keep the older-glibc base safe for the C++23 code. Windows and macOS run `cpack --preset=<package_preset>` on the host after the normal build.
+2. Smoke-tests the package on a clean target — installs the `.deb` in a fresh `debian:bookworm` container (Linux), extracts the ZIP and runs the exe (Windows), or extracts the TGZ and runs the binary (macOS). Each asserts `aqualink-automate --version` succeeds. The Linux test deliberately uses a clean `debian:bookworm` rather than the build image: it catches both a missing runtime dependency and a regression to a too-new glibc/libstdc++ baseline (which a newer-distro test would silently pass) before the package is published.
 3. Uploads the packages as an artifact named `packages-<configure_preset>` (for example `packages-config-linux-gcc`), with `retention-days: 30`.
 
-### Version stamping for dispatch builds
+### Version stamping
 
-A `workflow_dispatch` release build is for a tag that does not exist yet (`github-release` pushes it at the very end). To make `git describe` stamp the right version, `_build.yml` creates a **local** tag at the start of the packaging path:
-
-```bash
-git tag "<version_tag>" HEAD   # only when do_package && event == workflow_dispatch
-```
-
-**Note:** The version is also threaded explicitly into the configure step. `_build.yml` passes `-DDERIVED_VERSION_OVERRIDE=${{ inputs.version_tag || '0.0.0-dev' }}` (so a CI build with no tag stamps `0.0.0-dev`), and `cmake/GitVersionDerivation.cmake` honors `DERIVED_VERSION_OVERRIDE` (it is also how the Docker image is versioned, since the build context omits `.git`). For a `workflow_dispatch` release build the local tag created above lets `git describe` resolve the same `v*` version that is passed through as the override.
+The version is threaded explicitly into the configure step: `_build.yml` passes `-DDERIVED_VERSION_OVERRIDE=${{ inputs.version_tag || '0.0.0-dev' }}` (so a CI build with no tag stamps `0.0.0-dev` rather than emitting a noisy `git describe` warning on the shallow checkout), and `cmake/GitVersionDerivation.cmake` honors `DERIVED_VERSION_OVERRIDE` over `git describe` (it is also how the Docker image is versioned, since the build context omits `.git`). Release callers pass the resolved tag as `version_tag`, so a `workflow_dispatch` build stamps the right version even though its tag does not exist yet (`github-release` pushes it at the very end) — no local pre-tagging is needed.
 
 ## release.yml
 
@@ -143,17 +147,21 @@ There is **no `push` to `main` trigger** — pushing to `main` does not release.
 ### Job graph
 
 ```
-resolve-version ──> build-packages (_build.yml) ──> docker-publish ──> github-release
+resolve-version ──> build-packages (_build.yml) ──> docker-publish ──┬─> homeassistant-addon-publish
+                                                                     └─> github-release ──> publish-repos (publish-repos.yml)
 ```
 
-`docker-publish` and `github-release` are skipped on a dry run (`is_dry_run == 'true'`); `build-packages` still runs so the pipeline can be validated end to end without publishing.
+Every job after `build-packages` is skipped on a dry run (`is_dry_run == 'true'`); `build-packages` still runs so the pipeline can be validated end to end without publishing. A `cleanup-failed-prerelease` job additionally watches the graph with `if: always()` (below).
 
 | Job | What it does |
 |-----|--------------|
-| `resolve-version` | Resolves the version from the trigger, validates the tag, and enforces the release guards (below). |
-| `build-packages` | Calls `_build.yml` with `do_package: true`, `fetch_depth: 0`, and the resolved `version_tag`. |
-| `docker-publish` | Builds and pushes the `runtime` image, then smoke-tests the published image. |
+| `resolve-version` | Resolves the version from the trigger, validates the tag, and enforces the release guards (below). Also re-runs the Home Assistant add-on version lock-step check (`scripts/sync-homeassistant-addon-version.ps1 -Check`), so a release cannot ship a drifted add-on version. |
+| `build-packages` | Calls `_build.yml` with `do_package: true`, `upload_installtree: true`, `fetch_depth: 0`, and the resolved `version_tag`. |
+| `docker-publish` | Assembles and pushes the multi-arch `runtime` image from the prebuilt install trees, then smoke-tests the published image on both architectures. |
+| `homeassistant-addon-publish` | Builds and pushes the per-arch Home Assistant add-on wrapper images (`homeassistant-amd64` / `homeassistant-aarch64`) on top of the just-published app image, attests them, and smoke-tests the pulled wrapper (bashio + `run.sh` present). |
 | `github-release` | Pushes the tag for dispatch builds, downloads the package artifacts, and creates the GitHub release. |
+| `publish-repos` | Calls `publish-repos.yml` (with `contents: write` and `secrets: inherit`) to sign and publish the APT/DNF repos from the just-created release — see [Release helpers](#release-helpers-auto-tagyml-suggest-versionyml-publish-reposyml). |
+| `cleanup-failed-prerelease` | If a non-dry-run **prerelease** fails after its tag exists, deletes the orphaned tag — never a stable tag, and never one that already has a published release — so the same version can be re-tagged cleanly. |
 
 ### resolve-version guards
 
@@ -168,10 +176,10 @@ resolve-version ──> build-packages (_build.yml) ──> docker-publish ─�
 This job runs only on Linux when not a dry run, with `packages: write` (GHCR push) plus `id-token: write` + `attestations: write` (attestation signing).
 
 1. Logs in to GHCR, and to Docker Hub only if `DOCKERHUB_USERNAME` is set (so fork PRs and credential-less runs still build anonymously).
-2. Derives tags from `docker/metadata-action`: `type=sha`, the full semver, `major.minor`, and a raw `latest` tag enabled **only when the release is not a prerelease**.
-3. Builds and pushes the `runtime` target to GHCR (and Docker Hub when credentials are present), wrapped in a bounded retry (up to 3 attempts) so a transient Docker Hub CDN timeout does not fail the release. `--metadata-file` records the pushed image-index digest.
+2. Derives tags from `docker/metadata-action`: `type=sha`, the full semver, `major.minor`, a raw `latest` tag enabled **only when the release is not a prerelease**, and a raw `edge` tag enabled **only for prereleases** (the floating prerelease channel — see the tag table in [releasing.md](releasing.md)).
+3. Downloads the per-arch install trees uploaded by `build-packages` and **assembles** the multi-arch (`linux/amd64` + `linux/arm64`, via QEMU) `runtime-assembled` target from them — no C++ recompile; only the Matter sidecar's TypeScript builds — pushing to GHCR (and Docker Hub when credentials are present), wrapped in a bounded retry (up to 3 attempts) so a transient Docker Hub CDN timeout does not fail the release. `--metadata-file` records the pushed image-index digest. (CI's from-source `docker-verify` remains the cold-build gate for the `runtime` target itself.)
 4. **Attests the image by digest:** a keyless [build-provenance attestation](https://docs.github.com/actions/security-guides/using-artifact-attestations) (`actions/attest-build-provenance`, Sigstore/OIDC) and an SPDX **SBOM** attestation (`anchore/sbom-action` → `actions/attest-sbom`), both `push-to-registry: true` so they attach to the image in GHCR. Attesting by digest (not tag) binds the proof to the exact bytes pushed.
-5. Runs a post-push smoke test: pulls the GHCR image and asserts `--version` contains the resolved version. Because `buildx build --push` pushes straight to the registry, this genuinely exercises the published artifact rather than a local cache.
+5. Runs a post-push smoke test: pulls the GHCR image and asserts `--version` contains the resolved version, for **both** architectures (arm64 under QEMU). Because `buildx build --push` pushes straight to the registry, this genuinely exercises the published artifact rather than a local cache.
 
 ### github-release
 
@@ -187,6 +195,24 @@ Both attestation mechanisms are described end-to-end for consumers in [SECURITY.
 
 See [docs/releasing.md](releasing.md) for the operator-facing release walkthrough.
 
+## Release helpers (auto-tag.yml, suggest-version.yml, publish-repos.yml)
+
+Three small workflows surround `release.yml`. None is part of the PR gate.
+
+### suggest-version.yml
+
+Propose-only. On a `develop` → `main` release PR (`pull_request` into `main`, types opened/synchronize/reopened) it runs `scripts/next-version.sh --markdown` against the full history + tags and upserts the result as a sticky PR comment plus a job summary. It **never creates or pushes a tag** — the human still decides the version and pushes it (see the pre-release checklist in [releasing.md](releasing.md)). The same script is runnable locally: `scripts/next-version.sh`.
+
+### auto-tag.yml
+
+Opt-in tag advancement. It triggers on every push to `main`, but the single job runs **only when the repo variable `AUTO_TAG_ENABLED` is `"true"`** — by default it does nothing and versions are tagged by hand. When enabled, it advances **only the prerelease counter** (`vX.Y.Z-<channel>.N` → `.N+1`, channel from `AUTO_TAG_CHANNEL`, default `beta`) and pushes the tag, which fires `release.yml` exactly like a manual tag push. Everything else stays a human decision by design: it refuses to invent a first tag, bump the base version, or switch channels, and it skips when there are no new commits since the last tag or when the delta is docs-only (same classifier as `ci.yml`'s `changes` job — a docs merge must not trigger a redundant binary release).
+
+### publish-repos.yml
+
+Publishes the GPG-signed **APT** (reprepro) and **DNF** (createrepo_c) package repositories to the `gh-pages` branch, so users can `apt install` / `dnf install` and receive upgrades. It is a reusable workflow invoked by `release.yml`'s `publish-repos` job right after the GitHub release is created — a `release: published` trigger would never fire, because GitHub suppresses events for actions performed with the default `GITHUB_TOKEN` — and it is also dispatchable with a `tag` input to (re)publish an existing release. It downloads the release's `.deb`/`.rpm` assets, signs each `.rpm` in place (`rpm --addsign`; the DNF repo advertises `gpgcheck=1`, a per-package check), builds both repos, signs the repo metadata, and publishes with `keep_files: true` so previously published versions accumulate. **It no-ops until the `REPO_GPG_PRIVATE_KEY` secret is configured** — the one-time setup and operator walkthrough live in [releasing.md](releasing.md).
+
+`docs.yml` shares the `gh-pages` branch with this workflow: the rendered docs site owns the root `index.html` and page tree, the package machinery owns `apt/`, `rpm/`, `key.gpg`, and the `install-*.sh` scripts. The filename sets are disjoint and both publish with `keep_files: true`, so neither clobbers the other (see [Docs site](#docs-site-docsyml)).
+
 ## automated-codescanning.yml
 
 Code scanning is slow (each scanner does a full compile), so it runs only where code is genuinely new.
@@ -195,6 +221,8 @@ Code scanning is slow (each scanner does a full compile), so it runs only where 
 
 ```yaml
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["develop", "main"]
   schedule:
@@ -202,7 +230,9 @@ on:
   workflow_dispatch:
 ```
 
-There is **no `push` trigger.** Scanning happens on PRs into `develop` or `main`, on the weekly cron baseline of the default branch, or on demand. A former `push: [main, feature/**, bug/**]` trigger was removed because it re-scanned already-scanned code.
+Scanning happens on PRs into `develop` or `main`, once per merge to `main`, on the weekly cron, or on demand. The `push: [main]` trigger exists to keep the **default-branch security baseline** current: SARIF uploaded from a `pull_request` run is recorded against the throwaway `refs/pull/N/merge` ref and never updates `main`'s baseline in the Security tab, so without it the baseline would depend solely on the weekly cron. (The old `push: [main, feature/**, bug/**]` trigger that re-scanned every feature push remains gone — the push run fires once per promotion merge.)
+
+Both triggers carry a docs `paths-ignore` (`docs/**`, `**/*.md`, `mkdocs.yml`, `docs.yml`, `LICENSE`): docs-only changes touch no compiled code, and since none of these jobs is a required status check, a path-filtered (non-running) workflow does not block the PR — unlike `ci.yml`, which must use a gate job (`changes`) for the same purpose.
 
 ### Jobs
 
@@ -210,13 +240,25 @@ There is **no `push` trigger.** Scanning happens on PRs into `develop` or `main`
 |-----|---------|---------|
 | `CodeScanning_CodeQL` | Linux | CodeQL (`c-cpp`). Runs its own full build, filters the SARIF to `src/**`, and uploads to the Security tab. |
 | `CodeScanning_CodeQL_JS` | Linux (GitHub-hosted) | CodeQL (`javascript-typescript`, `build-mode: none`) for the Alpine.js web UI (`assets/web/scripts`, `sw.js`) and the TypeScript Matter sidecar (`matter-bridge/src`). No compile, so it runs on `ubuntu-latest` (not the self-hosted C++ fleet); `.github/codeql/codeql-config-js.yml` scopes it to first-party source (vendored/minified libraries and `i18n/` data excluded). |
-| `CodeScanning_E2ECoverage` | Linux | Builds a gcov-instrumented `aqualink-automate` (`config-linux-gcc-coverage`), runs the four Playwright modes against it, and `gcovr`s the `.gcda` into a SonarQube coverage report (`coverage-e2e.xml`) uploaded as the `e2e-coverage-xml` artifact. |
+| `CodeScanning_E2ECoverage` | Linux | Builds a gcov-instrumented `aqualink-automate` (`config-linux-gcc-coverage`), drives the full Playwright mode sweep against it (see below), and `gcovr`s the `.gcda` into a SonarQube coverage report (`coverage-e2e.xml`) uploaded as the `e2e-coverage-xml` artifact. |
 | `CodeScanning_SonarCloud` | Linux | SonarCloud via build-wrapper over a coverage build (`config-linux-gcc-coverage`, `-DUSE_SONARQUBE=ON`). Runs its own full compile, produces the unit/integration coverage report, downloads the e2e report, and scans with **both** (`sonar.coverageReportPaths` comma-separated; Sonar merges line coverage). |
 | `CodeScanning_MSVCCodeAnalysis` | Windows | MSVC code analysis (`NativeRecommendedRules.ruleset`) over the `config-windows-msvc` build; uploads SARIF. |
 
 Each job has the same skip condition: it does not run for a `develop` -> `main` promotion PR, because that code was already scanned when it entered `develop`. Re-scanning the promotion is pure duplication.
 
 **Coverage = unit + e2e.** The SonarCloud new-code coverage gate reflects what *both* test layers exercise. The unit/integration binary's coverage alone misses every line only the running app reaches (HTTP routes, WebSocket, MQTT, bootstrap), which read as uncovered and depressed the gate. `CodeScanning_E2ECoverage` instruments the app, drives the Playwright suite against it (the app exits cleanly on Playwright's `SIGTERM` — see `gracefulShutdown` in `playwright.config.ts` — so gcov flushes `.gcda`), and emits a second report. `CodeScanning_SonarCloud` `needs:` it and merges the two; if the e2e job fails, the scan still runs with unit-only coverage (it never drops the whole gate).
+
+**The coverage mode sweep.** The job runs the six `e2e-ui` modes from [ci.yml](#ciyml) plus seven more that exist to reach code the default modes cannot. Every mode step is `continue-on-error` — this job harvests coverage, it is not a functional gate (`e2e-ui` is), so a spec flake must not discard coverage already written:
+
+| Run | Env set | Exercises |
+|-----|---------|-----------|
+| TLS (https) | `AQUALINK_TLS=enabled` | the default (non-identity) suite over an HTTPS origin (self-signed cert auto-provisioned) — the server's TLS/SSL session path and certificate self-provisioning |
+| bootstrap admin | `AQUALINK_AUTH_MODE=enabled`, `AQUALINK_BOOTSTRAP_ADMIN=…`, `AQUALINK_BOOTSTRAP_ADMIN_PASSWORD=…`, `npx playwright test e2e/admin.spec.ts` | headless `--bootstrap-admin` start-up provisioning; admin.spec then logs in against the seeded admin |
+| open bind — warning | `AQUALINK_OPEN_BIND=warn` | non-loopback bind (0.0.0.0) with auth off → the open-control-plane start-up warning |
+| open bind — ack | `AQUALINK_OPEN_BIND=ack` | as above plus `--insecure-no-auth` → the acknowledged-posture branch |
+| MQTT (broker + HA discovery) | `AQUALINK_MQTT=enabled`, `npx playwright test e2e/mqtt.spec.ts` | the only e2e mode that exercises the MQTT layer: Playwright starts a loopback broker and the app runs `--mqtt --home-assistant` against it (MqttClient, MqttIntegration, MqttHub, HA auto-discovery) |
+| equipment cache persisted | `AQUALINK_EQUIPMENT_CACHE=<file>` | the equipment-cache load-or-init + write-scheduling paths, skipped by the in-memory default |
+| preferences persisted | `AQUALINK_PREFERENCES_FILE=<file>` | the preferences load/persist path against a real file rather than in-memory only |
 
 ## Supply-chain scanning (trivy.yml, osv-scanner.yml, scorecard.yml)
 
@@ -230,21 +272,21 @@ Three lightweight workflows cover the supply-chain surfaces the compile-heavy `a
 
 Division of labour with the existing tooling: **CodeQL / SonarCloud / MSVC** scan first-party source; **Dependabot** *updates* the Actions + npm manifests (and raises its own vulnerability alerts for them); **OSV-Scanner** closes the vcpkg gap Dependabot cannot see; **Trivy** covers the image layers no source or manifest scanner reaches. The vcpkg-built C++ libraries inside the image carry no package metadata for Trivy to match, so OSV-Scanner (reading the manifest) is what covers them — the two do not overlap.
 
-The three PR-facing jobs (`trivy.yml`, `osv-scanner.yml`) share the code scanners' promotion-PR skip and fork-PR gating. `scorecard.yml` does not run on `pull_request` at all (its checks are repository-level and need a token a fork PR lacks). The weekly crons are staggered (22:17 / 22:27 / 22:37 UTC) so they do not all contend at once.
+The two PR-facing workflows (`trivy.yml`, `osv-scanner.yml`) share the code scanners' promotion-PR skip and fork-PR gating. `scorecard.yml` does not run on `pull_request` at all (its checks are repository-level and need a token a fork PR lacks). The weekly crons are staggered (22:17 / 22:27 / 22:37 UTC) so they do not all contend at once.
 
 ### Scorecard hardening applied
 
 Two Scorecard checks are satisfied structurally rather than per-finding:
 
 - **Token permissions** — every workflow declares `permissions: {}` (deny-all) at the top level and re-grants the minimum `write` scope on the single job that needs it (e.g. `contents: write` on the tag/publish jobs, `actions: write` on the cache-cleanup job, `security-events: write` on the SARIF-upload jobs). A top-level write is what Scorecard penalizes; a narrowly job-scoped write is the recommended pattern and the residual per-job grants are the least privilege each job genuinely requires.
-- **Pinned dependencies** — the external base images in the root `Dockerfile` (`ubuntu:26.04`, `node:24-bookworm-slim`) are pinned by `@sha256:` digest. `.github/dependabot.yml` carries a `docker` ecosystem entry so Dependabot advances those digests weekly — a digest pin without an update path would otherwise freeze the image onto a stale, unpatched base. (Internal `FROM <stage>` references and the GitHub-hosted runner toolchains are not digest-pinnable and are not flagged as real findings.)
+- **Pinned dependencies** — the external base images in the root `Dockerfile` (`ubuntu:26.04`, `node:26-bookworm-slim`) are pinned by `@sha256:` digest. `.github/dependabot.yml` carries a `docker` ecosystem entry so Dependabot advances those digests weekly — a digest pin without an update path would otherwise freeze the image onto a stale, unpatched base. (Internal `FROM <stage>` references and the GitHub-hosted runner toolchains are not digest-pinnable and are not flagged as real findings.)
 
 ## Fuzzing (fuzzing.yml)
 
-`fuzzing.yml` runs the libFuzzer harnesses over the **untrusted RS-485 protocol decoders** (Jandy + Pentair message deserialisers) — the one supply-chain surface the posture scanners above cannot reach, because it is a *runtime* property of first-party parsing code. It builds the `config-linux-llvm-fuzzing` preset (Clang + `-fsanitize=fuzzer,address`), seeds a corpus from the recorded `test/fixtures/**/*.cap` captures, and fuzzes each harness for a bounded time; a crash fails the job and uploads the reproducer as an artifact. This gives the OpenSSF Scorecard **Fuzzing** check a genuine signal rather than a posture tick.
+`fuzzing.yml` runs the libFuzzer harnesses over the app's **untrusted-input parsers** — the RS-485 protocol decoders (Jandy + Pentair message deserialisers) plus the schedule/WebSocket JSON, MQTT payload, config, query-string, JWT, duration, and replay-line parsers — the one supply-chain surface the posture scanners above cannot reach, because it is a *runtime* property of first-party parsing code. It builds the `config-linux-llvm-fuzzing` preset (Clang + `-fsanitize=fuzzer,address`), seeds each harness's corpus (the decoder corpora come from the recorded `test/fixtures/**/*.cap` captures), and fuzzes each harness for a bounded time; a crash fails the job and uploads the reproducer as an artifact. This gives the OpenSSF Scorecard **Fuzzing** check a genuine signal rather than a posture tick.
 
-- **Triggers:** weekly cron (`47 22 * * 1`, staggered after the supply-chain crons); `pull_request` touching `src/jandy/**`, `src/pentair/**`, `src/core/protocol/**`, `fuzz/**`, or the fuzzing scaffolding; and `workflow_dispatch` (with a `max_total_time` input). It is **not** a required gate — a bounded run is best-effort reassurance, but any crash it does find is a real bug.
-- **Matrix:** one job per harness (`fuzz-jandy-message`, `fuzz-pentair-message`), on the GitHub-hosted `ubuntu-latest` (or `vars.RUNNER_LINUX`), with the same fork-PR gating as the build jobs.
+- **Triggers:** weekly cron (`47 22 * * 1`, staggered after the supply-chain crons); `pull_request` touching a fuzzed parser's source (`src/jandy/**`, `src/pentair/**`, and the fuzzed `src/core/` subsystems) or the fuzzing scaffolding (`fuzz/**`, `cmake/Fuzzing.cmake`); and `workflow_dispatch` (with a `max_total_time` input). It is **not** a required gate — a bounded run is best-effort reassurance, but any crash it does find is a real bug.
+- **Matrix:** one job per harness — ten of them, `fuzz-jandy-message` through `fuzz-replay-line` (the full list lives in [fuzzing.md](fuzzing.md)) — on the GitHub-hosted `ubuntu-latest` (or `vars.RUNNER_LINUX`), with the same fork-PR gating as the build jobs.
 - A crash is handled per the bug-fix discipline: fix the decoder + add a regression test, never weaken the parser. Full harness/corpus/run docs: [fuzzing.md](fuzzing.md).
 
 ## cleanup-branch-caches.yml
@@ -263,6 +305,28 @@ Routine dependency bumps merge themselves. `.github/dependabot.yml` raises one g
 - The squash commit takes the PR title, which Dependabot already emits in Conventional Commit form (`ci:`/`build:` prefixes configured in `.github/dependabot.yml`).
 - Requires the repository setting **Allow auto-merge** (Settings > General > Pull Requests), which is enabled on this repo.
 
+## Docs site (docs.yml)
+
+The documentation site (MkDocs Material — the published subset is selected by the `nav` + `exclude_docs` in `mkdocs.yml`) is built from the in-repo Markdown and published to the **root** of the `gh-pages` branch, so the docs home is the GitHub Pages landing page.
+
+- **Triggers:** push to `main` touching `docs/**`, `overrides/**`, `mkdocs.yml`, `README.md`, or the workflow itself; plus `workflow_dispatch`.
+- **Build:** `pip install "mkdocs-material[imaging]>=9.7"` (a floor, no upper cap) plus the Cairo imaging libraries for the social-cards plugin, then `mkdocs build --strict` — broken internal links and other warnings **fail the build** instead of shipping a broken page.
+- **Publish:** `peaceiris/actions-gh-pages` with `keep_files: true`, preserving the APT/DNF package tree that `publish-repos.yml` owns on the same branch (`apt/`, `rpm/`, `key.gpg`, `install-*.sh`); the filename sets are disjoint, so neither workflow deletes the other's files. Its `publish-docs` concurrency group is separate from `publish-repos`, so a docs build and a package publish can run at the same time.
+
+## Home Assistant add-on validation (homeassistant-addon.yml)
+
+Validates the Home Assistant add-on wrapper — the repo-root `repository.yaml` plus the stable `aqualink-automate/` and generated `aqualink-automate-edge/` channels (see [homeassistant-addon.md](homeassistant-addon.md)) — whenever it changes: `push` to `main`/`develop` and `pull_request` into `develop`/`main`, path-filtered to the add-on files and their generator/sync scripts.
+
+One `validate` job (GitHub-hosted, no third-party actions to pin) checks, in order:
+
+1. **YAML parses** — `repository.yaml`, both channels' `config.yaml`, and every translation catalog.
+2. **The Edge channel is generated, not hand-edited** — re-runs `scripts/gen-homeassistant-edge-addon.ps1` and fails on any diff, so the two channels can never drift by hand.
+3. **Options translations cover `config.yaml`** — every locale must document exactly the schema keys (`configuration:`) and ports (`network:`), no missing and no extra (mirrors the web UI's i18n key check).
+4. **`run.sh` passes shellcheck.**
+5. **Version lock-step** — each channel's `config.yaml` `version` equals every `build.yaml` base-image tag, via `scripts/sync-homeassistant-addon-version.ps1 -Check` (the same script the release process uses as the single writer in set mode, and which `release.yml` re-checks — so CI and release can never disagree).
+
+The add-on wrapper **images** are published by `release.yml`'s `homeassistant-addon-publish` job, not by this workflow.
+
 ## Self-hosted runners
 
 Every Linux and Windows job picks its runner from a repository variable, falling back to GitHub-hosted runners when the variable is unset. macOS always runs on `macos-latest` (GitHub-hosted).
@@ -273,7 +337,7 @@ Set these under **Settings > Variables > Actions**. Each value is a JSON array o
 
 | Variable | Type | Example | Applies to |
 |----------|------|---------|------------|
-| `RUNNER_LINUX` | JSON label array | `["self-hosted","linux","x64"]` | x64 Linux rows of `_build.yml`, `e2e-ui`, `matter-bridge`, `docker-verify`, `docker-publish`, CodeQL, E2ECoverage, SonarCloud |
+| `RUNNER_LINUX` | JSON label array | `["self-hosted","linux","x64"]` | x64 Linux rows of `_build.yml`, `e2e-ui`, `matter-bridge`, `docker-verify`, `docker-publish`, `homeassistant-addon-publish`, the fuzzing matrix, CodeQL, E2ECoverage, SonarCloud |
 | `RUNNER_LINUX_ARM` | JSON label array | `["self-hosted","linux","arm64"]` | The arm64 Linux row of `_build.yml`. Falls back to the GitHub-hosted `ubuntu-24.04-arm` (free for public repos). |
 | `RUNNER_WINDOWS` | JSON label array | `["self-hosted","windows","x64"]` | Windows row of `_build.yml`, MSVC code analysis |
 
@@ -287,7 +351,7 @@ Self-hosted jobs also run extra steps the hosted jobs skip — they clean the wo
 
 Runner VM images are built with Packer under `cicd/packer/`. See [cicd/packer/README.md](https://github.com/iainchesworth/aqualink-automate/blob/main/cicd/packer/README.md) for the full provisioning, deployment, and registration procedure.
 
-The Linux runner base is **Ubuntu 26.04 LTS** (GCC 15, Clang/LLVM 21), provisioned by `cicd/packer/linux-runner.pkr.hcl` (boots `ISOs/ubuntu-26.04-autoinstall.iso`) and the `cicd/packer/scripts/linux/0{2,3}-*-toolchain.sh` scripts. Both the Architecture table in `cicd/packer/README.md` and the Packer template agree on this base. The Windows runner base is Windows Server 2022. (Note this 26.04 runner image is a different release from the `ubuntu:25.04` Docker base used by `Dockerfile`; see the docker-verify note above.)
+The Linux runner base is **Ubuntu 26.04 LTS** (GCC 15, Clang/LLVM 21), provisioned by `cicd/packer/linux-runner.pkr.hcl` (boots `ISOs/ubuntu-26.04-autoinstall.iso`) and the `cicd/packer/scripts/linux/0{2,3}-*-toolchain.sh` scripts. Both the Architecture table in `cicd/packer/README.md` and the Packer template agree on this base. The Windows runner base is Windows Server 2022.
 
 ## Caching
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,7 +4,7 @@
 
 ## Workflow set
 
-The pipeline is nine workflow files plus two composite actions, all under `.github/`.
+The pipeline is ten workflow files plus two composite actions, all under `.github/`.
 
 | File | Kind | Purpose |
 |------|------|---------|
@@ -17,6 +17,7 @@ The pipeline is nine workflow files plus two composite actions, all under `.gith
 | `.github/workflows/osv-scanner.yml` | Workflow | OSV-Scanner CVE check of declared dependencies, incl. the vcpkg C++ manifest → Security tab. |
 | `.github/workflows/scorecard.yml` | Workflow | OpenSSF Scorecard supply-chain posture grade → Security tab. |
 | `.github/workflows/fuzzing.yml` | Workflow | Bounded libFuzzer run over the RS-485 protocol decoders on a weekly cron + decoder-touching PRs. Feeds Scorecard's Fuzzing check. See [fuzzing.md](fuzzing.md). |
+| `.github/workflows/dependabot-auto-merge.yml` | Workflow | Flags non-major Dependabot PRs for GitHub auto-merge; they land on `develop` once the required checks pass. |
 | `.github/actions/setup-cpp-toolchain` | Composite action | Install the platform-appropriate compiler and build tools. |
 | `.github/actions/setup-vcpkg-cache` | Composite action | Configure and restore the OS-keyed vcpkg binary cache. |
 
@@ -44,7 +45,7 @@ Concurrency is keyed on the PR number (or the ref for branch pushes) with `cance
 
 | Job | Runs on | What it does |
 |-----|---------|--------------|
-| `branch-name` | `ubuntu-latest` | PR only. Validates the PR head branch matches `<type>/<name>` with an allowed commit type, failing a non-conforming name. `develop`/`main` heads are accepted so the `develop` -> `main` release-promotion PR passes. A **required** status check on `develop`/`main`, so a misnamed branch cannot merge. |
+| `branch-name` | `ubuntu-latest` | PR only. Validates the PR head branch matches `<type>/<name>` with an allowed commit type, failing a non-conforming name. `develop`/`main` heads are accepted so the `develop` -> `main` release-promotion PR passes, and `dependabot/**` heads are accepted because Dependabot's branch names are not configurable (see [Dependabot auto-merge](#dependabot-auto-merge-dependabot-auto-mergeyml)). A **required** status check on `develop`/`main`, so a misnamed branch cannot merge. |
 | `build-and-test` | Per-OS matrix (see [_build.yml](#_buildyml)) | Calls `_build.yml` with no packaging. Configures, builds, and runs the full test suite on Linux, Windows, and macOS. |
 | `e2e-ui` | Linux | Builds only the app binary, then runs the Playwright UI suite once per mode (see the mode table below). |
 | `matter-bridge` | Linux | Node job in `matter-bridge/`: `npm ci`, typecheck (including the matter.js bridge), build, and unit tests. |
@@ -252,6 +253,15 @@ This workflow keeps the Actions cache from filling up with stale per-PR entries.
 
 - **Trigger:** `pull_request` with `types: [closed]`.
 - **Action:** On `ubuntu-latest` with `actions: write`, it installs the `gh-actions-cache` extension and deletes every cache key scoped to the closed PR's merge ref (`refs/pull/<number>/merge`). Deletion failures do not fail the workflow.
+
+## Dependabot auto-merge (dependabot-auto-merge.yml)
+
+Routine dependency bumps merge themselves. `.github/dependabot.yml` raises one grouped weekly PR per ecosystem (GitHub Actions, npm root, npm `matter-bridge/`, Docker digests) against `develop`; `dependabot-auto-merge.yml` runs on each Dependabot PR and — for non-major updates — enables GitHub **auto-merge** (squash) via `gh pr merge --auto`. GitHub then performs the merge only once every **required** status check passes ("Branch Name", which exempts `dependabot/**` heads, and the aggregated "CI Status"), so nothing lands without the full build/test matrix going green.
+
+- **Major bumps stay manual.** `dependabot/fetch-metadata` reports the *highest* update type in a grouped PR, so any group containing a semver-major update is left open for review. Digest-only bumps (the Docker group) carry no semver level and auto-merge.
+- **SonarCloud is expected to fail on Dependabot PRs** (Dependabot-triggered runs receive Dependabot secrets, not repo secrets such as `SONAR_TOKEN`). It is not a required check, so it does not hold up the merge.
+- The squash commit takes the PR title, which Dependabot already emits in Conventional Commit form (`ci:`/`build:` prefixes configured in `.github/dependabot.yml`).
+- Requires the repository setting **Allow auto-merge** (Settings > General > Pull Requests), which is enabled on this repo.
 
 ## Self-hosted runners
 

--- a/docs/homeassistant-addon.md
+++ b/docs/homeassistant-addon.md
@@ -65,7 +65,7 @@ The options form maps directly onto the application's settings (full reference:
 - **Web UI** — served through Home Assistant **ingress**: it appears in the sidebar and
   via **Open Web UI**, secured by your Home Assistant login and **not exposed on the
   LAN**. Because ingress provides authentication, the app's own auth is left off. For
-  direct LAN access (e.g. a wall tablet), assign a host port to `80/tcp` in the add-on's
+  direct LAN access (e.g. a wall tablet), assign a host port to `8099/tcp` in the add-on's
   **Network** panel — that port is unauthenticated by default, so firewall it **or** turn
   on `enable_auth` (with `auth_username`/`auth_password`) to make the app enforce its own
   login there. The admin is bootstrapped on first enable; `/api/health` stays open so the

--- a/matter-bridge/package-lock.json
+++ b/matter-bridge/package-lock.json
@@ -8,13 +8,13 @@
       "name": "aqualink-matter-bridge",
       "version": "0.1.0",
       "dependencies": {
-        "@matter/main": "^0.17.4",
-        "ws": "^8.18.0"
+        "@matter/main": "^0.17.7",
+        "ws": "^8.21.1"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "@types/ws": "^8.5.10",
-        "tsx": "^4.23.0",
+        "tsx": "^4.23.1",
         "typescript": "^7.0.2"
       },
       "engines": {
@@ -464,86 +464,86 @@
       }
     },
     "node_modules/@matter/general": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.4.tgz",
-      "integrity": "sha512-b1Q/Xdf1JHlcUFdaXU8uAaLeMSINMS0kKl/ElaDcE127Ax+3/UbZRtsLDclQopbpXtArXs73XBfdGFCA42gU8Q==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.7.tgz",
+      "integrity": "sha512-1k1px59FraPyge6wuK+1Wf/RyK/FpKoyOL6F8JpNRaMKh0CsIBkqcj6R46no2vkcqe7yzUBIo50x9dKklDJzJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^2.2.0"
       }
     },
     "node_modules/@matter/main": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.4.tgz",
-      "integrity": "sha512-wQu1CRxtyOaX+dEbCfRgbnNx6RfuPRQOPXKrKpuxebMh/W4xxCGCyUj0Fkb6QkO3wvjgaSnXeKx1PT2/n7wXFA==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.7.tgz",
+      "integrity": "sha512-3D/n9Q6JiqWdkPI49CRDY76GUHJ1GqlKIZ1YEeQp93khf+MAtzS9ttT98ifuVQUMpK/l5i/xcJRWJtHU28fKBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7",
+        "@matter/node": "0.17.7",
+        "@matter/protocol": "0.17.7",
+        "@matter/types": "0.17.7"
       },
       "optionalDependencies": {
-        "@matter/nodejs": "0.17.4"
+        "@matter/nodejs": "0.17.7"
       }
     },
     "node_modules/@matter/model": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.4.tgz",
-      "integrity": "sha512-q5Elw1ad5QykwkIVs9WhUkZQ1yMrHyRjnlKk+g2gO9aAtV9IoS1v+a6JA/dQbsDUiXnbdczU//jhGrOy/vkL6g==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.7.tgz",
+      "integrity": "sha512-e8L/JVt3pG97aYZ/JU5R3dRSv664qR7/3y+B0ySXRbbdOwirL7u4CCPRURDFG+u2yvsGSIh+18uABj6yIcP3CA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4"
+        "@matter/general": "0.17.7"
       }
     },
     "node_modules/@matter/node": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.4.tgz",
-      "integrity": "sha512-sQZfPrVC9mxrWHuUjJDhDR2MGMQJFyiRMfZiCZx2kHrbRi404D2Cod5U+ay3hH1zzPxai/PkooA4/wvKR+S4yQ==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.7.tgz",
+      "integrity": "sha512-vqAorFQPQ7aa5Qhpu7iRUALKwuDUazuAiotyUyhjpR7GF6zFCZ90xJwfCWKYhTsTao6Ylr2nGFtEPsbjBXpqzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7",
+        "@matter/protocol": "0.17.7",
+        "@matter/types": "0.17.7"
       }
     },
     "node_modules/@matter/nodejs": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.4.tgz",
-      "integrity": "sha512-c6uiT6yT5qPLhbDpVVo1Z5Q6jZCODB9sUviphwoI+dKcNMIwwjBVA/jRfggnTlR9A0cxiQuhVBQydzlAtCbI7w==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.7.tgz",
+      "integrity": "sha512-9ZByr+p/Bf3ezip6IZ/4DdMLUo3xDdBO82IbTmqsga4aym5NyCdDH6FSGZfWi+sN85+ZmQdxGTJ8h5kr1FKLhQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/node": "0.17.4",
-        "@matter/protocol": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.7",
+        "@matter/node": "0.17.7",
+        "@matter/protocol": "0.17.7",
+        "@matter/types": "0.17.7"
       },
       "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
       }
     },
     "node_modules/@matter/protocol": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.4.tgz",
-      "integrity": "sha512-wyju0Km43PVWITr//aHyD4cKDVFVlIrx0x85fRyHn1F8Ab2RY5/IHXIxutcXYl6Jtm22AVeXdeYZUtE6HmWjzQ==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.7.tgz",
+      "integrity": "sha512-q9e96VBrrMJFS0PYlTAW2YD7qVzhnqI3U/AvqFAhgd/Czo60DuAsPjttmI+VYijuK1oyho1Bi7BCJGgMjbtPhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4",
-        "@matter/types": "0.17.4"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7",
+        "@matter/types": "0.17.7"
       }
     },
     "node_modules/@matter/types": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.4.tgz",
-      "integrity": "sha512-nHiBrV6xoPMDPkuzL3+SQk90/2d4xbBgqwnxYQFqcvVrgITSwpGWzSGRC917BsuZE7koUNyD7T0Wlbt+GAlfkw==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.7.tgz",
+      "integrity": "sha512-NSFAlSyMUkCuYSzwtlOGb1gkmH8uFaZwpTelZY6EdTjhVMDu+meOE/CEHVzQmcAK+x8Mv2hjKlv1qCzUOqj7zQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@matter/general": "0.17.4",
-        "@matter/model": "0.17.4"
+        "@matter/general": "0.17.7",
+        "@matter/model": "0.17.7"
       }
     },
     "node_modules/@noble/curves": {
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1052,9 +1052,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/matter-bridge/package.json
+++ b/matter-bridge/package.json
@@ -17,13 +17,13 @@
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@matter/main": "^0.17.4",
-    "ws": "^8.18.0"
+    "@matter/main": "^0.17.7",
+    "ws": "^8.21.1"
   },
   "devDependencies": {
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "@types/ws": "^8.5.10",
-    "tsx": "^4.23.0",
+    "tsx": "^4.23.1",
     "typescript": "^7.0.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,24 +9,24 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.0",
         "aedes": "^1.1.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@types/node": {
@@ -387,35 +387,35 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "aedes": "^1.1.1"
   }
 }


### PR DESCRIPTION
Promote 0.12.0-beta.9 to main for release.

Home Assistant add-on maintenance (no core app changes):
- **Storage map renamed `addon_config` → `app_config`** (#126) — follows the Supervisor's add-ons→apps rename and silences the deprecation warning logged on every store refresh. Requires Supervisor ≥ 2026.07.1.
- Release prep (#131): both channels bumped to `0.12.0-beta.9`, changelogs updated, edge regenerated.

Also carried along:
- **CI:** apt/dpkg lock tolerance on the self-hosted runners (#127); routine Dependabot auto-merge enablement (#123) and grouped bumps (#119–#122: GitHub Actions, docker ubuntu, matter-bridge, Playwright).

After merge: tag `v0.12.0-beta.9` on main to fire the Release pipeline (packages, GHCR app image, Home Assistant wrapper images).