### PR TITLE
feat(homeassistant): serve the companion package from the running app

### DIFF
--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -241,6 +241,16 @@ install(CODE "
         -P \"${CMAKE_SOURCE_DIR}/cmake/stamp_sw_version.cmake\")
 " COMPONENT WebAssets)
 
+# Home Assistant companion package (blueprints, helpers package, dashboard) —
+# served by the running app for download without needing GitHub reachability
+# (e.g. an air-gapped install). Mirrors the dev-tree POST_BUILD copy in
+# src/CMakeLists.txt. test-harness/ is CI-only fixture content, excluded from
+# the shipped package.
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/homeassistant/companion/
+    DESTINATION ${AQ_WEB_DESTINATION}/homeassistant
+    COMPONENT WebAssets
+    PATTERN "test-harness" EXCLUDE)
+
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/examples/
     DESTINATION ${AQ_EXAMPLES_DESTINATION}
     COMPONENT ExampleConfigs

--- a/docs/design/ha-companion-package.md
+++ b/docs/design/ha-companion-package.md
@@ -1,6 +1,6 @@
 # Home Assistant Companion Package — Design & Delivery Plan
 
-**Date:** 2026-08-06 · **Status:** proposed (not yet implemented)
+**Date:** 2026-08-06 · **Status:** Phase 1 merged to `develop` 2026-08-07 (PR #128, [`homeassistant/companion/`](https://github.com/iainchesworth/aqualink-automate/tree/main/homeassistant/companion)); Phase 2 (app-served copy) in progress; Phase 3 not started.
 
 > Design/analysis snapshot. File/symbol citations were verified against the code on the
 > date above; re-verify before relying on them.

--- a/docs/homeassistant-companion.md
+++ b/docs/homeassistant-companion.md
@@ -117,6 +117,17 @@ pointing at the file.
 
 ## Getting the files
 
+- **Your running instance** — every install serves its own copy under `/homeassistant/`
+  on the app's web port (through Home Assistant ingress on the add-on), matching the
+  exact version you're running and requiring no internet access to GitHub:
+    - `/homeassistant/blueprints/automation/aqualink-automate/<name>.yaml` — the seven blueprints
+    - `/homeassistant/packages/aqualink_automate.yaml` — the helpers package
+    - `/homeassistant/dashboards/aqualink-pool.yaml` — the dashboard
+    - `/homeassistant/entity-manifest.json`, `/homeassistant/README.md`
+
+    Handy for air-gapped or LAN-only installs: download from your own instance and
+    paste into Home Assistant's raw configuration editor or `blueprints/automation/`
+    folder — no My-Home-Assistant redirect or GitHub reachability required.
 - **Repository** (tracks `main`): [`homeassistant/companion/`](https://github.com/iainchesworth/aqualink-automate/tree/main/homeassistant/companion)
 - **Release bundle** (version-pinned, GPG-signed and attested like every other
   release artifact): `aqualink-automate-homeassistant-companion-<version>.zip` on

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,12 +88,21 @@ file(GLOB_RECURSE SSL_ASSET_FILES
 	"${CMAKE_SOURCE_DIR}/assets/ssl/*"
 )
 
+# Collect the Home Assistant companion package files for dependency tracking (see
+# the POST_BUILD copy below). Excludes test-harness/, which is CI-only fixture
+# content that is never copied into the served web root.
+file(GLOB_RECURSE HA_COMPANION_ASSET_FILES
+	CONFIGURE_DEPENDS
+	"${CMAKE_SOURCE_DIR}/homeassistant/companion/*"
+)
+list(FILTER HA_COMPANION_ASSET_FILES EXCLUDE REGEX "/test-harness/")
+
 # Make the main source file depend on all asset files.
 # When any asset changes, this triggers a relink of the executable,
 # which in turn runs the POST_BUILD commands.
 set_property(
 	SOURCE aqualink-automate.cpp
-	APPEND PROPERTY OBJECT_DEPENDS ${WEB_ASSET_FILES} ${SSL_ASSET_FILES}
+	APPEND PROPERTY OBJECT_DEPENDS ${WEB_ASSET_FILES} ${SSL_ASSET_FILES} ${HA_COMPANION_ASSET_FILES}
 )
 
 # Copy web assets after the executable is built
@@ -108,6 +117,22 @@ add_custom_command(
 	# per build whose old offline shells purge on activate (see cmake/stamp_sw_version.cmake).
 	COMMAND ${CMAKE_COMMAND} -D "SW_JS=$<TARGET_FILE_DIR:aqualink-automate>/web/sw.js" -D "AQ_VERSION=${PROJECT_VERSION}" -P "${CMAKE_SOURCE_DIR}/cmake/stamp_sw_version.cmake"
 	COMMENT "Syncing web assets"
+)
+
+# Copy the Home Assistant companion package (blueprints, helpers package, dashboard)
+# into the served web root, so a running instance can offer it for download without
+# needing GitHub reachability (e.g. an air-gapped install) — see
+# docs/homeassistant-companion.md. Served by the same generic StaticFileHandler as
+# the rest of web/, with no C++ changes (same mechanism as api/swagger.yaml).
+# test-harness/ is CI-only fixture content; copy_directory_if_different has no
+# exclude option, so it is stripped immediately after the copy.
+add_custom_command(
+	TARGET aqualink-automate
+	POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E echo "Copying HA companion package to build folder..."
+	COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CMAKE_SOURCE_DIR}/homeassistant/companion" "$<TARGET_FILE_DIR:aqualink-automate>/web/homeassistant"
+	COMMAND ${CMAKE_COMMAND} -E rm -rf "$<TARGET_FILE_DIR:aqualink-automate>/web/homeassistant/test-harness"
+	COMMENT "Syncing HA companion package"
 )
 
 # Copy SSL assets after the executable is built


### PR DESCRIPTION
## Summary

Phase 2 of the Home Assistant companion package (design: `docs/design/ha-companion-package.md`): the running app now serves `homeassistant/companion/` under `/homeassistant/` on its own web port (through add-on ingress too), so any install can get the blueprints/helpers/dashboard without reaching GitHub - useful for air-gapped or LAN-only setups where the My-Home-Assistant import buttons and release-zip download aren't reachable.

Uses the existing generic `StaticFileHandler` and `.yaml -> application/yaml` MIME mapping - the same mechanism that already serves `api/swagger.yaml` - so **no C++ changes**.

## Changes

- `src/CMakeLists.txt` - POST_BUILD copies `homeassistant/companion/` into the build tree's `web/homeassistant/` (mirrors the existing `assets/web` copy), then strips `test-harness/` (CI-only fixtures; `copy_directory_if_different` has no exclude option). Companion files join the existing `OBJECT_DEPENDS` glob so editing a blueprint retriggers the copy without a clean build.
- `cmake/CPackConfig.cmake` - mirrors the same content into the packaged install tree via `install(DIRECTORY ... PATTERN "test-harness" EXCLUDE)`.
- `docs/homeassistant-companion.md` - documents the new `/homeassistant/*` URLs under "Getting the files".
- `docs/design/ha-companion-package.md` - status line updated (Phase 1 merged, Phase 2 in progress).

## Verification

- Built the app locally, booted it against a replay fixture, and confirmed all four companion content types return 200 with the correct content-type: `entity-manifest.json` -> `application/json`, the three YAML files -> `application/yaml`. Content is byte-identical to the source tree.
- `/homeassistant/test-harness/*` correctly 404s (excluded from both the dev-tree copy and the install rule).
- Ran `cmake --install --component WebAssets` directly against the built tree to exercise the CPack rule without a full Release rebuild - same result, `test-harness/` absent.
- Full unit suite: **No errors detected**.
- `mkdocs build --strict` and the companion entity-manifest check both pass.

## Deferred

Per the design doc, a web-UI link to the served bundle is explicitly optional and needs the full i18n catalog treatment across 8 locales - left for a follow-up rather than folded into this PR.