### PR TITLE
feat(homeassistant): add-on companion installer + activity scenes, spa readiness, showcase dashboard

### DIFF
--- a/.github/workflows/ha-companion.yml
+++ b/.github/workflows/ha-companion.yml
@@ -57,9 +57,11 @@ jobs:
           CFG=$(mktemp -d)
           cp homeassistant/companion/test-harness/configuration.yaml "$CFG/"
           cp homeassistant/companion/test-harness/automations.yaml "$CFG/"
-          mkdir -p "$CFG/packages" "$CFG/blueprints/automation"
+          cp homeassistant/companion/test-harness/scripts.yaml "$CFG/"
+          mkdir -p "$CFG/packages" "$CFG/blueprints/automation" "$CFG/blueprints/script"
           cp homeassistant/companion/packages/*.yaml "$CFG/packages/"
           cp -r homeassistant/companion/blueprints/automation/aqualink-automate "$CFG/blueprints/automation/"
+          cp -r homeassistant/companion/blueprints/script/aqualink-automate "$CFG/blueprints/script/"
           set +e
           OUT=$(docker run --rm -v "$CFG":/config ghcr.io/home-assistant/home-assistant:stable \
             python -m homeassistant --script check_config --config /config 2>&1)

--- a/aqualink-automate-edge/DOCS.md
+++ b/aqualink-automate-edge/DOCS.md
@@ -113,6 +113,23 @@ only if you want the app's own version (it is then persisted under `/data`):
 Your UI preferences and an equipment cache (for an instant dashboard after a restart)
 are always persisted under `/data` — no configuration needed.
 
+### Home Assistant companion package (optional)
+
+The add-on ships with a set of ready-made Home Assistant blueprints, a helpers
+package, and a dashboard — see the [companion package
+docs](https://iainchesworth.github.io/aqualink-automate/homeassistant-companion/)
+for what's in it. There are three ways to get them, and only the last needs the
+add-on's own settings:
+
+- Import a blueprint with one click from the docs page.
+- Download `aqualink-automate-homeassistant-companion-<version>.zip` from a
+  [GitHub release](https://github.com/iainchesworth/aqualink-automate/releases).
+- Turn on **`install_companion_package`** below.
+
+| Option | Description |
+|---|---|
+| `install_companion_package` | Off by default. When on, the add-on copies its bundled blueprints straight into Home Assistant's `blueprints/` folder on every start, so they show up under **Settings → Automations & Scenes → Blueprints** with no import step. **This requests a read-write view of Home Assistant's own configuration directory** — broader than anything else this add-on asks for — so it stays opt-in. It only ever adds or updates files under `blueprints/`; it never touches `configuration.yaml` or anything else in your config, and re-running it (a restart, an update) just re-syncs the current files. |
+
 ## Notes
 
 - The Matter bridge that the container image can run is **disabled** in this add-on —

--- a/aqualink-automate-edge/config.yaml
+++ b/aqualink-automate-edge/config.yaml
@@ -57,10 +57,23 @@ services:
 #     Supervisor >= 2026.07.1 (an older Supervisor rejects the manifest and hides
 #     the add-on until it auto-updates — acceptable, since the Supervisor
 #     self-updates and only the latest version is supported).
+#   - homeassistant_config (read-write): a view of Home Assistant's OWN /config
+#     (mounted at /homeassistant in the container), used ONLY when the opt-in
+#     `install_companion_package` option (below) is on, to copy the bundled
+#     Home Assistant companion blueprints (docs/homeassistant-companion.md) into
+#     Home Assistant's blueprints/ folder — see run.sh. This is a materially
+#     broader permission than the other two maps (it reaches Home Assistant's own
+#     configuration, not just this add-on's own storage), so it is requested here
+#     but only ACTED on when the user explicitly opts in; run.sh never writes
+#     anywhere under this map unless `install_companion_package: true`, and even
+#     then only ever adds/overwrites files under blueprints/ — configuration.yaml
+#     and everything else in /config is never touched.
 map:
   - type: ssl
     read_only: true
   - type: app_config
+    read_only: false
+  - type: homeassistant_config
     read_only: false
 # Web UI via INGRESS: Home Assistant serves the UI through its own authenticated
 # proxy and shows it in the sidebar — not published on the LAN, and secured by HA's
@@ -121,6 +134,7 @@ options:
   pool_configuration: auto
   jandy_device_type: auto
   jandy_device_id: ""
+  install_companion_package: false
 schema:
   # Serial protocol: ONE explicit choice of how to reach the panel — `usb` for a local
   # device (--serial-port), or `rfc2217` / `rawtcp` for a serial-to-ethernet adapter
@@ -175,3 +189,10 @@ schema:
   # type's default instance (OneTouch -> 0x41, IAQ -> 0xA1, ...). Ignored when
   # jandy_device_type is `auto`.
   jandy_device_id: str?
+  # Off by default. Turning this on installs the bundled Home Assistant companion
+  # blueprints (see docs/homeassistant-companion.md) directly into Home Assistant's
+  # blueprints/ folder on every start, using the homeassistant_config map above —
+  # a real, broader permission than this add-on otherwise needs, requested only
+  # for this feature. See run.sh for exactly what it does (additive-only, never
+  # touches configuration.yaml).
+  install_companion_package: bool

--- a/aqualink-automate-edge/run.sh
+++ b/aqualink-automate-edge/run.sh
@@ -133,6 +133,29 @@ if [ "${mqtt_mode}" != "disabled" ] && bashio::config.true 'home_assistant_disco
     args+=("--home-assistant" "--ha-device-id" "$(cat "${ha_device_id_file}")")
 fi
 
+# ── Home Assistant companion package (opt-in) ────────────────────────────────
+# Installs the blueprints already bundled in this image (built from
+# homeassistant/companion/ — see docs/homeassistant-companion.md) directly into
+# Home Assistant's own blueprints/ folder, so they appear under Settings ->
+# Automations & Scenes -> Blueprints without a manual import. Off by default:
+# turning it on requires the homeassistant_config map (see config.yaml), a
+# read-write view of Home Assistant's own /config. Idempotent — a restart or
+# add-on update just re-syncs the current files — and additive only: it never
+# touches configuration.yaml, and never removes a blueprint you've deleted.
+if bashio::config.true 'install_companion_package'; then
+    companion_blueprints="/opt/aqualink-automate/share/aqualink-automate/web/homeassistant/blueprints"
+    ha_config="/homeassistant"
+    if [ ! -d "${ha_config}" ]; then
+        bashio::log.warning "install_companion_package is on but ${ha_config} is not mounted (is the homeassistant_config map missing?) — skipping."
+    elif [ ! -d "${companion_blueprints}" ]; then
+        bashio::log.warning "No companion blueprints found in this image at ${companion_blueprints} — skipping."
+    else
+        mkdir -p "${ha_config}/blueprints"
+        cp -r "${companion_blueprints}/." "${ha_config}/blueprints/"
+        bashio::log.info "Installed the Home Assistant companion blueprints into ${ha_config}/blueprints/."
+    fi
+fi
+
 # ── History (opt-in; default OFF → use HA's Recorder) ──────────────────────────
 if bashio::config.true 'enable_history'; then
     args+=("--history-db" "${DATA}/history.db")

--- a/aqualink-automate-edge/translations/en.yaml
+++ b/aqualink-automate-edge/translations/en.yaml
@@ -110,5 +110,16 @@ configuration:
     description: >-
       Optional bus address for a single chosen device type (e.g. 0x41). Leave blank to
       use that type's default, and ignored entirely when the type is "auto".
+  install_companion_package:
+    name: Install Home Assistant blueprints
+    description: >-
+      Off by default. When on, installs the bundled Home Assistant companion
+      blueprints (dashboard/automation helpers) directly into Home Assistant's
+      blueprints folder on every start, so they appear under Settings →
+      Automations & Scenes → Blueprints without a manual import. This requests a
+      read-write view of Home Assistant's own configuration directory — a
+      materially broader permission than this add-on otherwise needs — and only
+      ever adds or updates files under blueprints/; it never touches
+      configuration.yaml or anything else in your config.
 network:
   8099/tcp: Optional direct web UI / HTTP API on your LAN (unauthenticated unless you enable the login option)

--- a/aqualink-automate/DOCS.md
+++ b/aqualink-automate/DOCS.md
@@ -113,6 +113,23 @@ only if you want the app's own version (it is then persisted under `/data`):
 Your UI preferences and an equipment cache (for an instant dashboard after a restart)
 are always persisted under `/data` — no configuration needed.
 
+### Home Assistant companion package (optional)
+
+The add-on ships with a set of ready-made Home Assistant blueprints, a helpers
+package, and a dashboard — see the [companion package
+docs](https://iainchesworth.github.io/aqualink-automate/homeassistant-companion/)
+for what's in it. There are three ways to get them, and only the last needs the
+add-on's own settings:
+
+- Import a blueprint with one click from the docs page.
+- Download `aqualink-automate-homeassistant-companion-<version>.zip` from a
+  [GitHub release](https://github.com/iainchesworth/aqualink-automate/releases).
+- Turn on **`install_companion_package`** below.
+
+| Option | Description |
+|---|---|
+| `install_companion_package` | Off by default. When on, the add-on copies its bundled blueprints straight into Home Assistant's `blueprints/` folder on every start, so they show up under **Settings → Automations & Scenes → Blueprints** with no import step. **This requests a read-write view of Home Assistant's own configuration directory** — broader than anything else this add-on asks for — so it stays opt-in. It only ever adds or updates files under `blueprints/`; it never touches `configuration.yaml` or anything else in your config, and re-running it (a restart, an update) just re-syncs the current files. |
+
 ## Notes
 
 - The Matter bridge that the container image can run is **disabled** in this add-on —

--- a/aqualink-automate/config.yaml
+++ b/aqualink-automate/config.yaml
@@ -55,10 +55,23 @@ services:
 #     Supervisor >= 2026.07.1 (an older Supervisor rejects the manifest and hides
 #     the add-on until it auto-updates — acceptable, since the Supervisor
 #     self-updates and only the latest version is supported).
+#   - homeassistant_config (read-write): a view of Home Assistant's OWN /config
+#     (mounted at /homeassistant in the container), used ONLY when the opt-in
+#     `install_companion_package` option (below) is on, to copy the bundled
+#     Home Assistant companion blueprints (docs/homeassistant-companion.md) into
+#     Home Assistant's blueprints/ folder — see run.sh. This is a materially
+#     broader permission than the other two maps (it reaches Home Assistant's own
+#     configuration, not just this add-on's own storage), so it is requested here
+#     but only ACTED on when the user explicitly opts in; run.sh never writes
+#     anywhere under this map unless `install_companion_package: true`, and even
+#     then only ever adds/overwrites files under blueprints/ — configuration.yaml
+#     and everything else in /config is never touched.
 map:
   - type: ssl
     read_only: true
   - type: app_config
+    read_only: false
+  - type: homeassistant_config
     read_only: false
 # Web UI via INGRESS: Home Assistant serves the UI through its own authenticated
 # proxy and shows it in the sidebar — not published on the LAN, and secured by HA's
@@ -119,6 +132,7 @@ options:
   pool_configuration: auto
   jandy_device_type: auto
   jandy_device_id: ""
+  install_companion_package: false
 schema:
   # Serial protocol: ONE explicit choice of how to reach the panel — `usb` for a local
   # device (--serial-port), or `rfc2217` / `rawtcp` for a serial-to-ethernet adapter
@@ -173,3 +187,10 @@ schema:
   # type's default instance (OneTouch -> 0x41, IAQ -> 0xA1, ...). Ignored when
   # jandy_device_type is `auto`.
   jandy_device_id: str?
+  # Off by default. Turning this on installs the bundled Home Assistant companion
+  # blueprints (see docs/homeassistant-companion.md) directly into Home Assistant's
+  # blueprints/ folder on every start, using the homeassistant_config map above —
+  # a real, broader permission than this add-on otherwise needs, requested only
+  # for this feature. See run.sh for exactly what it does (additive-only, never
+  # touches configuration.yaml).
+  install_companion_package: bool

--- a/aqualink-automate/run.sh
+++ b/aqualink-automate/run.sh
@@ -133,6 +133,29 @@ if [ "${mqtt_mode}" != "disabled" ] && bashio::config.true 'home_assistant_disco
     args+=("--home-assistant" "--ha-device-id" "$(cat "${ha_device_id_file}")")
 fi
 
+# ── Home Assistant companion package (opt-in) ────────────────────────────────
+# Installs the blueprints already bundled in this image (built from
+# homeassistant/companion/ — see docs/homeassistant-companion.md) directly into
+# Home Assistant's own blueprints/ folder, so they appear under Settings ->
+# Automations & Scenes -> Blueprints without a manual import. Off by default:
+# turning it on requires the homeassistant_config map (see config.yaml), a
+# read-write view of Home Assistant's own /config. Idempotent — a restart or
+# add-on update just re-syncs the current files — and additive only: it never
+# touches configuration.yaml, and never removes a blueprint you've deleted.
+if bashio::config.true 'install_companion_package'; then
+    companion_blueprints="/opt/aqualink-automate/share/aqualink-automate/web/homeassistant/blueprints"
+    ha_config="/homeassistant"
+    if [ ! -d "${ha_config}" ]; then
+        bashio::log.warning "install_companion_package is on but ${ha_config} is not mounted (is the homeassistant_config map missing?) — skipping."
+    elif [ ! -d "${companion_blueprints}" ]; then
+        bashio::log.warning "No companion blueprints found in this image at ${companion_blueprints} — skipping."
+    else
+        mkdir -p "${ha_config}/blueprints"
+        cp -r "${companion_blueprints}/." "${ha_config}/blueprints/"
+        bashio::log.info "Installed the Home Assistant companion blueprints into ${ha_config}/blueprints/."
+    fi
+fi
+
 # ── History (opt-in; default OFF → use HA's Recorder) ──────────────────────────
 if bashio::config.true 'enable_history'; then
     args+=("--history-db" "${DATA}/history.db")

--- a/aqualink-automate/translations/en.yaml
+++ b/aqualink-automate/translations/en.yaml
@@ -110,5 +110,16 @@ configuration:
     description: >-
       Optional bus address for a single chosen device type (e.g. 0x41). Leave blank to
       use that type's default, and ignored entirely when the type is "auto".
+  install_companion_package:
+    name: Install Home Assistant blueprints
+    description: >-
+      Off by default. When on, installs the bundled Home Assistant companion
+      blueprints (dashboard/automation helpers) directly into Home Assistant's
+      blueprints folder on every start, so they appear under Settings →
+      Automations & Scenes → Blueprints without a manual import. This requests a
+      read-write view of Home Assistant's own configuration directory — a
+      materially broader permission than this add-on otherwise needs — and only
+      ever adds or updates files under blueprints/; it never touches
+      configuration.yaml or anything else in your config.
 network:
   8099/tcp: Optional direct web UI / HTTP API on your LAN (unauthenticated unless you enable the login option)

--- a/docs/design/ha-companion-package.md
+++ b/docs/design/ha-companion-package.md
@@ -1,6 +1,6 @@
 # Home Assistant Companion Package — Design & Delivery Plan
 
-**Date:** 2026-08-06 · **Status:** Phase 1 merged to `develop` 2026-08-07 (PR #128, [`homeassistant/companion/`](https://github.com/iainchesworth/aqualink-automate/tree/main/homeassistant/companion)); Phase 2 (app-served copy) in progress; Phase 3 not started.
+**Date:** 2026-08-06 · **Status:** Phase 1 merged to `develop` 2026-08-07 (PR #128, [`homeassistant/companion/`](https://github.com/iainchesworth/aqualink-automate/tree/main/homeassistant/companion)); Phase 2 merged 2026-08-07 (PR #134, app-served under `/homeassistant/*`); Phase 3 in progress 2026-08-08 (add-on installer approved — see §11.2 — plus activity-scene blueprints, spa-readiness, and the showcase dashboard; the analytics/energy module was dropped as non-generalizable, see §7).
 
 > Design/analysis snapshot. File/symbol citations were verified against the code on the
 > date above; re-verify before relying on them.
@@ -273,19 +273,40 @@ force the companion to be updated in the same PR — that is the compatibility m
 **Phase 2 — app integration:** build-time copy into `assets/web/homeassistant/` so the
 running app serves the bundle; docs note the local URLs (works through add-on ingress).
 
-**Phase 3 — richer content & add-on installer (each optional, decide separately):**
-- Add-on `install_companion_package` opt-in installer (permission expansion — needs an
-  explicit maintainer decision).
-- `activity-scene.yaml` script blueprint; spa-readiness module; analytics module
-  (runtime/energy); showcase dashboard (HACS deps, generalised).
-- Web-UI "Home Assistant" page linking the served bundle (full i18n required).
+**Phase 3 — richer content & add-on installer:**
+- Add-on `install_companion_package` opt-in installer — **approved** (§11.2): adds the
+  `homeassistant_config` map (rw) to `aqualink-automate/config.yaml`, off by default;
+  `run.sh` copies the blueprints already baked into the app's own install tree
+  (`share/aqualink-automate/web/homeassistant/blueprints/` — the same content Phase 2
+  serves over HTTP) into Home Assistant's `blueprints/`, additive-only, never touching
+  `configuration.yaml`.
+- `activity-scene.yaml` script blueprint + `activity-scene-autooff.yaml` automation
+  blueprint (generalised start/stop scene: equipment/timer/boolean/dark-only-lights as
+  inputs, a `fields.action` toggle/turn_on/turn_off runtime parameter).
+- Spa-readiness: two template sensors in the helpers package (trigger-based baseline +
+  derived Off/Warming Up/Ready sensor with a `percent_ready` attribute, built only from
+  `spa_mode`/`spa_temperature`/`spa_setpoint`) + a `spa-ready.yaml` notification
+  blueprint.
+- Showcase dashboard (`dashboards/aqualink-pool-showcase.yaml`, HACS deps: button-card,
+  card-mod, layout-card, mushroom, bar-card) — generalised from the evidence base,
+  using only app-published + companion-package entities; commented placeholders for
+  equipment/scenes.
+- Analytics module (heat-pump COP/energy-delivered) — **dropped**: depends on the
+  evidence-base install's specific heat pump + power meters, not generalizable (see §7,
+  [[open-source-generality]]).
+- Web-UI "Home Assistant" page linking the served bundle (full i18n required) —
+  **deferred again**, same reasoning as Phase 2.
 
 ## 11. Open questions (maintainer decisions)
 
 1. **Attestation**: include the companion zip in the build-provenance/SBOM attestation
    globs, or exclude it? (Recommend include — it is shipped content.)
 2. **Add-on installer** (Phase 3): is the `homeassistant_config` permission expansion
-   acceptable for an opt-in convenience? Store-listing optics matter here.
+   acceptable for an opt-in convenience? Store-listing optics matter here. —
+   **Decided 2026-08-08: yes, build it.** Off by default (`install_companion_package`);
+   the map/option/permission are documented in `aqualink-automate/config.yaml`,
+   `DOCS.md`, and `docs/homeassistant-addon.md` with the exact scope (adds/updates
+   files under `blueprints/` only, never touches `configuration.yaml`).
 3. **Blueprint URL channel**: main-branch raw URLs (fixes propagate on re-import) vs
    tag-pinned URLs (reproducible). Recommend main for the import buttons, with the
    release zip as the pinned alternative.

--- a/docs/homeassistant-addon.md
+++ b/docs/homeassistant-addon.md
@@ -77,6 +77,15 @@ The options form maps directly onto the application's settings (full reference:
   under `/data`.
 - **Logging** — `log_level` (`info` / `debug` / `trace`); output appears in the add-on's
   **Log** tab (the app logs to stdout).
+- **Home Assistant companion package** — `install_companion_package` (off by default)
+  copies the add-on's bundled [companion blueprints](homeassistant-companion.md) straight
+  into Home Assistant's `blueprints/` folder on every start, so they appear under
+  **Settings → Automations & Scenes → Blueprints** with no import step. This requests a
+  **read-write view of Home Assistant's own configuration directory** — broader than
+  anything else the add-on asks for — so it stays opt-in; it only ever adds or updates
+  files under `blueprints/` and never touches `configuration.yaml`. The companion
+  package is also reachable without it: one-click import from the
+  [docs](homeassistant-companion.md#blueprints), or the release zip.
 
 ## Notes
 

--- a/docs/homeassistant-companion.md
+++ b/docs/homeassistant-companion.md
@@ -39,6 +39,8 @@ it under **Settings → Automations & scenes → Blueprints**.
 | **Chlorinator self-heal** | Pump running in your chosen window but chlorinator off → turns it back on (optionally only while ORP is low) and notifies. |
 | **Swim ready** | The water warming past your swim temperature sends a "pool is ready" note. |
 | **Freeze advisory** | Air temperature at the pad dropping to freeze risk sends an advisory (deliberately ignores quiet hours). |
+| **Spa ready** | The spa reaching its setpoint sends a "spa is ready" note — reads the *Spa readiness* helper sensor below. |
+| **Activity scene auto-off** | Pairs with the *Activity scene* script (below): when its duration timer finishes, turns everything the scene started back off. |
 
 [Import: Salt level low](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Fsalt-level-low.yaml){ .md-button }
 [Import: Equipment problem](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Fequipment-problem.yaml){ .md-button }
@@ -47,10 +49,32 @@ it under **Settings → Automations & scenes → Blueprints**.
 [Import: Chlorinator self-heal](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Fchlorinator-self-heal.yaml){ .md-button }
 [Import: Swim ready](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Fswim-ready.yaml){ .md-button }
 [Import: Freeze advisory](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Ffreeze-advisory.yaml){ .md-button }
+[Import: Spa ready](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Fspa-ready.yaml){ .md-button }
+[Import: Activity scene auto-off](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fautomation%2Faqualink-automate%2Factivity-scene-autooff.yaml){ .md-button }
 
 No My-Home-Assistant? Copy the files from
 `homeassistant/companion/blueprints/automation/aqualink-automate/` into
 `<config>/blueprints/automation/aqualink-automate/` and reload automations.
+
+### Script blueprint: activity scene
+
+Unlike the alert blueprints above, **Activity scene** is a *script* blueprint —
+a reusable start/stop scene (swim, spa, jet pool, whatever you like) for any
+switches you point it at, with an optional duration timer and dark-only extra
+lighting. Create one script instance per activity under **Settings →
+Automations & scenes → Blueprints** (it'll ask you to create an `input_boolean`
+helper first, if you don't already have one to track that activity). A
+dashboard tile's tap action toggles it; its hold action can call the same
+script with `turn_off` to force it off. Pair each instance that uses a
+duration timer with an **Activity scene auto-off** automation (above) pointed
+at the same timer and script, so running out turns everything off
+automatically.
+
+[Import: Activity scene (script)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fiainchesworth%2Faqualink-automate%2Fmain%2Fhomeassistant%2Fcompanion%2Fblueprints%2Fscript%2Faqualink-automate%2Factivity-scene.yaml){ .md-button }
+
+No My-Home-Assistant? Copy the file from
+`homeassistant/companion/blueprints/script/aqualink-automate/` into
+`<config>/blueprints/script/aqualink-automate/` and reload scripts.
 
 ## Helpers package
 
@@ -67,6 +91,10 @@ provides what the blueprints and dashboard expect:
   (`deficit_ppm × volume_L ÷ 1 000 000`).
 - `sensor.aqualink_pool_temperature_delta_today` — how much the water has warmed
   since midnight (with a restart-safe midnight baseline sensor behind it).
+- `sensor.aqualink_spa_readiness` — `Off` / `Warming Up` / `Ready`, with
+  `current_temperature`, `target_temperature`, and a `percent_ready` attribute
+  measuring progress from the temperature captured when spa mode last turned on.
+  Feeds the **Spa ready** blueprint above.
 - Commented `history_stats` recipes for pump-runtime / heater-heating-time
   counters — these reference your panel's own device entities, so uncomment and
   point them at yours.
@@ -100,6 +128,33 @@ panel's own switches (commented examples are in the file). Alternatively registe
 it as a [YAML-mode dashboard](https://www.home-assistant.io/dashboards/dashboards-and-views/)
 pointing at the file.
 
+### Showcase dashboard (optional, needs HACS)
+
+[`dashboards/aqualink-pool-showcase.yaml`](https://github.com/iainchesworth/aqualink-automate/blob/main/homeassistant/companion/dashboards/aqualink-pool-showcase.yaml)
+is a more polished alternative demonstrating what's possible with a few popular
+HACS custom cards — [button-card](https://github.com/custom-cards/button-card),
+[card-mod](https://github.com/thomasloven/lovelace-card-mod),
+[layout-card](https://github.com/thomasloven/lovelace-layout-card),
+[lovelace-mushroom](https://github.com/piitaya/lovelace-mushroom), and
+[bar-card](https://github.com/custom-cards/bar-card). It's not a drop-in
+replacement for the stock dashboard above — install those five via HACS first,
+then follow the same install steps. Like the stock dashboard, it uses only
+entities the app and the helpers package publish, with commented sections for
+your own equipment and any *Activity scene* instances.
+
+## Add-on auto-install (optional)
+
+Running the [Home Assistant add-on](homeassistant-addon.md)? Its
+**`install_companion_package`** option (off by default) copies the bundled
+blueprints straight into Home Assistant's `blueprints/` folder on every start,
+so they appear under **Settings → Automations & Scenes → Blueprints** with no
+import step. It requests a read-write view of Home Assistant's own
+configuration directory to do this — broader than anything else the add-on
+asks for — so it stays opt-in, and it only ever adds or updates files under
+`blueprints/`; it never touches `configuration.yaml` or anything else in your
+config. See the [Home Assistant add-on's Configuration
+section](homeassistant-addon.md#configuration) for details.
+
 ## Customisation notes
 
 - **Fahrenheit panels**: temperature *sensors* convert automatically to your Home
@@ -120,9 +175,10 @@ pointing at the file.
 - **Your running instance** — every install serves its own copy under `/homeassistant/`
   on the app's web port (through Home Assistant ingress on the add-on), matching the
   exact version you're running and requiring no internet access to GitHub:
-    - `/homeassistant/blueprints/automation/aqualink-automate/<name>.yaml` — the seven blueprints
+    - `/homeassistant/blueprints/automation/aqualink-automate/<name>.yaml` — the nine automation blueprints
+    - `/homeassistant/blueprints/script/aqualink-automate/activity-scene.yaml` — the script blueprint
     - `/homeassistant/packages/aqualink_automate.yaml` — the helpers package
-    - `/homeassistant/dashboards/aqualink-pool.yaml` — the dashboard
+    - `/homeassistant/dashboards/aqualink-pool.yaml`, `/homeassistant/dashboards/aqualink-pool-showcase.yaml` — the two dashboards
     - `/homeassistant/entity-manifest.json`, `/homeassistant/README.md`
 
     Handy for air-gapped or LAN-only installs: download from your own instance and

--- a/homeassistant/companion/README.md
+++ b/homeassistant/companion/README.md
@@ -11,9 +11,11 @@ repository, published at <https://iainchesworth.github.io/aqualink-automate/home
 
 | Folder | What it is | How to install |
 |---|---|---|
-| `blueprints/automation/aqualink-automate/` | Alert & self-healing automation blueprints (salt low with "add N kg" advice, equipment problems, app offline, pump-runtime shortfall, chlorinator self-heal, swim ready, freeze advisory) | Import via the buttons on the docs page, or copy into `<config>/blueprints/automation/aqualink-automate/` |
-| `packages/aqualink_automate.yaml` | Helpers the blueprints/dashboard build on: quiet-hours datetimes, pool volume + target-salt inputs, salt-to-add and temperature-delta template sensors, commented runtime-sensor recipes | Copy into `<config>/packages/` (enable [packages](https://www.home-assistant.io/docs/configuration/packages/) once) |
+| `blueprints/automation/aqualink-automate/` | Alert & self-healing automation blueprints (salt low with "add N kg" advice, equipment problems, app offline, pump-runtime shortfall, chlorinator self-heal, swim ready, freeze advisory, spa ready, activity-scene auto-off) | Import via the buttons on the docs page, or copy into `<config>/blueprints/automation/aqualink-automate/` |
+| `blueprints/script/aqualink-automate/` | The "Activity scene" script blueprint — a reusable start/stop scene (swim/spa/jet pool/etc.) for any switches, with an optional duration timer and dark-only lighting | Import via the docs page, or copy into `<config>/blueprints/script/aqualink-automate/` |
+| `packages/aqualink_automate.yaml` | Helpers the blueprints/dashboards build on: quiet-hours datetimes, pool volume + target-salt inputs, salt-to-add / temperature-delta / spa-readiness template sensors, commented runtime-sensor recipes | Copy into `<config>/packages/` (enable [packages](https://www.home-assistant.io/docs/configuration/packages/) once) |
 | `dashboards/aqualink-pool.yaml` | A pool dashboard built only from stock cards (sections + tiles) | Paste into a new dashboard's raw configuration editor |
+| `dashboards/aqualink-pool-showcase.yaml` | A more polished alternative demonstrating popular HACS custom cards | Install the HACS cards listed in the file's header first, then paste into a new dashboard |
 | `entity-manifest.json` | The machine-readable list of entity ids the app publishes; CI validates all companion YAML against it | (not installed — reference/CI) |
 | `test-harness/` | CI scaffolding for validating this content inside a real Home Assistant container | (not installed — CI only) |
 
@@ -26,10 +28,14 @@ repository, published at <https://iainchesworth.github.io/aqualink-automate/home
   **install-specific**: reference them only in commented examples or as blueprint
   inputs without defaults. CI (`scripts/check-ha-companion-entities.ps1`) enforces
   this by validating every active `*.aqualink_automate_*` reference against the
-  manifest.
+  manifest. (Watch for this even among static-looking names — a panel's *heater*
+  labels, e.g. "Solar Heat", are dynamic too; only the entities actually listed in
+  `entity-manifest.json` are safe to hardcode.)
 - Helper entities created *by this package* use the `aqualink_` prefix (never
   `aqualink_automate_`) so app-published and package-created entities cannot collide.
-- Stock Home Assistant cards/integrations only — no HACS dependencies.
+- Stock Home Assistant cards/integrations only, **except** the showcase dashboard,
+  which is deliberately HACS-dependent and clearly labeled as such — it is an
+  alternative to, not a replacement for, the stock-cards dashboard.
 - Every alert blueprint keeps the hygiene scaffold: quiet hours, repeat-interval
   dedup, unavailable-state guards, actionable message content.
 

--- a/homeassistant/companion/blueprints/automation/aqualink-automate/activity-scene-autooff.yaml
+++ b/homeassistant/companion/blueprints/automation/aqualink-automate/activity-scene-autooff.yaml
@@ -1,0 +1,42 @@
+blueprint:
+  name: "AquaLink Automate: Activity scene auto-off"
+  description: >-
+    Pairs with the "Activity scene" script blueprint: when the activity's
+    duration timer finishes, calls that same script with the `turn_off` field so
+    everything it turned on gets turned back off automatically. Create one of
+    these per activity scene that uses a duration timer.
+  domain: automation
+  author: aqualink-automate
+  source_url: https://github.com/iainchesworth/aqualink-automate/blob/main/homeassistant/companion/blueprints/automation/aqualink-automate/activity-scene-autooff.yaml
+  input:
+    duration_timer:
+      name: Duration timer
+      description: The same timer entity given to the "Activity scene" script instance.
+      selector:
+        entity:
+          filter:
+            - domain: timer
+    activity_script:
+      name: Activity scene script
+      description: The script entity created from the "Activity scene" blueprint.
+      selector:
+        entity:
+          filter:
+            - domain: script
+
+mode: single
+max_exceeded: silent
+
+triggers:
+  - trigger: event
+    event_type: timer.finished
+    event_data:
+      entity_id: !input duration_timer
+
+actions:
+  - action: script.turn_on
+    target:
+      entity_id: !input activity_script
+    data:
+      variables:
+        action: turn_off

--- a/homeassistant/companion/blueprints/automation/aqualink-automate/spa-ready.yaml
+++ b/homeassistant/companion/blueprints/automation/aqualink-automate/spa-ready.yaml
@@ -1,0 +1,84 @@
+blueprint:
+  name: "AquaLink Automate: Spa ready"
+  description: >-
+    Notifies once the spa has warmed up to its setpoint. Reads the "AquaLink Spa
+    Readiness" sensor from the companion helpers package (packages/aqualink_automate.yaml)
+    — install that first. Includes quiet hours.
+  domain: automation
+  author: aqualink-automate
+  source_url: https://github.com/iainchesworth/aqualink-automate/blob/main/homeassistant/companion/blueprints/automation/aqualink-automate/spa-ready.yaml
+  input:
+    readiness_sensor:
+      name: Spa readiness sensor
+      description: The sensor installed by the companion helpers package.
+      default: sensor.aqualink_spa_readiness
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+    notify_service:
+      name: Notification action
+      description: "The notify action to call (e.g. notify.mobile_app_your_phone)."
+      default: notify.notify
+      selector:
+        text: {}
+    quiet_hours_start:
+      name: Quiet hours start
+      description: >-
+        input_datetime marking the start of the no-notification window (installed
+        by the companion helpers package). Leave the helper's value unset to
+        disable quiet hours.
+      default: input_datetime.aqualink_quiet_hours_start
+      selector:
+        entity:
+          filter:
+            - domain: input_datetime
+    quiet_hours_end:
+      name: Quiet hours end
+      default: input_datetime.aqualink_quiet_hours_end
+      selector:
+        entity:
+          filter:
+            - domain: input_datetime
+
+mode: single
+max_exceeded: silent
+
+variables:
+  readiness_entity: !input readiness_sensor
+  quiet_start: !input quiet_hours_start
+  quiet_end: !input quiet_hours_end
+
+triggers:
+  - trigger: state
+    entity_id: !input readiness_sensor
+    to: "Ready"
+    for:
+      minutes: 2
+
+conditions:
+  - alias: "Outside the quiet-hours window (if configured)"
+    condition: template
+    value_template: >-
+      {% set qs_state = states(quiet_start) %}
+      {% set qe_state = states(quiet_end) %}
+      {% if qs_state in ['unknown', 'unavailable'] or qe_state in ['unknown', 'unavailable'] %}
+        true
+      {% else %}
+        {% set now_ts = now().timestamp() %}
+        {% set qs = today_at(qs_state) | as_timestamp %}
+        {% set qe = today_at(qe_state) | as_timestamp %}
+        {% if qe < qs %}
+          {{ not (now_ts >= qs or now_ts <= qe) }}
+        {% else %}
+          {{ not (qs <= now_ts <= qe) }}
+        {% endif %}
+      {% endif %}
+
+actions:
+  - action: !input notify_service
+    data:
+      title: "Spa is ready"
+      message: >-
+        The spa has reached {{ state_attr(readiness_entity, 'current_temperature') }}°
+        (target {{ state_attr(readiness_entity, 'target_temperature') }}°).

--- a/homeassistant/companion/blueprints/script/aqualink-automate/activity-scene.yaml
+++ b/homeassistant/companion/blueprints/script/aqualink-automate/activity-scene.yaml
@@ -1,0 +1,124 @@
+blueprint:
+  name: "AquaLink Automate: Activity scene"
+  description: >-
+    A reusable start/stop scene for a pool activity (swim, spa, jet pool, whatever
+    you like) — not tied to any specific aqualink-automate entity, so it works with
+    any switches you point it at. Turns your chosen equipment on, optionally starts
+    a countdown timer, and optionally turns on extra lighting but only after dark.
+    Toggling re-runs with the opposite action, so one script instance covers both a
+    dashboard tile's tap (toggle) and its hold (call with the `turn_off` field) —
+    pair it with the companion "Activity scene auto-off" automation blueprint so a
+    timer running out turns everything off automatically.
+  domain: script
+  author: aqualink-automate
+  source_url: https://github.com/iainchesworth/aqualink-automate/blob/main/homeassistant/companion/blueprints/script/aqualink-automate/activity-scene.yaml
+  input:
+    equipment:
+      name: Equipment
+      description: Switches to turn on/off for this activity (e.g. a jet pump, an aux circuit).
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: switch
+    activity_boolean:
+      name: Activity indicator
+      description: >-
+        An input_boolean tracking whether this activity is active. Create one
+        under Settings -> Devices & Services -> Helpers before using this
+        blueprint.
+      selector:
+        entity:
+          filter:
+            - domain: input_boolean
+    duration_timer:
+      name: Duration timer (optional)
+      description: >-
+        An optional timer helper started when the activity begins. Pair with the
+        "Activity scene auto-off" automation blueprint so it turns everything off
+        when the timer finishes.
+      default: ""
+      selector:
+        entity:
+          filter:
+            - domain: timer
+    lights:
+      name: Lighting (optional, dark-only)
+      description: Extra lights/switches turned on only while the sun is below the horizon.
+      default: []
+      selector:
+        entity:
+          multiple: true
+          filter:
+            - domain: ["light", "switch"]
+
+fields:
+  action:
+    name: Action
+    description: "toggle (default) flips the current state; turn_on / turn_off force a direction."
+    default: toggle
+    selector:
+      select:
+        options:
+          - toggle
+          - turn_on
+          - turn_off
+
+mode: single
+max_exceeded: silent
+
+variables:
+  activity_boolean: !input activity_boolean
+  duration_timer: !input duration_timer
+  lights: !input lights
+  requested_action: "{{ action | default('toggle') }}"
+  turn_off: >-
+    {{ requested_action == 'turn_off'
+       or (requested_action == 'toggle' and is_state(activity_boolean, 'on')) }}
+
+sequence:
+  - choose:
+      - conditions: "{{ turn_off }}"
+        sequence:
+          - action: switch.turn_off
+            target:
+              entity_id: !input equipment
+          - if: "{{ lights | count > 0 }}"
+            then:
+              - action: homeassistant.turn_off
+                target:
+                  entity_id: "{{ lights }}"
+          - if: "{{ duration_timer not in [none, ''] }}"
+            then:
+              - action: timer.cancel
+                target:
+                  entity_id: "{{ duration_timer }}"
+          - action: input_boolean.turn_off
+            target:
+              entity_id: "{{ activity_boolean }}"
+    default:
+      - action: input_boolean.turn_on
+        target:
+          entity_id: "{{ activity_boolean }}"
+      - if: "{{ duration_timer not in [none, ''] }}"
+        then:
+          - action: timer.start
+            target:
+              entity_id: "{{ duration_timer }}"
+      # A bare `condition:` step inside a sequence halts the WHOLE script on false
+      # (not just this step), so the dark-only gate lives in the `if:` list itself
+      # — if it's daytime, this step is skipped and the sequence still continues
+      # on to turn on the equipment below.
+      - if:
+          - condition: template
+            value_template: "{{ lights | count > 0 }}"
+          - condition: sun
+            after: sunset
+            before: sunrise
+        then:
+          - action: homeassistant.turn_on
+            target:
+              entity_id: "{{ lights }}"
+      - action: switch.turn_on
+        target:
+          entity_id: !input equipment

--- a/homeassistant/companion/dashboards/aqualink-pool-showcase.yaml
+++ b/homeassistant/companion/dashboards/aqualink-pool-showcase.yaml
@@ -1,0 +1,352 @@
+# =============================================================================
+# AquaLink Automate — showcase pool dashboard
+#
+# A more polished alternative to dashboards/aqualink-pool.yaml, demonstrating
+# what's possible with a few popular HACS custom cards. It is NOT a drop-in
+# replacement — install these first via HACS (Settings -> Add-ons/Integrations
+# -> HACS, "Frontend" category), then reload your browser:
+#
+#   - button-card      https://github.com/custom-cards/button-card
+#   - card-mod          https://github.com/thomasloven/lovelace-card-mod
+#   - layout-card       https://github.com/thomasloven/lovelace-layout-card
+#   - lovelace-mushroom https://github.com/piitaya/lovelace-mushroom
+#   - bar-card          https://github.com/custom-cards/bar-card
+#
+# Install: Settings -> Dashboards -> Add dashboard -> Start from scratch, open
+# it, three-dot menu -> Raw configuration editor, paste this file's content.
+# Then personalise the two commented sections near the bottom (Scenes,
+# Equipment) with your own panel devices and any activity-scene scripts you've
+# created (see the "Activity scene" blueprint) — everything above that line
+# works unedited, using only entities aqualink-automate itself publishes plus
+# the companion helpers package's derived sensors (install that too — see
+# packages/aqualink_automate.yaml — for the Salt to Add / Warmed Today / Spa
+# Readiness cards below to show real values).
+# =============================================================================
+title: Pool (Showcase)
+button_card_templates:
+  aq_base:
+    show_icon: false
+    styles:
+      card:
+        - font-family: "'Hanken Grotesk', var(--primary-font-family, sans-serif)"
+        - box-shadow: none
+  aq_tile:
+    template: aq_base
+    show_name: true
+    show_label: true
+    tap_action:
+      action: toggle
+    styles:
+      card:
+        - padding: 14px
+        - border-radius: 16px
+        - border: >-
+            [[[ return (entity && entity.state === 'on') ? '1px solid #2e8b86' : '1px solid var(--divider-color)'; ]]]
+        - background: >-
+            [[[ return (entity && entity.state === 'on') ? 'rgba(46,139,134,0.14)' : 'var(--card-background-color)'; ]]]
+      grid:
+        - grid-template-areas: '"n" "l"'
+        - align-items: center
+      name:
+        - justify-self: start
+        - font-size: 14.5px
+        - font-weight: "700"
+        - color: var(--primary-text-color)
+      label:
+        - justify-self: start
+        - font-family: "'Space Mono', ui-monospace, monospace"
+        - font-size: 11.5px
+        - color: var(--secondary-text-color)
+  aq_chip:
+    template: aq_base
+    show_name: false
+    show_label: true
+    tap_action:
+      action: more-info
+    styles:
+      card:
+        - padding: 12px 14px
+        - border-radius: 12px
+        - border: 1px solid var(--divider-color)
+        - background: var(--card-background-color)
+      grid:
+        - grid-template-areas: '"dot l"'
+        - grid-template-columns: auto 1fr
+        - column-gap: 10px
+        - align-items: center
+      label:
+        - justify-self: start
+        - font-size: 13.5px
+        - font-weight: "600"
+        - color: var(--primary-text-color)
+      custom_fields:
+        dot:
+          - align-self: center
+    custom_fields:
+      dot: >-
+        [[[
+          var s = (entity ? entity.state : '') || '';
+          var col;
+          if (s === 'Heating' || s === 'Ready') { col = '#2e8b86'; }
+          else if (/Fault/i.test(s)) { col = '#d85a30'; }
+          else if (/Warn|Low/i.test(s)) { col = '#ef9f27'; }
+          else if (s === 'Enabled' || s === 'on' || s === 'Ok' || s === 'Warming Up') { col = '#5c8a55'; }
+          else { col = 'var(--disabled-text-color)'; }
+          return `<div style="width:9px;height:9px;border-radius:50%;background:${col};"></div>`;
+        ]]]
+  aq_stat:
+    template: aq_base
+    show_name: false
+    show_label: false
+    tap_action:
+      action: none
+    styles:
+      card:
+        - padding: 13px 14px
+        - border-radius: 14px
+        - border: none
+        - background: none
+      grid:
+        - grid-template-areas: '"l" "v"'
+        - justify-items: start
+    custom_fields:
+      l: >-
+        [[[ return `<div style="font-family:'Space Mono',monospace;font-size:10px;letter-spacing:.12em;color:var(--disabled-text-color);text-transform:uppercase;">${variables.label||''}</div>`; ]]]
+      v: >-
+        [[[
+          var v = entity ? entity.state : '--';
+          return `<div style="font-size:22px;font-weight:700;letter-spacing:-0.02em;color:var(--primary-text-color);font-variant-numeric:tabular-nums;">${v}<span style="font-size:12px;font-weight:600;color:var(--secondary-text-color);"> ${variables.unit||''}</span></div>`;
+        ]]]
+
+views:
+  - title: Showcase
+    path: showcase
+    icon: mdi:pool
+    type: custom:grid-layout
+    layout:
+      grid-template-columns: repeat(4, 1fr)
+      grid-gap: 14px
+      padding: 18px
+      grid-template-areas: |
+        "header header header header"
+        "hero   hero   side   side"
+        "chem   chem   chem   chem"
+        "alerts alerts alerts alerts"
+        "scenes scenes scenes scenes"
+        "equip  equip  equip  equip"
+      mediaquery:
+        "(max-width: 700px)":
+          grid-template-columns: 1fr
+          grid-template-areas: |
+            "header"
+            "hero"
+            "side"
+            "chem"
+            "alerts"
+            "scenes"
+            "equip"
+    cards:
+      - type: markdown
+        view_layout:
+          grid-area: header
+        content: >-
+          ## Pool & Spa
+
+          {{ states('sensor.aqualink_automate_circulation_mode') | upper }} MODE ·
+          {{ states('sensor.aqualink_automate_air_temperature') }}° AIR
+        card_mod:
+          style: |
+            @import url('https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;600;700;800&family=Space+Mono:wght@400;700&display=swap');
+            ha-card { border: none; background: none; box-shadow: none; font-family: 'Hanken Grotesk', sans-serif; }
+            ha-card h2 { font-weight: 800; letter-spacing: -0.02em; margin: 0; }
+            ha-card p { font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.1em; color: var(--secondary-text-color); margin: 4px 0 0; }
+
+      - type: custom:button-card
+        template: aq_base
+        view_layout:
+          grid-area: hero
+        tap_action:
+          action: none
+        custom_fields:
+          t: >-
+            [[[
+              var spa = (states['sensor.aqualink_automate_circulation_mode']||{}).state === 'Spa';
+              var ent = spa ? 'sensor.aqualink_automate_spa_temperature' : 'sensor.aqualink_automate_pool_temperature';
+              var v = (states[ent]||{}).state || '--';
+              return `<div style="font-family:'Space Mono',monospace;font-size:11px;letter-spacing:.18em;color:var(--secondary-text-color);">${(spa?'SPA':'POOL')} WATER TEMPERATURE</div>
+                      <div style="font-size:64px;font-weight:600;letter-spacing:-0.04em;line-height:1;font-variant-numeric:tabular-nums;color:var(--primary-text-color);">${v}<span style="font-size:26px;font-weight:500;color:var(--secondary-text-color);">°</span></div>`;
+            ]]]
+        styles:
+          card:
+            - padding: 18px 20px
+            - border-radius: 18px
+          grid:
+            - grid-template-areas: '"t"'
+          custom_fields:
+            t:
+              - justify-self: start
+
+      - type: vertical-stack
+        view_layout:
+          grid-area: side
+        cards:
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: sensor.aqualink_automate_circulation_mode
+                state: Spa
+            card:
+              type: custom:mushroom-number-card
+              entity: number.aqualink_automate_spa_setpoint
+              name: Target
+              display_mode: buttons
+              icon_type: none
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: sensor.aqualink_automate_circulation_mode
+                state_not: Spa
+            card:
+              type: custom:mushroom-number-card
+              entity: number.aqualink_automate_pool_setpoint
+              name: Target
+              display_mode: buttons
+              icon_type: none
+          # Your panel's heaters (e.g. a solar or gas heater) are dynamic,
+          # panel-label-driven sensors — add a chip for yours here, e.g.:
+          #   - type: custom:button-card
+          #     template: aq_chip
+          #     entity: sensor.aqualink_automate_<your_heater_label>
+          #     label: "[[[ return 'Heat · ' + (entity ? entity.state : '—'); ]]]"
+          # Requires the companion helpers package.
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: sensor.aqualink_automate_circulation_mode
+                state: Spa
+            card:
+              type: custom:button-card
+              template: aq_chip
+              entity: sensor.aqualink_spa_readiness
+              label: "[[[ return 'Spa · ' + (entity ? entity.state : '—') + (entity && entity.attributes ? ' (' + (entity.attributes.percent_ready||0) + '%)' : ''); ]]]"
+
+      - type: custom:layout-card
+        layout_type: custom:grid-layout
+        view_layout:
+          grid-area: chem
+        layout:
+          grid-template-columns: repeat(4, 1fr)
+          grid-gap: 12px
+          mediaquery:
+            "(max-width: 500px)":
+              grid-template-columns: 1fr 1fr
+        cards:
+          - type: custom:button-card
+            template: aq_stat
+            entity: sensor.aqualink_automate_salt_level
+            variables:
+              label: Salt
+              unit: ppm
+          - type: custom:button-card
+            template: aq_stat
+            entity: sensor.aqualink_automate_ph
+            variables:
+              label: pH
+          - type: custom:button-card
+            template: aq_stat
+            entity: sensor.aqualink_automate_orp
+            variables:
+              label: ORP
+              unit: mV
+          # Requires the companion helpers package.
+          - type: custom:button-card
+            template: aq_stat
+            entity: sensor.aqualink_salt_to_add
+            variables:
+              label: Salt To Add
+              unit: kg
+
+      - type: custom:layout-card
+        layout_type: custom:grid-layout
+        view_layout:
+          grid-area: alerts
+        layout:
+          grid-template-columns: repeat(3, 1fr)
+          grid-gap: 12px
+          mediaquery:
+            "(max-width: 500px)":
+              grid-template-columns: 1fr
+        cards:
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: binary_sensor.aqualink_automate_chlorinator_fault
+                state: "on"
+            card:
+              type: custom:button-card
+              template: aq_chip
+              entity: binary_sensor.aqualink_automate_chlorinator_fault
+              label: Chlorinator fault
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: binary_sensor.aqualink_automate_salt_low
+                state: "on"
+            card:
+              type: custom:button-card
+              template: aq_chip
+              entity: binary_sensor.aqualink_automate_salt_low
+              label: Salt low
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: binary_sensor.aqualink_automate_serial_comms_loss
+                state: "on"
+            card:
+              type: custom:button-card
+              template: aq_chip
+              entity: binary_sensor.aqualink_automate_serial_comms_loss
+              label: Serial comms loss
+
+      # Scenes (OPTIONAL — needs your own activity-scene instances). Create
+      # scripts from the "Activity scene" blueprint (one per activity, e.g.
+      # Swim / Jet Pool), each with its own input_boolean + optional timer
+      # helper, then replace this note with tiles wired to them. Example for a
+      # script named "Swim" (entity script.swim, boolean
+      # input_boolean.swim_active):
+      #
+      # - type: custom:button-card
+      #   template: aq_tile
+      #   entity: input_boolean.swim_active
+      #   name: Swim
+      #   tap_action: { action: call-service, service: script.turn_on, target: { entity_id: script.swim } }
+      #   hold_action: { action: call-service, service: script.turn_on, target: { entity_id: script.swim }, data: { variables: { action: turn_off } } }
+      - type: markdown
+        view_layout:
+          grid-area: scenes
+        content: >-
+          Create scripts from the **Activity scene** blueprint, then replace
+          this card with tiles wired to them (see the comment in this
+          dashboard's YAML for a worked example).
+        card_mod:
+          style: "ha-card { opacity: 0.6; font-size: 13px; }"
+
+      # Equipment (OPTIONAL — needs YOUR panel's device entities). Pumps, aux
+      # circuits, chlorinator, and heaters carry your panel's own labels as
+      # entity ids (Settings -> Devices & Services -> MQTT ->
+      # aqualink-automate). Example:
+      #
+      # - type: custom:button-card
+      #   template: aq_tile
+      #   entity: switch.aqualink_automate_filter_pump
+      #   name: Filter Pump
+      - type: markdown
+        view_layout:
+          grid-area: equip
+        content: >-
+          Your panel's pumps, aux circuits, chlorinator, and heaters appear as
+          switches on the **aqualink-automate** MQTT device — replace this
+          card with tiles for them (see the comment in this dashboard's YAML
+          for a worked example).
+        card_mod:
+          style: "ha-card { opacity: 0.6; font-size: 13px; }"

--- a/homeassistant/companion/packages/aqualink_automate.yaml
+++ b/homeassistant/companion/packages/aqualink_automate.yaml
@@ -122,6 +122,66 @@ template:
           {{ (states('sensor.aqualink_automate_pool_temperature') | float(0)
               - states('sensor.aqualink_pool_temperature_baseline') | float(0)) | round(1) }}
 
+  # Water temperature captured the moment spa mode turns on — the "start point" the
+  # spa-readiness sensor below measures progress from. A trigger-based sensor
+  # restores its last value across restarts; it only re-baselines on a genuine
+  # off/unknown/unavailable -> on transition, not on every poll while spa mode
+  # stays on.
+  - trigger:
+      - trigger: state
+        entity_id: binary_sensor.aqualink_automate_spa_mode
+        to: "on"
+    sensor:
+      - name: "AquaLink Spa Readiness Baseline"
+        unique_id: aqualink_companion_spa_readiness_baseline
+        unit_of_measurement: "°C"
+        icon: mdi:thermometer-low
+        state: "{{ states('sensor.aqualink_automate_spa_temperature') }}"
+
+  - sensor:
+      # Spa warm-up status built only from what the app publishes: spa mode,
+      # live spa temperature, and the spa setpoint. "Off" outside spa mode,
+      # "Warming Up" while below setpoint, "Ready" once at/above it.
+      # percent_ready tracks progress from the temperature captured when spa mode
+      # turned on (baseline above) to the setpoint — 100 once at/above target,
+      # 0 if the setpoint is at/below the baseline (nothing to warm up).
+      - name: "AquaLink Spa Readiness"
+        unique_id: aqualink_companion_spa_readiness
+        icon: mdi:hot-tub
+        availability: >-
+          {{ states('binary_sensor.aqualink_automate_spa_mode') not in ['unknown', 'unavailable'] }}
+        state: >-
+          {% if is_state('binary_sensor.aqualink_automate_spa_mode', 'off') %}
+            Off
+          {% else %}
+            {% set current = states('sensor.aqualink_automate_spa_temperature') | float(none) %}
+            {% set target = states('number.aqualink_automate_spa_setpoint') | float(none) %}
+            {% if current is none or target is none %}
+              Warming Up
+            {% elif current >= target %}
+              Ready
+            {% else %}
+              Warming Up
+            {% endif %}
+          {% endif %}
+        attributes:
+          current_temperature: "{{ states('sensor.aqualink_automate_spa_temperature') | float(none) }}"
+          target_temperature: "{{ states('number.aqualink_automate_spa_setpoint') | float(none) }}"
+          percent_ready: >-
+            {% if is_state('binary_sensor.aqualink_automate_spa_mode', 'off') %}
+              0
+            {% else %}
+              {% set current = states('sensor.aqualink_automate_spa_temperature') | float(none) %}
+              {% set target = states('number.aqualink_automate_spa_setpoint') | float(none) %}
+              {% set baseline = states('sensor.aqualink_spa_readiness_baseline') | float(none) %}
+              {% if current is none or target is none or baseline is none or target <= baseline %}
+                {{ 100 if (current is not none and target is not none and current >= target) else 0 }}
+              {% else %}
+                {% set raw_percent = ((current - baseline) / (target - baseline)) * 100 %}
+                {{ [[raw_percent, 0] | max, 100] | min | round(0) }}
+              {% endif %}
+            {% endif %}
+
 # -----------------------------------------------------------------------------
 # Runtime counters (OPTIONAL — needs YOUR entity ids)
 #

--- a/homeassistant/companion/test-harness/automations.yaml
+++ b/homeassistant/companion/test-harness/automations.yaml
@@ -40,3 +40,16 @@
   alias: "CI: freeze-advisory"
   use_blueprint:
     path: aqualink-automate/freeze-advisory.yaml
+
+- id: companion_ci_spa_ready
+  alias: "CI: spa-ready"
+  use_blueprint:
+    path: aqualink-automate/spa-ready.yaml
+
+- id: companion_ci_activity_scene_autooff
+  alias: "CI: activity-scene-autooff"
+  use_blueprint:
+    path: aqualink-automate/activity-scene-autooff.yaml
+    input:
+      duration_timer: timer.companion_ci_activity_timer
+      activity_script: script.companion_ci_activity_scene

--- a/homeassistant/companion/test-harness/configuration.yaml
+++ b/homeassistant/companion/test-harness/configuration.yaml
@@ -1,13 +1,15 @@
 # CI-only Home Assistant configuration used to validate the companion package
 # inside the official Home Assistant container (see .github/workflows/ha-companion.yml).
-# The workflow copies this file, automations.yaml, the packages/ folder, and the
-# blueprints into a scratch config dir and runs `hass --script check_config`.
-# NOT part of the shipped companion content.
+# The workflow copies this file, automations.yaml, scripts.yaml, the packages/
+# folder, and the blueprints (both automation/ and script/) into a scratch
+# config dir and runs `hass --script check_config`. NOT part of the shipped
+# companion content.
 homeassistant:
   name: AquaLink Companion CI
   packages: !include_dir_named packages
 
 automation: !include automations.yaml
+script: !include scripts.yaml
 
 recorder:
 

--- a/homeassistant/companion/test-harness/scripts.yaml
+++ b/homeassistant/companion/test-harness/scripts.yaml
@@ -1,0 +1,14 @@
+# CI-only: instantiates the "Activity scene" script blueprint so
+# `hass --script check_config` validates its schema and templates.
+# Dummy entity ids are fine — check_config validates structure, not existence.
+companion_ci_activity_scene:
+  alias: "CI: activity-scene"
+  use_blueprint:
+    path: aqualink-automate/activity-scene.yaml
+    input:
+      equipment:
+        - switch.companion_ci_equipment
+      activity_boolean: input_boolean.companion_ci_activity_active
+      duration_timer: timer.companion_ci_activity_timer
+      lights:
+        - light.companion_ci_activity_light


### PR DESCRIPTION
## Summary

Phase 3 of the Home Assistant companion package (design: `docs/design/ha-companion-package.md`), covering the two things scoped in for this pass:

### 1. Add-on opt-in companion installer

- New `homeassistant_config` (read-write) map + `install_companion_package` option (**off by default**) in `aqualink-automate/config.yaml`. This is a materially broader permission than the add-on otherwise requests — it reaches Home Assistant's own config directory, not just the add-on's own storage — so it stays opt-in, and the scope is documented everywhere it's surfaced (`config.yaml`, `DOCS.md`, `docs/homeassistant-addon.md`): it only ever adds/updates files under `blueprints/`, never touches `configuration.yaml`.
- `run.sh` copies the blueprints already baked into the app's own install tree (`share/aqualink-automate/web/homeassistant/blueprints/` — the same content Phase 2 serves over HTTP) into Home Assistant's `blueprints/` folder. Idempotent (a restart/update just re-syncs) and additive-only.
- **Caveat I want to flag explicitly**: I could not verify the exact Supervisor mount path for the `homeassistant_config` map type (assumed `/homeassistant`, per current HA documentation) against a live HAOS instance — I don't have one in this environment. The code fails safe if that assumption is wrong: a clear `bashio::log.warning` and no-op, not a crash. Worth a real-device smoke test before this ships in a release.

### 2. New companion content

- **Activity scene** — a general-purpose *script* blueprint (equipment/timer/boolean/dark-only-lights as inputs, a `fields.action` toggle/turn_on/turn_off runtime parameter) plus an **Activity scene auto-off** automation blueprint that fires the stop action on `timer.finished`.
- **Spa readiness** — two template sensors in the helpers package (a trigger-based baseline captured when spa mode turns on, and a derived Off/Warming Up/Ready sensor with a `percent_ready` attribute), built only from `spa_mode`/`spa_temperature`/`spa_setpoint`, plus a **Spa ready** notification blueprint.
- **Showcase dashboard** — a HACS-styled alternative to the stock dashboard (button-card/card-mod/layout-card/mushroom/bar-card), generalised from the original evidence base down to only app-published + companion-package entities, with commented placeholders for equipment/scene tiles.
- **Dropped**: an analytics/energy module (heat-pump COP etc.) — depends on install-specific hardware (a particular heat pump + power meters) and can't be generalised, so it doesn't belong in the shipped package.

## Bugs caught before they reached CI

Worth calling out since they're the kind of thing that's easy to miss in review:
- A bare `condition:` step inside the activity-scene script's sequence would have halted the **whole script** on a daytime run (not just skipped the lights step) — moved the sun check into the `if:` condition list instead.
- `percent_ready` used `| max(0) | min(100)` to clamp a scalar — those are Jinja2 list-reduction filters, not a clamp, and would have thrown at render time. Fixed to the `[[value, 0] | max, 100] | min` list-based pattern already used correctly elsewhere in the package.
- The showcase dashboard initially referenced `sensor.aqualink_automate_solar_heat` copied straight from the evidence base — the entity cross-check script correctly caught that this is actually a dynamic, panel-label-driven heater sensor (not a fixed one), so it's been replaced with a commented example.

## Verification

- yamllint, the entity-manifest cross-check (91 active references, all valid), and a real `hass --script check_config` run all pass — including a negative-control test (deliberately corrupting the new script blueprint) that confirmed the harness genuinely exercises it rather than silently skipping.
- `shellcheck` (via Docker, not installed locally) passes clean on `run.sh`.
- The add-on's own translation-parity check passes with the new option.
- `aqualink-automate-edge/` regenerated and byte-identical to stable apart from the generator's known deltas (name/slug/panel_title).
- `mkdocs build --strict` passes with the new docs/cross-links.
- No C++ files touched this phase, so no rebuild needed.