### PR TITLE
ci(runners): stop OS-disk creep the ephemeral reset missed

### DIFF
--- a/cicd/packer/README.md
+++ b/cicd/packer/README.md
@@ -26,19 +26,26 @@ cruft between jobs. Two design changes fix that:
 - **Two thin disks per VM — OS is protected from build junk.** `disk0` holds only the OS
   + toolchains; `disk1` is a data volume (Linux `/data`, Windows `D:`) split into:
   - `work/` — the runner work dir (checkout + build tree), **wiped every job**;
-  - `cache/` — the persistent **vcpkg binary cache + ccache**, kept across jobs but
-    **size-capped** (ccache 3 GB; each vcpkg archive/download cache pruned to 3 GB / 2 GB)
-    so it can't grow without bound. `~/.cache` is redirected onto `cache/` (Linux symlink /
-    Windows junction) so vcpkg and ccache land there with no workflow change.
-  - `docker/` (Linux only) — Docker's `data-root`, so multi-GB base images pulled by
-    release builds never touch the OS disk; the supervisor prunes them each job.
+  - `cache/` — the persistent **vcpkg binary cache + ccache + sonar-scanner cache**, kept
+    across jobs but **size-capped** (ccache 3 GB; each vcpkg archive/download cache pruned
+    to 3 GB / 2 GB; sonar 1 GB) so it can't grow without bound. `~/.cache` is redirected
+    onto `cache/` (Linux symlink / Windows junction) so vcpkg and ccache land there with
+    no workflow change; on Linux `~/.sonar` (which is *not* under `~/.cache`) is likewise
+    symlinked to `cache/sonar`.
+  - `docker/` + `containerd/` (Linux only) — Docker's `data-root` **and** containerd's
+    `root`, so multi-GB base images/layers pulled by release builds never touch the OS
+    disk (moving only Docker's data-root is not enough — buildx/BuildKit park content in
+    containerd's own store); the supervisor prunes them each job.
 
   Build artifacts can therefore never fill the OS disk, and the thin vmdks stay near
   actual usage (`discard`/`fstrim` on Linux, `Optimize-Volume -ReTrim` on Windows).
 
 - **Ephemeral runners that recycle themselves.** A supervisor (Linux `github-runner.service`,
   Windows `GitHubRunnerEphemeral` scheduled task) runs a loop: reset the workspace + Docker
-  + temp, cap the caches, `fstrim`, mint a fresh registration token from an on-box
+  + temp + the runner's `_diag` logs, delete superseded self-updated agent versions
+  (`bin.<ver>`/`externals.<ver>`, ~680 MB each on the OS disk), run apt hygiene
+  (`apt-get clean` + wipe `/var/lib/apt/lists`), cap the caches, `fstrim`, mint a fresh
+  registration token from an on-box
   credential, then register a one-shot `--ephemeral` runner and run **exactly one job**.
   After the job the runner deregisters and the loop recycles. Every build starts from a
   clean slate, and GitHub can never hand a runner a second job in a dirty state. Throughput
@@ -241,12 +248,12 @@ Workflows automatically use self-hosted runners when these variables are set. Re
 
 | Script | Packages |
 |--------|----------|
-| `00-data-volume.sh` | Partitions/formats the data disk, mounts it at `/data` (`discard`), creates `work/` + `cache/`, symlinks `~/.cache` → `/data/cache` |
-| `01-base-packages.sh` | build-essential, ca-certificates, curl, git, gpg, jq, pkg-config, tar, unzip, wget, zip; enables `discard` (continuous TRIM) on the root fs **and** sets `fstrim.timer` to hourly so the thin vmdk stays lean under churny CI |
+| `00-data-volume.sh` | Partitions/formats the data disk, mounts it at `/data` (`discard`), creates `work/` + `cache/` + `docker/` + `containerd/`, symlinks `~/.cache` → `/data/cache` and `~/.sonar` → `/data/cache/sonar` |
+| `01-base-packages.sh` | build-essential, ca-certificates, curl, git, gpg, jq, pkg-config, tar, unzip, wget, zip; purges `unattended-upgrades` + masks the apt-daily timers (background dpkg runs race CI's apt calls and creep the OS disk); sets a default `DPkg::Lock::Timeout`; enables `discard` (continuous TRIM) on the root fs **and** sets `fstrim.timer` to hourly so the thin vmdk stays lean under churny CI |
 | `02-gcc-toolchain.sh` | gcc-15, g++-15, gcov-15 (from 26.04 LTS main repos; PPA fallback only on older bases), update-alternatives symlinks |
 | `03-llvm-toolchain.sh` | clang-21, clang-tidy-21, lld-21, libc++-21-dev, libc++abi-21-dev (from 26.04 LTS `universe`; apt.llvm.org fallback only on older bases), update-alternatives symlinks |
 | `04-cmake-ninja.sh` | CMake 3.31.12 (Kitware binary), ninja-build |
-| `05-docker.sh` | Docker Engine CE + buildx plugin; `data-root` → `/data/docker` (off the OS disk) |
+| `05-docker.sh` | Docker Engine CE + buildx plugin; Docker `data-root` → `/data/docker` **and** containerd `root` → `/data/containerd` (both off the OS disk, both ordered after `data.mount`) |
 | `06-dev-tools.sh` | python3, gcovr, autoconf, automake, libtool |
 | `07-ccache.sh` | ccache (4 GB max on `/data/cache/ccache`, compression enabled) |
 | `08-github-runner.sh` | GitHub Actions runner agent + **ephemeral supervisor** (`github-runner.service`) |

--- a/cicd/packer/scripts/linux/00-data-volume.sh
+++ b/cicd/packer/scripts/linux/00-data-volume.sh
@@ -72,9 +72,10 @@ fi
 mount "$DATA_MNT" 2>/dev/null || mount -a
 
 # work/ (wiped each job) and cache/ (persistent). vcpkg lives under cache/vcpkg,
-# ccache under cache/ccache (see 07-ccache.sh). docker/ is Docker's data-root so
-# images pulled by release builds land here, not on the OS disk (see 05-docker.sh).
-mkdir -p "${DATA_MNT}/work" "${DATA_MNT}/cache" "${DATA_MNT}/docker"
+# ccache under cache/ccache (see 07-ccache.sh). docker/ is Docker's data-root and
+# containerd/ is containerd's root, so images/layers pulled by release builds
+# land here, not on the OS disk (see 05-docker.sh).
+mkdir -p "${DATA_MNT}/work" "${DATA_MNT}/cache" "${DATA_MNT}/docker" "${DATA_MNT}/containerd"
 chown -R "${RUNNER_USER}:${RUNNER_USER}" "${DATA_MNT}/work" "${DATA_MNT}/cache"
 
 # Redirect ~/.cache onto the persistent cache area. Replace a real dir if one
@@ -86,4 +87,16 @@ fi
 ln -sfn "${DATA_MNT}/cache" "${RUNNER_HOME}/.cache"
 chown -h "${RUNNER_USER}:${RUNNER_USER}" "${RUNNER_HOME}/.cache"
 
-echo "==> Data volume ready: ${DATA_MNT}/work (ephemeral) + ${DATA_MNT}/cache (persistent); ~/.cache -> ${DATA_MNT}/cache"
+# sonar-scanner caches its JRE/plugins under ~/.sonar (NOT ~/.cache, so the
+# symlink above doesn't cover it) and it grows past 1 GB on the OS disk.
+# Redirect it into the size-capped cache area (the supervisor prunes
+# /data/cache/sonar — see 08-github-runner.sh).
+install -d -o "${RUNNER_USER}" -g "${RUNNER_USER}" "${DATA_MNT}/cache/sonar"
+if [ -e "${RUNNER_HOME}/.sonar" ] && [ ! -L "${RUNNER_HOME}/.sonar" ]; then
+    cp -a "${RUNNER_HOME}/.sonar/." "${DATA_MNT}/cache/sonar/" 2>/dev/null || true
+    rm -rf "${RUNNER_HOME}/.sonar"
+fi
+ln -sfn "${DATA_MNT}/cache/sonar" "${RUNNER_HOME}/.sonar"
+chown -h "${RUNNER_USER}:${RUNNER_USER}" "${RUNNER_HOME}/.sonar"
+
+echo "==> Data volume ready: ${DATA_MNT}/work (ephemeral) + ${DATA_MNT}/cache (persistent); ~/.cache -> ${DATA_MNT}/cache; ~/.sonar -> ${DATA_MNT}/cache/sonar"

--- a/cicd/packer/scripts/linux/01-base-packages.sh
+++ b/cicd/packer/scripts/linux/01-base-packages.sh
@@ -8,7 +8,18 @@ echo "==> Installing base packages"
 # flaky fetch — apt.llvm.org and the Ubuntu mirrors are intermittently unreliable.
 cat > /etc/apt/apt.conf.d/80-retries <<'EOF'
 Acquire::Retries "5";
+DPkg::Lock::Timeout "600";
 EOF
+
+# The stock server image ships unattended-upgrades + the apt-daily timers. On an
+# ephemeral CI runner they are pure downside: a background dpkg run holds
+# /var/lib/dpkg/lock-frontend and races CI's own apt-get calls (a real job
+# failure on 2026-08-06, since worked around in workflows with
+# DPkg::Lock::Timeout), and the packages/metadata they pull creep the small OS
+# disk between recycles. Security currency comes from template rebuilds instead.
+apt-get purge -y unattended-upgrades 2>/dev/null || true
+systemctl disable --now apt-daily.timer apt-daily-upgrade.timer 2>/dev/null || true
+systemctl mask apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
 
 apt-get update
 apt-get install -y --no-install-recommends \

--- a/cicd/packer/scripts/linux/05-docker.sh
+++ b/cicd/packer/scripts/linux/05-docker.sh
@@ -52,9 +52,34 @@ After=data.mount
 Requires=data.mount
 DROPIN
 
+# containerd keeps its own content/snapshotter store, and it defaults to
+# /var/lib/containerd on the OS disk — moving Docker's data-root does NOT move
+# it, and buildx/BuildKit park gigabytes of Docker-managed content there (it
+# exhausted a 9.5 GB OS disk in production). Point containerd's root at the
+# data volume too (/data/containerd, created by 00-data-volume.sh).
+mkdir -p /etc/containerd /data/containerd
+cat > /etc/containerd/config.toml <<'TOML'
+# Managed by packer (05-docker.sh). Matches the containerd.io package default
+# (CRI disabled; Docker drives containerd over its own socket) with the content
+# root moved onto the data volume so image/snapshotter content stays off the
+# small OS disk.
+disabled_plugins = ["cri"]
+root = "/data/containerd"
+TOML
+
+# Same mount-ordering constraint as docker.service: containerd must not start
+# until /data is mounted, or it would initialise its root on the OS disk and
+# then be shadowed by the mount.
+mkdir -p /etc/systemd/system/containerd.service.d
+cat > /etc/systemd/system/containerd.service.d/data-root.conf <<'DROPIN'
+[Unit]
+After=data.mount
+Requires=data.mount
+DROPIN
+
 systemctl daemon-reload
 
 # Enable and start Docker (data-root takes effect on the next start).
 systemctl enable docker
 
-echo "==> Docker $(docker --version) installed (data-root on /data/docker)"
+echo "==> Docker $(docker --version) installed (data-root on /data/docker, containerd root on /data/containerd)"

--- a/cicd/packer/scripts/linux/08-github-runner.sh
+++ b/cicd/packer/scripts/linux/08-github-runner.sh
@@ -60,6 +60,7 @@ CACHE="${DATA}/cache"
 CCACHE_MAX="${CCACHE_MAX:-3G}"
 VCPKG_ARCHIVES_CAP_GB="${VCPKG_ARCHIVES_CAP_GB:-3}"
 VCPKG_DOWNLOADS_CAP_GB="${VCPKG_DOWNLOADS_CAP_GB:-2}"
+SONAR_CACHE_CAP_GB="${SONAR_CACHE_CAP_GB:-1}"
 
 # Deterministic PATH for jobs: ccache shims first, then CMake (/usr/local/bin)
 # and the apt toolchain (/usr/bin). Mirrors what `svc.sh install` used to capture.
@@ -100,6 +101,28 @@ prune_vcpkg_cache() {
     prune_dir_to_cap "${CACHE}/vcpkg/archives" "$VCPKG_ARCHIVES_CAP_GB"
     prune_dir_to_cap "${CACHE}/vcpkg-bookworm" "$VCPKG_ARCHIVES_CAP_GB"
     prune_dir_to_cap "${CACHE}/vcpkg/downloads" "$VCPKG_DOWNLOADS_CAP_GB"
+    # sonar-scanner's JRE/plugin cache (~/.sonar -> /data/cache/sonar, see
+    # 00-data-volume.sh) — old scanner/JRE versions accumulate forever otherwise.
+    prune_dir_to_cap "${CACHE}/sonar" "$SONAR_CACHE_CAP_GB"
+}
+
+prune_old_runner_versions() {
+    # The runner agent self-updates by laying down versioned bin.<ver>/
+    # externals.<ver> dirs next to the live ones and repointing itself;
+    # superseded versions (~680 MB each) are never removed and creep the OS
+    # disk. Delete every versioned dir that isn't what the live bin/externals
+    # resolve to. Safe here: a self-update only stages between job assignment
+    # and job start, never while the supervisor is resetting between jobs.
+    local keep="" link d
+    for link in "${RUNNER_DIR}/bin" "${RUNNER_DIR}/externals"; do
+        keep="${keep} $(readlink -f "$link" 2>/dev/null)"
+    done
+    for d in "${RUNNER_DIR}"/bin.* "${RUNNER_DIR}"/externals.*; do
+        [ -d "$d" ] || continue
+        case " $keep " in *" $(readlink -f "$d") "*) continue ;; esac
+        log "removing superseded runner agent dir ${d##*/}"
+        rm -rf "$d" 2>/dev/null || true
+    done
 }
 
 reset_workspace() {
@@ -125,6 +148,13 @@ reset_workspace() {
     # The runner's _diag logs live on the OS disk and accumulate per job; the
     # previous job's are already uploaded, so clear them to bound OS-disk growth.
     rm -rf "${RUNNER_DIR}/_diag"/* >/dev/null 2>&1 || true
+    # Superseded self-updated agent versions also live on the OS disk.
+    prune_old_runner_versions
+    # apt hygiene: downloaded .debs and list metadata sit on the OS disk and
+    # creep between recycles (lists alone reached ~144 MB). Safe to wipe the
+    # lists — every workflow that installs packages runs `apt-get update` first.
+    sudo apt-get clean >/dev/null 2>&1 || true
+    sudo rm -rf /var/lib/apt/lists/* >/dev/null 2>&1 || true
     # Preserve caches but bound their size.
     command -v ccache >/dev/null 2>&1 && ccache --max-size="$CCACHE_MAX" >/dev/null 2>&1 || true
     prune_vcpkg_cache

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -353,6 +353,8 @@ Runner VM images are built with Packer under `cicd/packer/`. See [cicd/packer/RE
 
 The Linux runner base is **Ubuntu 26.04 LTS** (GCC 15, Clang/LLVM 21), provisioned by `cicd/packer/linux-runner.pkr.hcl` (boots `ISOs/ubuntu-26.04-autoinstall.iso`) and the `cicd/packer/scripts/linux/0{2,3}-*-toolchain.sh` scripts. Both the Architecture table in `cicd/packer/README.md` and the Packer template agree on this base. The Windows runner base is Windows Server 2022.
 
+The Linux image is hardened against OS-disk creep: Docker's `data-root` **and** containerd's `root` live on the dedicated `/data` disk, `~/.cache` and `~/.sonar` are symlinked into the size-capped `/data/cache`, `unattended-upgrades` is removed (background dpkg runs also raced CI's own `apt-get` calls), and the ephemeral supervisor's per-job reset additionally deletes superseded self-updated runner-agent versions and runs apt hygiene (`apt-get clean`, wipe `/var/lib/apt/lists`). See `cicd/packer/README.md` ("Disk layout & the pristine ephemeral model").
+
 ## Caching
 
 ### vcpkg binary cache


### PR DESCRIPTION
## Summary

`github-runner-linux-01` filled its 9.5 GB OS disk on 2026-08-07 ("No space left on device"), failing the v0.12.0-beta.9 release run. Recovery found four creep sources the ephemeral supervisor's per-job reset does not cover:

- **containerd's own root** (`/var/lib/containerd`, ~2.0 GB) — moving Docker's `data-root` to `/data/docker` doesn't move containerd's separate content/snapshotter store; buildx/BuildKit park gigabytes there. Now pointed at `/data/containerd`, same `After=/Requires=data.mount` ordering as `docker.service`.
- **`~/.sonar`** (~1.2 GB on `linux-02`) — sonar-scanner's JRE/plugin cache isn't under `~/.cache`, so the existing symlink missed it. Now symlinked to `/data/cache/sonar`, pruned to a 1 GB cap by the supervisor.
- **Superseded self-updated runner-agent versions** (`bin.<ver>`/`externals.<ver>`, ~680 MB each) — never cleaned up; the supervisor now deletes every versioned dir that isn't what the live `bin`/`externals` symlinks resolve to, each recycle.
- **apt residue** — `unattended-upgrades` purged and the `apt-daily*` timers masked from the image (a background dpkg run also raced CI's own `apt-get` on 2026-08-06, worked around in-workflow with `DPkg::Lock::Timeout`; now defaulted in the image too); the reset loop now runs `apt-get clean` + wipes `/var/lib/apt/lists` (144 MB).

Docs (`cicd/packer/README.md`, `docs/ci-cd.md`) updated to match per CLAUDE.md.

## Live remediation (already applied, not part of this diff)

- Rebuilt `tpl-github-runner-linux` via packer with these changes baked in; build log confirms containerd/sonar/unattended-upgrades all took effect.
- Patched both live runners in place (stopped the supervisor, applied the same containerd/sonar/agent-version/apt fixes, restarted): `linux-01` 65%→60% OS-disk used, `linux-02` 83%→58%. Both re-registered online and are picking up jobs normally.

## Test plan

- [x] `bash -n` on all edited scripts
- [x] `packer validate` + full `packer build` of `linux-runner.pkr.hcl` — succeeded, log confirms new provisioning steps ran
- [x] Live-patched `linux-01`/`linux-02`, verified `df -h /` shrank, `/etc/containerd/config.toml` has `root = "/data/containerd"`, `~/.sonar` symlinked, `github-runner.service`/`docker.service` active, runners back online in GitHub
- [ ] Next real CI/release run on these runners will exercise the rebuilt-template path end to end